### PR TITLE
Truncate tool function names to 64 characters, which is the OpenAI limit

### DIFF
--- a/lib/ruby_llm/tool.rb
+++ b/lib/ruby_llm/tool.rb
@@ -57,6 +57,7 @@ module RubyLLM
           .gsub(/([a-z\d])([A-Z])/, '\1_\2')
           .downcase
           .delete_suffix('_tool')
+          .slice(0, 64)
     end
 
     def description

--- a/spec/ruby_llm/tool_spec.rb
+++ b/spec/ruby_llm/tool_spec.rb
@@ -32,5 +32,12 @@ RSpec.describe RubyLLM::Tool do
       stub_const('TestModule::SampleTool', Class.new(described_class))
       expect(TestModule::SampleTool.new.name).to eq('test_module--sample')
     end
+
+    it 'truncates names longer than 64 characters' do
+      stub_const('VeryLongToolNameThatExceedsTheMaximumAllowedLengthForOpenAIAndOtherProvidersTool', Class.new(described_class))
+      tool = VeryLongToolNameThatExceedsTheMaximumAllowedLengthForOpenAIAndOtherProvidersTool.new
+      expect(tool.name.length).to be <= 64
+      expect(tool.name).to start_with('very_long_tool_name_that_exceeds_the_maximum_allowed_length_for')
+    end
   end
 end


### PR DESCRIPTION
I have some very long tool names in my codebase, and I ran into the OpenAI 64-character limit.

My fix is pretty blunt, and it's system-wide rather than provider-specific.  Obviously happy if you want to re-work it, just opening the discussion really.

I ran into an error about an invalid API key when running this against `anthropic/claude-3-5-haiku-20241022` -- not sure what that's about, it passes on all other providers.

Thanks!