### PR TITLE
Add VCR so it is not need to use api keys from all providers to run local tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development do
   gem 'simplecov', '>= 0.21'
   gem 'simplecov-cobertura'
   gem 'sqlite3'
+  gem 'vcr'
   gem 'webmock', '~> 3.18'
   gem 'yard', '>= 0.9'
 end

--- a/README.md
+++ b/README.md
@@ -193,6 +193,15 @@ chat.with_tool(Search).ask "Find documents about Ruby 3.3 features"
 
 Check out the guides at https://rubyllm.com for deeper dives into conversations with tools, streaming responses, embedding generations, and more.
 
+## Running tests locally
+
+Remember to set all credentials, otherwise you may get some errors.
+
+If you don't want (or don't have) all of them, you may use VCR cached requests
+by setting `VCR_RECORD=none` to rely only on cached results or
+`VCR_RECORD=new_episodes` to use cached requests and perform http requests only
+if needed.
+
 ## License
 
 Released under the MIT License.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,9 @@ SimpleCov.start do
   formatter SimpleCov::Formatter::MultiFormatter.new(
     [
       SimpleCov::Formatter::SimpleFormatter,
-      SimpleCov::Formatter::Codecov,
+      (SimpleCov::Formatter::Codecov unless ENV['SKIP_CODECOV_UPLOAD']),
       SimpleCov::Formatter::CoberturaFormatter
-    ]
+    ].compact
   )
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,37 @@ require 'bundler/setup'
 require 'fileutils'
 require 'ruby_llm'
 
+require 'vcr'
+require 'webmock/rspec'
+
+VCR.configure do |config|
+  config.cassette_library_dir = 'spec/cassettes'
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+  config.allow_http_connections_when_no_cassette = false
+
+  # Filter sensitive request headers
+  config.filter_sensitive_data('<AUTHORIZATION>') { |interaction| interaction.request.headers['Authorization']&.first }
+  config.filter_sensitive_data('<X_GOOG_API_KEY>') do |interaction|
+    interaction.request.headers['X-Goog-Api-Key']&.first
+  end
+
+  # Filter sensitive response headers
+  config.filter_sensitive_data('<OPENAI_ORGANIZATION>') do |interaction|
+    interaction.response.headers['Openai-Organization']&.first
+  end
+  config.filter_sensitive_data('<X_REQUEST_ID>') { |interaction| interaction.response.headers['X-Request-Id']&.first }
+  config.filter_sensitive_data('<REQUEST_ID>') { |interaction| interaction.response.headers['Request-Id']&.first }
+  config.filter_sensitive_data('<CF_RAY>') { |interaction| interaction.response.headers['Cf-Ray']&.first }
+
+  # Filter cookies
+  config.before_record do |interaction|
+    if interaction.response.headers['Set-Cookie']
+      interaction.response.headers['Set-Cookie'] = interaction.response.headers['Set-Cookie'].map { '<COOKIE>' }
+    end
+  end
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
@@ -30,6 +61,14 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  vcr_record = ENV.fetch('VCR_RECORD', 'all').to_sym
+  config.around do |example|
+    cassette_name = example.full_description.parameterize(separator: '_')
+    VCR.use_cassette(cassette_name, record: vcr_record) do
+      example.run
+    end
   end
 end
 


### PR DESCRIPTION
First of all, thanks for this awesome project!

I wanted to contribute on it, but in the same way as raised by @redox at crmne/ruby_llm/issues/51 I could not run all tests locally because I don't have API keys to all providers.

Seeing that there are some other PRs and issues asking for support for more providers, this can get even worse if not tacked someday.

On this PR I add VCR on tests, so we could cache requests against providers with no rewrite on actual tests.

Locally I run that with OpenAI api key and I hide some credentials and possible identifying leaking info at cassettes.

It would be nice to run this with Gemini, Deepseek and Anthropic adding cassette files at this repo, so we can spare some actual API calls (money and time).

Also I added a config by env variable to avoid attempts of codecov upload. When running it locally without the proper credentials it seems pointless and error prone to even try to upload that.

This PR does not change any current behavior. VCR is also only used for caching if `VCR_RECORD` is used with proper configuration and default behavior of codecov upload is not changed.

PS.: of course, we may need to redact some cassette files before just adding them.