### PR TITLE
feat: adds test provider to simplify local development

### DIFF
--- a/lib/ruby_llm.rb
+++ b/lib/ruby_llm.rb
@@ -76,6 +76,7 @@ module RubyLLM
   end
 end
 
+RubyLLM::Provider.register :test, RubyLLM::Providers::Test
 RubyLLM::Provider.register :openai, RubyLLM::Providers::OpenAI
 RubyLLM::Provider.register :anthropic, RubyLLM::Providers::Anthropic
 RubyLLM::Provider.register :gemini, RubyLLM::Providers::Gemini

--- a/lib/ruby_llm/models.json
+++ b/lib/ruby_llm/models.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "test",
+    "provider": "test",
+    "metadata": {}
+  },
+  {
     "id": "claude-2.0",
     "name": "Claude 2.0",
     "provider": "anthropic",

--- a/lib/ruby_llm/providers/test.rb
+++ b/lib/ruby_llm/providers/test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    # TestProvider is a mock provider for testing purposes.
+    module Test
+      # extend Provider
+
+      module_function
+
+      def complete(...)
+        RubyLLM::Message.new(role: :assistant, content: 'Default response from TestProvider')
+      end
+
+      def list_models(...)
+        [
+          Model::Info.new(
+            id: 'test',
+            display_name: 'test',
+            provider: 'test',
+            family: 'test',
+            type: 'chat',
+            context_window: 100_000_000,
+            max_tokens: 200_000_000,
+            supports_vision: false,
+            supports_functions: false,
+            supports_json_mode: false,
+            input_price_per_million: 0,
+            output_price_per_million: 0,
+            modalities: { input: ['text'], output: ['text'] },
+            created_at: '2025-06-01 00:00:00 +0100'
+          )
+        ]
+      end
+
+      def configured?(...)
+        true
+      end
+
+      def slug
+        'test'
+      end
+
+      def local?
+        true
+      end
+
+      def remote?
+        true
+      end
+
+      def connection(...)
+        nil
+      end
+    end
+  end
+end

--- a/spec/ruby_llm/providers/test_spec.rb
+++ b/spec/ruby_llm/providers/test_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::Test do
+  describe 'registering models' do
+    it 'findable by provider' do
+      expect(test_provider_models.all).to all(have_attributes(provider: 'test', type: 'chat'))
+    end
+
+    it 'findable by model (globally)' do
+      found = RubyLLM.models.find('test')
+
+      expect(found).to have_attributes(id: 'test', provider: 'test')
+    end
+
+    it 'findable by model ID within provider-specific list' do
+      found = RubyLLM.models.by_provider('test').find('test')
+
+      expect(found).to have_attributes(id: 'test', provider: 'test')
+    end
+
+    context 'when models are refreshed' do
+      before { RubyLLM.models.refresh! }
+
+      it 'finds model by ID within provider-specific list after refresh' do
+        test_model = RubyLLM.models.by_provider('test').find('test')
+
+        expect(test_model).to have_attributes(id: 'test', provider: 'test')
+      end
+    end
+  end
+
+  describe 'create chat with test model' do
+    subject { RubyLLM.chat(model: 'test') }
+
+    it 'creates a chat with the test model without provider specified' do
+      expect(subject.model).to have_attributes(id: 'test', provider: 'test')
+    end
+
+    it 'creates a chat with the test model when provider is specified' do
+      expect(RubyLLM.chat(model: 'test', provider: 'test').model)
+        .to have_attributes(id: 'test', provider: 'test')
+    end
+
+    it 'gets sample message from chat' do
+      expect(subject.ask('Hello').content).to eq('Default response from TestProvider')
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -112,6 +112,7 @@ RSpec.shared_context 'with configured RubyLLM' do
 end
 
 CHAT_MODELS = [
+  { provider: :test, model: 'test' },
   { provider: :anthropic, model: 'claude-3-5-haiku-20241022' },
   { provider: :bedrock, model: 'anthropic.claude-3-5-haiku-20241022-v1:0' },
   { provider: :gemini, model: 'gemini-2.0-flash' },


### PR DESCRIPTION
Introduces a new mock provider, `TestProvider`, to the `RubyLLM` library for development and testing purposes. The changes include adding the provider, registering it, defining its behavior, and creating corresponding tests to ensure functionality.