### PR TITLE
Use consistent name for Weather tool in docs

### DIFF
--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -156,7 +156,7 @@ When building [Tools]({% link guides/tools.md %}), you need to decide how errors
 1.  **Return Error to LLM:** If the error is something the LLM might be able to recover from (e.g., invalid parameters provided by the LLM, temporary lookup failure), return a Hash containing an `:error` key. The LLM will see this error message as the tool's output and may try again or use a different approach.
 
     ```ruby
-    class WeatherTool < RubyLLM::Tool
+    class Weather < RubyLLM::Tool
       # ... params ...
       def execute(location:)
         if location.blank?

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -117,7 +117,7 @@ Attach tools to a `Chat` instance using `with_tool` or `with_tools`.
 chat = RubyLLM.chat(model: 'gpt-4o') # Use a model that supports tools
 
 # Instantiate your tool if it requires arguments, otherwise use the class
-weather_tool = WeatherLookup.new
+weather_tool = Weather.new
 
 # Add the tool(s) to the chat
 chat.with_tool(weather_tool)


### PR DESCRIPTION
For those following along with examples straight out of the documentation, provide a consistent name for the `Weather` tool example.