### PR TITLE
Feat: Add caching for tools

### DIFF
--- a/gemfiles/rails_7.1.gemfile.lock
+++ b/gemfiles/rails_7.1.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     ruby_llm (1.3.0rc1)
+      activesupport
       base64
       event_stream_parser (~> 1)
       faraday (>= 1.10.0)
@@ -179,6 +180,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.18.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     overcommit (0.67.1)
@@ -291,6 +294,7 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
+    sqlite3 (2.6.0-arm64-darwin)
     sqlite3 (2.6.0-x86_64-linux-gnu)
     stringio (3.1.7)
     thor (1.3.2)
@@ -316,6 +320,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     ruby_llm (1.3.0rc1)
+      activesupport
       base64
       event_stream_parser (~> 1)
       faraday (>= 1.10.0)
@@ -96,6 +97,7 @@ GEM
     benchmark (0.4.1)
     bigdecimal (3.2.1)
     builder (3.3.0)
+    cgi (0.4.2)
     childprocess (5.1.0)
       logger (~> 1.5)
     codecov (0.2.12)
@@ -113,7 +115,8 @@ GEM
     docile (1.4.1)
     dotenv (3.1.8)
     drb (2.2.3)
-    erb (5.0.1)
+    erb (4.0.4)
+      cgi (>= 0.3.3)
     erubi (1.13.1)
     event_stream_parser (1.0.0)
     faraday (2.13.1)
@@ -172,7 +175,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
+    nokogiri (1.18.8-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-linux)
       racc (~> 1.4)
     overcommit (0.67.1)
       childprocess (>= 0.6.3, < 6)
@@ -284,7 +289,8 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
-    sqlite3 (2.6.0-x86_64-linux-gnu)
+    sqlite3 (2.6.0-arm64-darwin)
+    sqlite3 (2.6.0-x86_64-linux)
     stringio (3.1.7)
     thor (1.3.2)
     timeout (0.4.3)
@@ -307,9 +313,10 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     yard (0.9.37)
-    zeitwerk (2.7.3)
+    zeitwerk (2.6.18)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/gemfiles/rails_8.0.gemfile.lock
+++ b/gemfiles/rails_8.0.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     ruby_llm (1.3.0rc1)
+      activesupport
       base64
       event_stream_parser (~> 1)
       faraday (>= 1.10.0)
@@ -172,6 +173,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.18.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     overcommit (0.67.1)
@@ -284,6 +287,7 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
+    sqlite3 (2.6.0-arm64-darwin)
     sqlite3 (2.6.0-x86_64-linux-gnu)
     stringio (3.1.7)
     thor (1.3.2)
@@ -310,6 +314,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/ruby_llm.rb
+++ b/lib/ruby_llm.rb
@@ -73,6 +73,10 @@ module RubyLLM
         level: config.log_level
       )
     end
+
+    def cache
+      @cache ||= ActiveSupport::Cache.lookup_store(*config.cache_store)
+    end
   end
 end
 

--- a/lib/ruby_llm/configuration.rb
+++ b/lib/ruby_llm/configuration.rb
@@ -38,7 +38,9 @@ module RubyLLM
                   # Logging configuration
                   :log_file,
                   :log_level,
-                  :log_assume_model_exists
+                  :log_assume_model_exists,
+                  :perform_caching,
+                  :cache_store
 
     def initialize
       # Connection configuration
@@ -58,6 +60,10 @@ module RubyLLM
       @log_file = $stdout
       @log_level = ENV['RUBYLLM_DEBUG'] ? Logger::DEBUG : Logger::INFO
       @log_assume_model_exists = true
+
+      # Cache configuration
+      @perform_caching = false
+      @cache_store = :null_store
     end
 
     def inspect

--- a/lib/ruby_llm/tool.rb
+++ b/lib/ruby_llm/tool.rb
@@ -47,8 +47,8 @@ module RubyLLM
         @parameters ||= {}
       end
 
-      def cacheable?
-        false
+      def cacheable(value = false)
+        @cacheable = value
       end
 
       def cache_expiration(expires_in = 12.hours)
@@ -75,10 +75,15 @@ module RubyLLM
       self.class.parameters
     end
 
+    def cacheable?
+      self.class.instance_variable_defined?(:@cacheable)
+    end
+
     def call(args)
       RubyLLM.logger.debug "Tool #{name} called with: #{args.inspect}"
-      if RubyLLM.config.perform_caching && self.class.cacheable?
-        cache_key = [name, args].to_param
+
+      if RubyLLM.config.perform_caching && cacheable?
+        cache_key = [name, args].compact.to_param
         RubyLLM.logger.debug "Retrieving result from cache with key: #{cache_key.inspect}"
 
         result = RubyLLM.cache.fetch(cache_key, expires_in: self.class.cache_expiration) do

--- a/ruby_llm.gemspec
+++ b/ruby_llm.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Runtime dependencies
-  spec.add_dependency 'activesupport', '~> 7'
   spec.add_dependency 'base64'
   spec.add_dependency 'event_stream_parser', '~> 1'
   spec.add_dependency 'faraday', ENV['FARADAY_VERSION'] || '>= 1.10.0'
