### PR TITLE
Support removing tools

### DIFF
--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -132,6 +132,46 @@ puts response.content
 {: .warning }
 Ensure the model you select supports function calling/tools. Check model capabilities using `RubyLLM.models.find('your-model-id').supports_functions?`. Attempting to use `with_tool` on an unsupported model will raise `RubyLLM::UnsupportedFunctionsError`.
 
+## Removing Tools
+
+Each tool definition adds to the input tokens for every request, so it is often a good idea to remove tools that are not needed on a given request. You can remove tools from a `Chat` instance using these methods:
+
+### Remove a Single Tool
+
+Use `without_tool` to remove a specific tool by passing either the tool class or instance:
+
+```ruby
+# Remove by class
+chat.without_tool(Weather)
+
+# Or by instance
+chat.without_tool(weather_tool)
+```
+
+### Remove Multiple Tools
+
+Use `without_tools` to remove multiple tools at once:
+
+```ruby
+chat.without_tools(Weather, AnotherTool, some_tool_instance)
+```
+
+### Clear All Tools
+
+To remove all tools from the chat instance:
+
+```ruby
+chat.clear_tools
+```
+
+All these methods return the `Chat` instance, allowing for method chaining:
+
+```ruby
+chat.clear_tools
+  .with_tool(Weather.new)
+  .ask("What's the weather?")
+```
+
 ## The Tool Execution Flow
 
 When you `ask` a question that the model determines requires a tool:

--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -50,13 +50,29 @@ module RubyLLM
         raise UnsupportedFunctionsError, "Model #{@model.id} doesn't support function calling"
       end
 
-      tool_instance = tool.is_a?(Class) ? tool.new : tool
-      @tools[tool_instance.name.to_sym] = tool_instance
+      tool_instance = instantiate_tool(tool)
+      @tools[tool_name(tool_instance)] = tool_instance
       self
     end
 
     def with_tools(*tools)
       tools.each { |tool| with_tool tool }
+      self
+    end
+
+    def without_tool(tool)
+      tool_instance = instantiate_tool(tool)
+      @tools.delete(tool_name(tool_instance))
+      self
+    end
+
+    def without_tools(*tools)
+      tools.each { |tool| without_tool(tool) }
+      self
+    end
+
+    def clear_tools
+      @tools.clear
       self
     end
 
@@ -147,6 +163,14 @@ module RubyLLM
         content: result.is_a?(Hash) && result[:error] ? result[:error] : result.to_s,
         tool_call_id: tool_use_id
       )
+    end
+
+    def tool_name(tool)
+      tool.name.to_sym
+    end
+
+    def instantiate_tool(tool)
+      tool.is_a?(Class) ? tool.new : tool
     end
   end
 end

--- a/spec/ruby_llm/chat_tools_spec.rb
+++ b/spec/ruby_llm/chat_tools_spec.rb
@@ -140,4 +140,75 @@ RSpec.describe RubyLLM::Chat do
       end
     end
   end
+
+  describe 'tool management' do
+    let(:chat) { RubyLLM.chat }
+    let(:weather_tool) { Weather.new }
+    let(:best_language_tool) { BestLanguageToLearn.new }
+
+    before do
+      chat.with_tool(Weather)
+      chat.with_tool(BestLanguageToLearn)
+    end
+
+    describe '#without_tool' do
+      it 'removes a tool by class' do
+        expect(chat.tools.keys).to include(:weather, :best_language_to_learn)
+        
+        chat.without_tool(Weather)
+        
+        expect(chat.tools.keys).not_to include(:weather)
+        expect(chat.tools.keys).to include(:best_language_to_learn)
+      end
+
+      it 'removes a tool by instance' do
+        expect(chat.tools.keys).to include(:weather, :best_language_to_learn)
+        
+        chat.without_tool(weather_tool)
+        
+        expect(chat.tools.keys).not_to include(:weather)
+        expect(chat.tools.keys).to include(:best_language_to_learn)
+      end
+
+      it 'returns self for method chaining' do
+        expect(chat.without_tool(weather_tool)).to be(chat)
+      end
+    end
+
+    describe '#without_tools' do
+      it 'removes multiple tools by class' do
+        expect(chat.tools.keys).to include(:weather, :best_language_to_learn)
+        
+        chat.without_tools(Weather, BestLanguageToLearn)
+        
+        expect(chat.tools).to be_empty
+      end
+
+      it 'removes multiple tools by instance' do
+        expect(chat.tools.keys).to include(:weather, :best_language_to_learn)
+        
+        chat.without_tools(weather_tool, best_language_tool)
+        
+        expect(chat.tools).to be_empty
+      end
+
+      it 'returns self for method chaining' do
+        expect(chat.without_tools(weather_tool, best_language_tool)).to be(chat)
+      end
+    end
+
+    describe '#clear_tools' do
+      it 'removes all tools' do
+        expect(chat.tools).not_to be_empty
+        
+        chat.clear_tools
+        
+        expect(chat.tools).to be_empty
+      end
+
+      it 'returns self for method chaining' do
+        expect(chat.clear_tools).to be(chat)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What this does

I realized recently just how many tokens tools can take. 

Here's an example of saying "Hello" to Bedrock with 4 basic local tools + the tools from the Playwright MCP:
![image](https://github.com/user-attachments/assets/747d6f83-44e7-4cd2-9548-d8e7a719001d)
This call took 3024 input tokens.
Without the Playwright MCP, the call takes 842 tokens.

In a chat with an agentic interface, I want the option to add/remove tools at will to save on tokens. 

It also simplifies tool selection for the LLM if there are fewer tools to choose from.


## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [X] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [X] This aligns with RubyLLM's focus on **LLM communication**
- [X] This isn't application-specific logic that belongs in user code
- [X] This benefits most users, not just my specific use case

## Quality check

- [X] I ran `overcommit --install` and all hooks pass
- [X] I tested my changes thoroughly
- [X] I updated documentation if needed
- [X] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [X] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
Resolves #229 