### PR TITLE
fix: prevent with_instructions from throwing error

### DIFF
--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -39,7 +39,7 @@ module RubyLLM
     alias say ask
 
     def with_instructions(instructions, replace: false)
-      @messages = @messages.reject! { |msg| msg.role == :system } if replace
+      @messages = @messages.reject { |msg| msg.role == :system } if replace
 
       add_message role: :system, content: instructions
       self


### PR DESCRIPTION
Replacing instructions for a chat with no prior instructions leads to `@messages` being assigned to `nil`. To prevent this from happening, use `reject` instead to ensure an array is always present.

Here is an example of this error:
```
irb(main):007> chat = RubyLLM::Chat.new
=>
#<RubyLLM::Chat:0x000000012bd30d70
...
irb(main):008> chat.with_instructions("You are a good assistant", replace: true)
/opt/homebrew/lib/ruby/gems/3.4.0/gems/ruby_llm-1.3.0rc1/lib/ruby_llm/chat.rb:109:in 'RubyLLM::Chat#add_message': undefined method '<<' for nil (NoMethodError)

      messages << message
               ^^
        from /opt/homebrew/lib/ruby/gems/3.4.0/gems/ruby_llm-1.3.0rc1/lib/ruby_llm/chat.rb:44:in 'RubyLLM::Chat#with_instructions'
        from (irb):8:in '<main>'
        from <internal:kernel>:168:in 'Kernel#loop'
        from /opt/homebrew/Cellar/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/irb-1.14.3/exe/irb:9:in '<top (required)>'
        from /opt/homebrew/opt/ruby/bin/irb:25:in 'Kernel#load'
        from /opt/homebrew/opt/ruby/bin/irb:25:in '<main>'
irb(main):009>
```