### PR TITLE
Allow setting temperature in constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,9 @@ build-iPhoneSimulator/
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
 Gemfile.lock
-# .ruby-version
-# .ruby-gemset
+.ruby-version
+.ruby-gemset
+
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
@@ -57,3 +58,6 @@ Gemfile.lock
 # .rubocop-https?--*
 
 repomix-output.*
+
+# Intellij Project Files:
+.idea

--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -13,7 +13,7 @@ module RubyLLM
 
     attr_reader :model, :messages, :tools
 
-    def initialize(model: nil, provider: nil, assume_model_exists: false, context: nil) # rubocop:disable Metrics/MethodLength
+    def initialize(model: nil, provider: nil, assume_model_exists: false, context: nil, temperature: 0.7) # rubocop:disable Metrics/MethodLength
       if assume_model_exists && !provider
         raise ArgumentError, 'Provider must be specified if assume_model_exists is true'
       end
@@ -22,7 +22,7 @@ module RubyLLM
       model_id = model || config.default_model
       with_model(model_id, provider: provider, assume_exists: assume_model_exists)
       @connection = context ? context.connection_for(@provider) : @provider.connection(config)
-      @temperature = 0.7
+      @temperature = temperature
       @messages = []
       @tools = {}
       @on = {


### PR DESCRIPTION
# Why?
Temperature isn't really "part of the conversation" so it feels much better to define it as a configuration parameter in the constructor.

# What?
* Add ability to specify temperature in the constructor like `Chat.new(temperature: 0.2).ask("Say something more consistently...")
* You can still define it with the `with_temperature` method as well if you want.

# Also
* Added IntelliJ project file and ruby version files to `.gitignore` since they shouldn't be committed by contributors based on the way this project is setup.