### PR TITLE
Add o3-mini support & expose "temperature"

### DIFF
--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -13,10 +13,19 @@ module RubyLLM
 
     attr_reader :model, :messages, :tools
 
-    def initialize(model: nil)
+    def initialize(model: nil) # rubocop:disable Metrics/MethodLength
       model_id = model || RubyLLM.config.default_model
       self.model = model_id
-      @temperature = @model.metadata['family'] == 'o1' ? 1 : 0.7
+      @temperature = case @model.temperature
+                     when false
+                       nil
+                     when Numeric
+                       @model.temperature
+                     when nil, ''
+                       0.7
+                     else
+                       raise "Invalid temperature: #{@model.temperature}"
+                     end
       @messages = []
       @tools = {}
       @on = {

--- a/lib/ruby_llm/model_info.rb
+++ b/lib/ruby_llm/model_info.rb
@@ -15,7 +15,8 @@ module RubyLLM
   class ModelInfo
     attr_reader :id, :created_at, :display_name, :provider, :metadata,
                 :context_window, :max_tokens, :supports_vision, :supports_functions,
-                :supports_json_mode, :input_price_per_million, :output_price_per_million, :type, :family
+                :supports_json_mode, :input_price_per_million, :output_price_per_million, :type, :family,
+                :temperature
 
     def initialize(data) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       @id = data[:id]
@@ -26,6 +27,7 @@ module RubyLLM
       @max_tokens = data[:max_tokens]
       @type = data[:type]
       @family = data[:family]
+      @temperature = data[:temperature]
       @supports_vision = data[:supports_vision]
       @supports_functions = data[:supports_functions]
       @supports_json_mode = data[:supports_json_mode]
@@ -44,6 +46,7 @@ module RubyLLM
         max_tokens: max_tokens,
         type: type,
         family: family,
+        temperature: temperature,
         supports_vision: supports_vision,
         supports_functions: supports_functions,
         supports_json_mode: supports_json_mode,

--- a/lib/ruby_llm/models.json
+++ b/lib/ruby_llm/models.json
@@ -1747,6 +1747,26 @@
     }
   },
   {
+    "id": "o3-mini",
+    "created_at": "2025-03-17T11:52:00+02:00",
+    "display_name": "O3-Mini",
+    "provider": "openai",
+    "context_window": 200000,
+    "max_tokens": 8192,
+    "type": "chat",
+    "family": "o3_mini",
+    "temperature": false,
+    "supports_vision": false,
+    "supports_functions": true,
+    "supports_json_mode": false,
+    "input_price_per_million": 1.10,
+    "output_price_per_million": 4.40,
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
     "id": "o1-mini",
     "created_at": "2024-09-06T20:56:48+02:00",
     "display_name": "O1-Mini",
@@ -1793,6 +1813,7 @@
     "max_tokens": 4096,
     "type": "chat",
     "family": "o1",
+    "temperature": 1,
     "supports_vision": true,
     "supports_functions": true,
     "supports_json_mode": false,
@@ -1812,6 +1833,7 @@
     "max_tokens": 4096,
     "type": "chat",
     "family": "o1",
+    "temperature": 1,
     "supports_vision": true,
     "supports_functions": true,
     "supports_json_mode": false,

--- a/lib/ruby_llm/providers/openai/chat.rb
+++ b/lib/ruby_llm/providers/openai/chat.rb
@@ -17,7 +17,7 @@ module RubyLLM
             messages: format_messages(messages),
             temperature: temperature,
             stream: stream
-          }.tap do |payload|
+          }.compact.tap do |payload|
             if tools.any?
               payload[:tools] = tools.map { |_, tool| tool_for(tool) }
               payload[:tool_choice] = 'auto'


### PR DESCRIPTION
The code was mentioning `o3-mini` but somehow this model wasn't part of the `models.json` configuration file.

I assume it could because it doesn't support the `temperature` parameter, so things had to get slightly adjusted.