### PR TITLE
fixed issue related to rby 3.1 compatibility

### DIFF
--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -31,9 +31,9 @@ module RubyLLM
       }
     end
 
-    def ask(message = nil, with: nil, &)
+    def ask(message = nil, with: nil, &block)
       add_message role: :user, content: Content.new(message, with)
-      complete(&)
+      complete(&block)
     end
 
     alias say ask

--- a/lib/ruby_llm/provider.rb
+++ b/lib/ruby_llm/provider.rb
@@ -10,7 +10,7 @@ module RubyLLM
     module Methods
       extend Streaming
 
-      def complete(messages, tools:, temperature:, model:, connection:, &)
+      def complete(messages, tools:, temperature:, model:, connection:, &block)
         normalized_temperature = maybe_normalize_temperature(temperature, model)
 
         payload = render_payload(messages,
@@ -20,7 +20,7 @@ module RubyLLM
                                  stream: block_given?)
 
         if block_given?
-          stream_response connection, payload, &
+          stream_response connection, payload, &block
         else
           sync_response connection, payload
         end


### PR DESCRIPTION
## What this does

Hey @crmne!

Currently, RubyLLM has minimum requirement for Ruby at 3.1. This is related to an issue that was raised on RubyLLM::MCP: https://github.com/patvice/ruby_llm-mcp/issues/6.

Seems like there is an issue with how anonymous block forwarding is being used in two cases which doesn't allow the gem to be required in ruby 3.1. Ruby 3.1 has some stricter rules when it comes to anonymous block forwarding, to use `&` syntax it requires the entire parameter list is forwarded otherwise you get a syntax error when Ruby is parsing the file.

Simple fix is to just not use `&` forwarding in these two cases and relay on the older syntax  `&block`. Then everything works as you would expect.

## Type of change

- [x] Bug fix

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

Fixes https://github.com/patvice/ruby_llm-mcp/issues/6.

Unrelated to this, Rspec are not possible to run at the moment on 3.1 without some amount of modification but seems like it's out of scope for this PR. The way that the specs currently setup Rails require Rails 8 (as far as I can tell) and Rails 8 only support Ruby >= 3.3.

Something else to consider, Ruby 3.1 has reached EOL. Could consider bumping the minim Ruby version to 3.2 for future RubyLLM version so these kinds of issues can go away.