### PR TITLE
Update deepseek-chat and reasoner models info

### DIFF
--- a/lib/ruby_llm/models.json
+++ b/lib/ruby_llm/models.json
@@ -1904,7 +1904,7 @@
     "name": "DeepSeek-V3",
     "provider": "deepseek",
     "family": "deepseek-chat",
-    "created_at": null,
+    "created_at": "2025-03-24 14:59:15 +0100",
     "context_window": 64000,
     "max_output_tokens": 8000,
     "knowledge_cutoff": null,
@@ -1917,7 +1917,10 @@
       ]
     },
     "capabilities": [
-      "function_calling"
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "predicted_outputs" 
     ],
     "pricing": {
       "text_tokens": {
@@ -1938,7 +1941,7 @@
     "name": "DeepSeek-R1",
     "provider": "deepseek",
     "family": "deepseek-reasoner",
-    "created_at": null,
+    "created_at": "2025-01-20 14:59:15 +0100",
     "context_window": 64000,
     "max_output_tokens": 8000,
     "knowledge_cutoff": null,
@@ -1951,7 +1954,6 @@
       ]
     },
     "capabilities": [
-      "function_calling"
     ],
     "pricing": {
       "text_tokens": {


### PR DESCRIPTION
DeepSeek official running `deepseek-chat` in v3-0324, so if `deepseek/deepseek-chat-v3-0324` provided by openrouter support those capabilities, the official DeepSeek certainly will do.

I notice Ruby-LLM will get such model info from https://api.parsera.org/v1/llm-specs but any method to update in the API?

@raznem