@@ -43,4 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-retry', '>= 1'
   spec.add_dependency 'marcel', '~> 1.0'
   spec.add_dependency 'zeitwerk', '~> 2'
+  spec.add_dependency 'activesupport'
 end

--- a/ruby_llm.gemspec
+++ b/ruby_llm.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Runtime dependencies
+  spec.add_dependency 'activesupport', '~> 7'
   spec.add_dependency 'base64'
   spec.add_dependency 'event_stream_parser', '~> 1'
   spec.add_dependency 'faraday', ENV['FARADAY_VERSION'] || '>= 1.10.0'

--- a/spec/fixtures/vcr_cassettes/chat_caching_caches_tool_results.yml
+++ b/spec/fixtures/vcr_cassettes/chat_caching_caches_tool_results.yml
@@ -1,0 +1,471 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4.1-nano","messages":[{"role":"user","content":"Give
+        me the current counter value from the database"}],"temperature":0.7,"stream":false,"tools":[{"type":"function","function":{"name":"counter","description":"Returns
+        a counter value","parameters":{"type":"object","properties":{},"required":[]}}}],"tool_choice":"auto"}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Jun 2025 03:08:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - "<OPENAI_ORGANIZATION>"
+      Openai-Processing-Ms:
+      - '341'
+      Openai-Version:
+      - '2020-10-01'
+      X-Envoy-Upstream-Service-Time:
+      - '365'
+      X-Ratelimit-Limit-Requests:
+      - '30000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '29999'
+      X-Ratelimit-Remaining-Tokens:
+      - '149999984'
+      X-Ratelimit-Reset-Requests:
+      - 2ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - "<X_REQUEST_ID>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<COOKIE>"
+      - "<COOKIE>"
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-BeCItuWniSURucGTC7C2ufTfft2ne",
+          "object": "chat.completion",
+          "created": 1748920115,
+          "model": "gpt-4.1-nano-2025-04-14",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                  {
+                    "id": "call_f17cCdbxG0uRIf36epPAh4Uf",
+                    "type": "function",
+                    "function": {
+                      "name": "counter",
+                      "arguments": "{}"
+                    }
+                  }
+                ],
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "tool_calls"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 44,
+            "completion_tokens": 9,
+            "total_tokens": 53,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_38343a2f8f"
+        }
+  recorded_at: Tue, 03 Jun 2025 03:08:36 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4.1-nano","messages":[{"role":"user","content":"Give
+        me the current counter value from the database"},{"role":"assistant","tool_calls":[{"id":"call_f17cCdbxG0uRIf36epPAh4Uf","type":"function","function":{"name":"counter","arguments":"{}"}}]},{"role":"tool","content":"true","tool_call_id":"call_f17cCdbxG0uRIf36epPAh4Uf"}],"temperature":0.7,"stream":false,"tools":[{"type":"function","function":{"name":"counter","description":"Returns
+        a counter value","parameters":{"type":"object","properties":{},"required":[]}}}],"tool_choice":"auto"}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Jun 2025 03:08:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - "<OPENAI_ORGANIZATION>"
+      Openai-Processing-Ms:
+      - '293'
+      Openai-Version:
+      - '2020-10-01'
+      X-Envoy-Upstream-Service-Time:
+      - '304'
+      X-Ratelimit-Limit-Requests:
+      - '30000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '29999'
+      X-Ratelimit-Remaining-Tokens:
+      - '149999981'
+      X-Ratelimit-Reset-Requests:
+      - 2ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - "<X_REQUEST_ID>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<COOKIE>"
+      - "<COOKIE>"
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-BeCIuDgTu3UEcNAfstpatw1kXVfas",
+          "object": "chat.completion",
+          "created": 1748920116,
+          "model": "gpt-4.1-nano-2025-04-14",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The current counter value from the database is 1.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 61,
+            "completion_tokens": 12,
+            "total_tokens": 73,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_38343a2f8f"
+        }
+  recorded_at: Tue, 03 Jun 2025 03:08:36 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4.1-nano","messages":[{"role":"user","content":"Give
+        me the current counter value from the database"},{"role":"assistant","tool_calls":[{"id":"call_f17cCdbxG0uRIf36epPAh4Uf","type":"function","function":{"name":"counter","arguments":"{}"}}]},{"role":"tool","content":"true","tool_call_id":"call_f17cCdbxG0uRIf36epPAh4Uf"},{"role":"assistant","content":"The
+        current counter value from the database is 1."},{"role":"user","content":"Give
+        me the current counter value from the database"}],"temperature":0.7,"stream":false,"tools":[{"type":"function","function":{"name":"counter","description":"Returns
+        a counter value","parameters":{"type":"object","properties":{},"required":[]}}}],"tool_choice":"auto"}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Jun 2025 03:08:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - "<OPENAI_ORGANIZATION>"
+      Openai-Processing-Ms:
+      - '144'
+      Openai-Version:
+      - '2020-10-01'
+      X-Envoy-Upstream-Service-Time:
+      - '146'
+      X-Ratelimit-Limit-Requests:
+      - '30000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '29999'
+      X-Ratelimit-Remaining-Tokens:
+      - '149999954'
+      X-Ratelimit-Reset-Requests:
+      - 2ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - "<X_REQUEST_ID>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<COOKIE>"
+      - "<COOKIE>"
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-BeCIujr2mNUQ0RR4EoCySXV7RI3ep",
+          "object": "chat.completion",
+          "created": 1748920116,
+          "model": "gpt-4.1-nano-2025-04-14",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                  {
+                    "id": "call_PHRLkewS8aC98RidkhDND0V8",
+                    "type": "function",
+                    "function": {
+                      "name": "counter",
+                      "arguments": "{}"
+                    }
+                  }
+                ],
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "tool_calls"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 89,
+            "completion_tokens": 9,
+            "total_tokens": 98,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_38343a2f8f"
+        }
+  recorded_at: Tue, 03 Jun 2025 03:08:36 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4.1-nano","messages":[{"role":"user","content":"Give
+        me the current counter value from the database"},{"role":"assistant","tool_calls":[{"id":"call_f17cCdbxG0uRIf36epPAh4Uf","type":"function","function":{"name":"counter","arguments":"{}"}}]},{"role":"tool","content":"true","tool_call_id":"call_f17cCdbxG0uRIf36epPAh4Uf"},{"role":"assistant","content":"The
+        current counter value from the database is 1."},{"role":"user","content":"Give
+        me the current counter value from the database"},{"role":"assistant","tool_calls":[{"id":"call_PHRLkewS8aC98RidkhDND0V8","type":"function","function":{"name":"counter","arguments":"{}"}}]},{"role":"tool","content":"true","tool_call_id":"call_PHRLkewS8aC98RidkhDND0V8"}],"temperature":0.7,"stream":false,"tools":[{"type":"function","function":{"name":"counter","description":"Returns
+        a counter value","parameters":{"type":"object","properties":{},"required":[]}}}],"tool_choice":"auto"}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Jun 2025 03:08:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - "<OPENAI_ORGANIZATION>"
+      Openai-Processing-Ms:
+      - '206'
+      Openai-Version:
+      - '2020-10-01'
+      X-Envoy-Upstream-Service-Time:
+      - '210'
+      X-Ratelimit-Limit-Requests:
+      - '30000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '29999'
+      X-Ratelimit-Remaining-Tokens:
+      - '149999951'
+      X-Ratelimit-Reset-Requests:
+      - 2ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - "<X_REQUEST_ID>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<COOKIE>"
+      - "<COOKIE>"
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-BeCIvGoZWKCFRmiLWrHRrj9yeKa26",
+          "object": "chat.completion",
+          "created": 1748920117,
+          "model": "gpt-4.1-nano-2025-04-14",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The current counter value from the database is 1.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 106,
+            "completion_tokens": 12,
+            "total_tokens": 118,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_38343a2f8f"
+        }
+  recorded_at: Tue, 03 Jun 2025 03:08:37 GMT
+recorded_with: VCR 6.3.1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'simplecov'
 require 'simplecov-cobertura'
 require 'codecov'
 require 'vcr'
