### PR TITLE
Set OpenAI o1-preview-2024-09-12 `supports_vision` to false

### DIFF
--- a/lib/ruby_llm/models.json
+++ b/lib/ruby_llm/models.json
@@ -1812,7 +1812,7 @@
     "max_tokens": 4096,
     "type": "chat",
     "family": "o1",
-    "supports_vision": true,
+    "supports_vision": false,
     "supports_functions": true,
     "supports_json_mode": false,
     "input_price_per_million": 0.5,


### PR DESCRIPTION
OpenAI's `o1-preview-2024-09-12` model doesn't support vision, as stated here: https://platform.openai.com/docs/models/o1

This changes its `supports_vision` attribute from `true` to `false`.