### PR TITLE
Add OpenAI URL override and support for custom request headers

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -12,6 +12,8 @@ RubyLLM.configure do |config|
   config.anthropic_api_key = ENV.fetch('ANTHROPIC_API_KEY', nil)
   config.gemini_api_key = ENV.fetch('GEMINI_API_KEY', nil)
   config.deepseek_api_key = ENV.fetch('DEEPSEEK_API_KEY', nil)
+
+  config.openai_base_url_override = ENV.fetch('OPENAI_BASE_URL', nil)
 end
 
 IRB.start(__FILE__)

--- a/lib/ruby_llm/configuration.rb
+++ b/lib/ruby_llm/configuration.rb
@@ -18,7 +18,9 @@ module RubyLLM
                   :default_embedding_model,
                   :default_image_model,
                   :request_timeout,
-                  :max_retries
+                  :max_retries,
+                  :openai_base_url_override,
+                  :additional_headers
 
     def initialize
       @request_timeout = 120

--- a/lib/ruby_llm/provider.rb
+++ b/lib/ruby_llm/provider.rb
@@ -60,7 +60,9 @@ module RubyLLM
       end
 
       def post(url, payload)
+        additional_headers = RubyLLM.config.additional_headers
         connection.post url, payload do |req|
+          req.headers.merge! additional_headers unless additional_headers.nil?
           req.headers.merge! headers
           yield req if block_given?
         end

--- a/lib/ruby_llm/providers/openai.rb
+++ b/lib/ruby_llm/providers/openai.rb
@@ -29,7 +29,8 @@ module RubyLLM
       module_function
 
       def api_base
-        'https://api.openai.com/v1'
+        return 'https://api.openai.com/v1' unless RubyLLM.config.openai_base_url_override
+        return RubyLLM.config.openai_base_url_override
       end
 
       def headers


### PR DESCRIPTION
Relates to https://github.com/crmne/ruby_llm/issues/9

**Preface**
Opening early to discuss whether this is a welcome addition, the architectural decisions, documentation implications, and whether expanding this URL config override to other LLMs within the gem's scope makes sense. I'm committed to maintaining the developer experience simplicity of the project's stated mission, so I'm on board with redoing the initial approach to fit in with longer-term priorities (or closing outright!). 

---
**Goal**
This commit introduces the configuration primitives necessary for semantic caching proxy services for OpenAI requests. Specifically, the option to override the OpenAI root API URL path and the ability to add custom headers to the request payload in the form of a hash. I'm a Fastly employee, and I used [our semantic caching product](https://docs.fastly.com/en/guides/about-the-ai-accelerator-page#supported-llms) as a test implementation. 

---
**In-Progress Disclaimer**
This branch **does not yet** introduce tests and should not be merged until a subsequent commit lands with proper testing.