+require 'active_support/testing/time_helpers'
 
 SimpleCov.start do
   add_filter '/spec/'
@@ -105,6 +106,8 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 RSpec.shared_context 'with configured RubyLLM' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ require 'simplecov'
 require 'simplecov-cobertura'
 require 'codecov'
 require 'vcr'
-require 'active_support/testing/time_helpers'
 
 SimpleCov.start do
   add_filter '/spec/'
@@ -106,8 +105,6 @@ RSpec.configure do |config|
       example.run
     end
   end
-
-  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 RSpec.shared_context 'with configured RubyLLM' do


### PR DESCRIPTION
Hey @crmne, love the work you're doing with the gem!

This is just an idea/proposal, and I completely understand if this is something you don't want to add as part of the gem, or you think it would be better as a separate plugin or gem. It's not completely ready to merge yet, but wanted to share it before spending more time on it.

I've been playing around with the gem, and found a couple scenarios where caching the output of a tool call would really help saving some costs and also making things faster, for instance if you have a tool like this to get the content of a webpage with Tavily:

```ruby
class TavilyExtract < RubyLLM::Tool
  description "Extract web page content from a specified URL"
  param :url, desc: "The URL of the page to extract the content from"

  def initialize
    @api_key = ENV.fetch("TAVILY_API_KEY", nil)
  end

  def execute(url:)
    uri = "https://api.tavily.com/extract"
    headers = {
      "Authorization" => "Bearer #{api_key}",
      "Content-Type" => "application/json"
    }
    body = {
      urls: url,
      extract_depth: 'advanced'
    }.to_json

    JSON.parse(HTTParty.post(uri, headers: headers, body: body).body)
  end
end
```

Of course the content of the page can change, but maybe that's not super critical for you and having a cached version of it is good enough, or you can simply put a short expiration time for it.

Not a huge fan of depending on `activestorage` for this, but just wanted to provide a generic mechanism to support multiple caching adapters. Any other idea is welcome.