### PR TITLE
Add base64 to runtime dependencies

### DIFF
--- a/ruby_llm.gemspec
+++ b/ruby_llm.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Runtime dependencies
+  spec.add_dependency 'base64'
   spec.add_dependency 'event_stream_parser', '~> 1'
   spec.add_dependency 'faraday', '~> 2'
   spec.add_dependency 'faraday-multipart', '~> 1'


### PR DESCRIPTION
`base64` is not part of the default gems starting as of Ruby 3.4.0.