### PR TITLE
Resolve "text content blocks must be non-empty" issue against Anthropic/Bedrock API

### DIFF
--- a/lib/ruby_llm/providers/anthropic/tools.rb
+++ b/lib/ruby_llm/providers/anthropic/tools.rb
@@ -20,7 +20,7 @@ module RubyLLM
 
           {
             role: 'assistant',
-            content: 
+            content:
           }
         end
 

--- a/lib/ruby_llm/providers/anthropic/tools.rb
+++ b/lib/ruby_llm/providers/anthropic/tools.rb
@@ -14,12 +14,13 @@ module RubyLLM
         def format_tool_call(msg)
           tool_call = msg.tool_calls.values.first
 
+          content = []
+          content << Media.format_text(msg.content) unless msg.content.nil? || msg.content.empty?
+          content << format_tool_use_block(tool_call)
+
           {
             role: 'assistant',
-            content: [
-              Media.format_text(msg.content),
-              format_tool_use_block(tool_call)
-            ]
+            content: 
           }
         end
 

--- a/spec/ruby_llm/providers/anthropic/tools_spec.rb
+++ b/spec/ruby_llm/providers/anthropic/tools_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::Anthropic::Tools do
+  let(:tools) { described_class }
+
+  describe '.format_tool_call' do
+    let(:msg) do
+      instance_double(Message,
+                      content: 'Some content',
+                      tool_calls: {
+                        'tool_123' => instance_double(ToolCall,
+                                                      id: 'tool_123',
+                                                      name: 'test_tool',
+                                                      arguments: { 'arg1' => 'value1' })
+                      })
+    end
+
+    it 'formats a message with content and tool call' do # rubocop:disable RSpec/ExampleLength
+      result = tools.format_tool_call(msg)
+
+      expect(result).to eq({
+                             role: 'assistant',
+                             content: [
+                               { type: 'text', text: 'Some content' },
+                               {
+                                 type: 'tool_use',
+                                 id: 'tool_123',
+                                 name: 'test_tool',
+                                 input: { 'arg1' => 'value1' }
+                               }
+                             ]
+                           })
+    end
+
+    context 'when message has no content' do
+      let(:msg) do
+        instance_double(Message,
+                        content: nil,
+                        tool_calls: {
+                          'tool_123' => instance_double(ToolCall,
+                                                        id: 'tool_123',
+                                                        name: 'test_tool',
+                                                        arguments: { 'arg1' => 'value1' })
+                        })
+      end
+
+      it 'formats a message with only tool call' do # rubocop:disable RSpec/ExampleLength
+        result = tools.format_tool_call(msg)
+
+        expect(result).to eq({
+                               role: 'assistant',
+                               content: [
+                                 {
+                                   type: 'tool_use',
+                                   id: 'tool_123',
+                                   name: 'test_tool',
+                                   input: { 'arg1' => 'value1' }
+                                 }
+                               ]
+                             })
+      end
+    end
+
+    context 'when message has empty content' do
+      let(:msg) do
+        instance_double(Message,
+                        content: '',
+                        tool_calls: {
+                          'tool_123' => instance_double(ToolCall,
+                                                        id: 'tool_123',
+                                                        name: 'test_tool',
+                                                        arguments: { 'arg1' => 'value1' })
+                        })
+      end
+
+      it 'formats a message with only tool call' do # rubocop:disable RSpec/ExampleLength
+        result = tools.format_tool_call(msg)
+
+        expect(result).to eq({
+                               role: 'assistant',
+                               content: [
+                                 {
+                                   type: 'tool_use',
+                                   id: 'tool_123',
+                                   name: 'test_tool',
+                                   input: { 'arg1' => 'value1' }
+                                 }
+                               ]
+                             })
+      end
+    end
+  end
+
+  describe '.format_tool_result' do
+    let(:msg) do
+      instance_double(Message,
+                      tool_call_id: 'tool_123',
+                      content: 'Tool result')
+    end
+
+    it 'formats a tool result message' do # rubocop:disable RSpec/ExampleLength
+      result = tools.format_tool_result(msg)
+
+      expect(result).to eq({
+                             role: 'user',
+                             content: [
+                               {
+                                 type: 'tool_result',
+                                 tool_use_id: 'tool_123',
+                                 content: 'Tool result'
+                               }
+                             ]
+                           })
+    end
+  end
+end


### PR DESCRIPTION
## What this does

Fix issue where after calling tools you intermittently encounter this error: `text content blocks must be non-empty`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
Fixes #227