### PR TITLE
Parse errors from Bedrock properly

### DIFF
--- a/lib/ruby_llm/providers/bedrock.rb
+++ b/lib/ruby_llm/providers/bedrock.rb
@@ -33,6 +33,22 @@ module RubyLLM
         end
       end
 
+      def parse_error(response) # rubocop:disable Metrics/MethodLength
+        return if response.body.empty?
+
+        body = try_parse_json(response.body)
+        case body
+        when Hash
+          body['message']
+        when Array
+          body.map do |part|
+            part['message']
+          end.join('. ')
+        else
+          body
+        end
+      end
+
       def sign_request(url, method: :post, payload: nil)
         signer = create_signer
         request = build_request(url, method:, payload:)


### PR DESCRIPTION
Turns out, the response body from Bedrock looks like this:

```
{"message":"messages.1.content: Input should be a valid list"}
```

