### PR TITLE
Add support for API Key Per Request

### DIFF
--- a/lib/ruby_llm.rb
+++ b/lib/ruby_llm.rb
@@ -28,8 +28,8 @@ module RubyLLM
   class Error < StandardError; end
 
   class << self
-    def chat(model: nil, provider: nil)
-      Chat.new(model: model, provider: provider)
+    def chat(model: nil, provider: nil, config: configuration)
+      Chat.new(model: model, provider: provider, config: config)
     end
 
     def embed(...)
@@ -55,6 +55,8 @@ module RubyLLM
     def config
       @config ||= Configuration.new
     end
+
+    alias configuration config
 
     def logger
       @logger ||= Logger.new(

--- a/lib/ruby_llm/configuration.rb
+++ b/lib/ruby_llm/configuration.rb
@@ -27,5 +27,14 @@ module RubyLLM
       @default_embedding_model = 'text-embedding-3-small'
       @default_image_model = 'dall-e-3'
     end
+
+    def dup
+      config = self.class.new
+      instance_variables.each do |var|
+        value = instance_variable_get(var)
+        config.instance_variable_set(var, value)
+      end
+      config
+    end
   end
 end

--- a/lib/ruby_llm/providers/anthropic.rb
+++ b/lib/ruby_llm/providers/anthropic.rb
@@ -19,9 +19,9 @@ module RubyLLM
         'https://api.anthropic.com'
       end
 
-      def headers
+      def headers(config)
         {
-          'x-api-key' => RubyLLM.config.anthropic_api_key,
+          'x-api-key' => config.anthropic_api_key,
           'anthropic-version' => '2023-06-01'
         }
       end


### PR DESCRIPTION
This PR addresses #55 by adding support for passing an API Key per request.

## Proposed API (and implemented in PR)

```ruby
# Anthropic Example
chat = RubyLLM.chat
response = chat.with_model('claude-3-7-sonnet-20250219')
               .with_api_key(ENV.fetch('SOME_OTHER_ANTHROPIC_API_KEY', nil))
               .ask("What's your favorite algorithm?")

puts response.content
#=> I don't have personal favorites since I don't ... 

# OpenAI Example
chat = RubyLLM.chat
response = chat.with_api_key(ENV.fetch('OTHER_OPENAI_API_KEY', nil))
               .ask("What's your favorite algorithm?")

puts response
#=> I don't have personal preferences, but I can tell you about some ...

# Setting key on chat initialization
response = RubyLLM.chat(api_key: ENV.fetch('OTHER_OPENAI_API_KEY', nil)).ask("What's your favorite algorithm?")
puts response.content
#=> As an AI, I don't have personal preferences or feelings, but 
```

Embedding Example

```ruby
response = RubyLLM.embed("What's your favorite algorithm?", api_key: ENV.fetch('OTHEN_OPENAI_API_KEY', nil))
puts response
#=> #<RubyLLM::Embedding:0x00000001295eca20>
```

Paint Example

```ruby
response = RubyLLM.paint "a sunset over mountains in watercolor style", api_key: ENV.fetch('OPENAI_API_KEY', nil)
puts response
#=> #<RubyLLM::Image:0x000000012b75f658>
```

### Questions/Notes

- I'm unsure about Bedrock
- Providing a different API key for specs?