### PR TITLE
Update rspec test doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,13 @@ bundle install
 # Set up git hooks
 overcommit --install
 
+# Set up .env and set default value for ollama
+touch .env
+
+```
+OLLAMA_API_BASE=http://localhost:11434/v1
+```
+
 # Run the tests (uses VCR cassettes)
 bundle exec rspec
 ```


### PR DESCRIPTION
If someone forget set env about  `OLLAMA_API_BASE`, when run rspec will get some errors.  Add doc about it.



```ruby
11) RubyLLM::Models#refresh! works as a class method too
      Failure/Error:
        @app.call(env).on_complete do |response|
          self.class.parse_error(provider: @provider, response: response)
        end

      URI::InvalidURIError:
        bad URI (is not URI?): "<OLLAMA_API_BASE>/models"
      # ./lib/ruby_llm/error.rb:47:in `call'
      # ./lib/ruby_llm/connection.rb:30:in `get'
      # ./lib/ruby_llm/provider.rb:30:in `list_models'
      # ./lib/ruby_llm/models.rb:43:in `block in refresh!'
      # ./lib/ruby_llm/models.rb:42:in `each'
      # ./lib/ruby_llm/models.rb:42:in `flat_map'
      # ./lib/ruby_llm/models.rb:42:in `refresh!'
      # ./spec/ruby_llm/models_spec.rb:109:in `block (3 levels) in <top (required)>'
      # ./spec/spec_helper.rb:86:in `block (3 levels) in <top (required)>'
      # ./spec/spec_helper.rb:85:in `block (2 levels) in <top (required)>'

Finished in 1.3 seconds (files took 0.55649 seconds to load)
187 examples, 11 failures, 9 pending
```