### PR TITLE
Prevent rails specific code from being loaded by zeitwerk automatically

### DIFF
--- a/lib/ruby_llm.rb
+++ b/lib/ruby_llm.rb
@@ -17,6 +17,8 @@ loader.inflector.inflect(
   'api' => 'API',
   'deepseek' => 'DeepSeek'
 )
+loader.ignore("#{__dir__}/ruby_llm/railtie")
+loader.ignore("#{__dir__}/ruby_llm/active_record")
 loader.setup
 
 # A delightful Ruby interface to modern AI language models.


### PR DESCRIPTION
Ignore rails specifics in zeitwerk configuration