### PR TITLE
Support OpenAI compatible providers through a base URL

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -33,6 +33,12 @@ RubyLLM.configure do |config|
 end
 ```
 
+You can optionally provide the base URL for the OpenAI API, through which you can point to OpenAI API compatible engines like [Ollama](https://github.com/ollama/ollama), [KoboldCPP](https://github.com/LostRuins/koboldcpp), [TabbyAPI](https://github.com/theroyallab/tabbyAPI), etc:
+
+```ruby
+  config.openai_base_url = "http://localhost:11434/v1"
+```
+
 ## Your First Chat
 
 Let's start with a simple chat interaction:

--- a/lib/ruby_llm/configuration.rb
+++ b/lib/ruby_llm/configuration.rb
@@ -11,6 +11,7 @@ module RubyLLM
   #   end
   class Configuration
     attr_accessor :openai_api_key,
+                  :openai_base_url,
                   :anthropic_api_key,
                   :gemini_api_key,
                   :deepseek_api_key,

--- a/lib/ruby_llm/providers/openai.rb
+++ b/lib/ruby_llm/providers/openai.rb
@@ -29,7 +29,7 @@ module RubyLLM
       module_function
 
       def api_base
-        'https://api.openai.com/v1'
+        RubyLLM.config.openai_base_url || 'https://api.openai.com/v1'
       end
 
       def headers


### PR DESCRIPTION
Allow configuring an arbitrary HTTP endpoint for an OpenAI compatible API, which easily affords compatibility with any inference engines that provide it.

A few popular ones are name dropped in the docs for searchability; I suggest you also mention OAI compatibility in the readme, which will interest people looking for fully self-hosted solutions.