### PR TITLE
Issue 203: Fix model alias matching for provider prefixes (claude-3-7-sonnet support)

### DIFF
--- a/lib/ruby_llm/aliases.json
+++ b/lib/ruby_llm/aliases.json
@@ -29,6 +29,14 @@
     "anthropic": "claude-3-5-sonnet-20241022",
     "bedrock": "anthropic.claude-3-5-sonnet-20240620-v1:0:200k"
   },
+  "claude-3-7-sonnet": {
+    "anthropic": "claude-3-7-sonnet-latest",
+    "bedrock": "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+  },
+  "claude-3-7-sonnet-20250219": {
+    "anthropic": "claude-3-7-sonnet-20250219",
+    "bedrock": "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+  },
   "claude-3-haiku": {
     "bedrock": "anthropic.claude-3-haiku-20240307-v1:0",
     "openrouter": "anthropic/claude-3-haiku"

--- a/lib/tasks/aliases.rake
+++ b/lib/tasks/aliases.rake
@@ -123,22 +123,23 @@ namespace :aliases do # rubocop:disable Metrics/BlockLength
 
   def find_best_bedrock_model(anthropic_model, bedrock_models) # rubocop:disable Metrics/PerceivedComplexity,Rake/MethodDefinitionInTask
     # Special mapping for Claude 2.x models
-    bedrock_pattern = case anthropic_model
-                      when 'claude-2.0', 'claude-2'
-                        'anthropic.claude-v2'
-                      when 'claude-2.1'
-                        'anthropic.claude-v2:1'
-                      when 'claude-instant-v1', 'claude-instant'
-                        'anthropic.claude-instant'
-                      else
-                        # For Claude 3+ models, extract base name
-                        base_name = extract_base_name(anthropic_model)
-                        "anthropic.#{base_name}"
-                      end
+    base_pattern = case anthropic_model
+                   when 'claude-2.0', 'claude-2'
+                     'claude-v2'
+                   when 'claude-2.1'
+                     'claude-v2:1'
+                   when 'claude-instant-v1', 'claude-instant'
+                     'claude-instant'
+                   else
+                     # For Claude 3+ models, extract base name
+                     extract_base_name(anthropic_model)
+                   end
 
-    # Find all matching Bedrock models
+    # Find all matching Bedrock models by stripping provider prefix and comparing base name
     matching_models = bedrock_models.select do |bedrock_model|
-      bedrock_model.start_with?(bedrock_pattern)
+      # Strip any provider prefix (anthropic. or us.anthropic.)
+      model_without_prefix = bedrock_model.sub(/^(?:us\.)?anthropic\./, '')
+      model_without_prefix.start_with?(base_pattern)
     end
 
     return nil if matching_models.empty?

--- a/spec/ruby_llm/chat_model_aliases_spec.rb
+++ b/spec/ruby_llm/chat_model_aliases_spec.rb
@@ -24,4 +24,11 @@ RSpec.describe RubyLLM::Chat do
     expect(chat.model.id).to eq('anthropic.claude-3-5-haiku-20241022-v1:0')
     expect(chat.model.provider).to eq('bedrock')
   end
+
+  it 'handles different provider prefixes correctly' do # rubocop:disable RSpec/MultipleExpectations
+    # Test that we can match models regardless of their provider prefix
+    chat = RubyLLM.chat(model: 'claude-3-7-sonnet', provider: :bedrock)
+    expect(chat.model.id).to eq('us.anthropic.claude-3-7-sonnet-20250219-v1:0')
+    expect(chat.model.provider).to eq('bedrock')
+  end
 end


### PR DESCRIPTION
## Resolves issue #203

Fix model alias matching to properly handle provider prefixes, particularly for Bedrock models that can have varying prefixes (e.g., `anthropic.` or `us.anthropic.`).

## Changes
- Updated alias matching logic to handle provider prefixes more flexibly
- Fixed support for `claude-3-7-sonnet` model which uses the `us.anthropic.` prefix
- Ran aliases.rake to add proper model aliases back for Claude-3-7-sonnet

## Problem
The alias matching system was too strict with provider prefixes, causing models like `claude-3-7-sonnet` to fail matching when the Bedrock version used a different prefix (`us.anthropic.`) compared to other Claude models (`anthropic.`).

## Solution
Modified the alias matching to be more flexible with provider prefixes while maintaining the correct model identification. This ensures compatibility with both existing and new model versions regardless of their provider prefix format.

## Testing
- Verified that `claude-3-7-sonnet` model works correctly with both Anthropic API and Bedrock
- Added spec for handling different provider prefixes correctly for bedrock models
- Ensured existing model aliases continue to work as expected