### PR TITLE
Switched from git ls-files to Ruby's Dir.glob for defining spec.file

### DIFF
--- a/ruby_llm.gemspec
+++ b/ruby_llm.gemspec
@@ -25,13 +25,8 @@ Gem::Specification.new do |spec|
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|docs)/}) }
-  end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  # Use Dir.glob to list all files within the lib directory
+  spec.files = Dir.glob('lib/**/*') + ['README.md', 'LICENSE']
   spec.require_paths = ['lib']
 
   # Runtime dependencies


### PR DESCRIPTION
that compatibility in environments without git and make the gem more portable.