### PR TITLE
Add RubyLLM::Chat#with_options to pass options to the underlying API payload

### DIFF
--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -11,7 +11,7 @@ module RubyLLM
   class Chat
     include Enumerable
 
-    attr_reader :model, :messages, :tools
+    attr_reader :model, :messages, :tools, :options
 
     def initialize(model: nil, provider: nil, assume_model_exists: false, context: nil)
       if assume_model_exists && !provider
@@ -25,6 +25,7 @@ module RubyLLM
       @temperature = 0.7
       @messages = []
       @tools = {}
+      @options = {}
       @on = {
         new_message: nil,
         end_message: nil
@@ -78,6 +79,11 @@ module RubyLLM
       self
     end
 
+    def with_options(**options)
+      @options = options
+      self
+    end
+
     def on_new_message(&block)
       @on[:new_message] = block
       self
@@ -100,6 +106,7 @@ module RubyLLM
         temperature: @temperature,
         model: @model.id,
         connection: @connection,
+        options: @options,
         &
       )
       @on[:end_message]&.call(response)

--- a/lib/ruby_llm/provider.rb
+++ b/lib/ruby_llm/provider.rb
@@ -10,19 +10,30 @@ module RubyLLM
     module Methods
       extend Streaming
 
-      def complete(messages, tools:, temperature:, model:, connection:, &)
+      def complete(messages, tools:, temperature:, model:, connection:, options: {}, &)
         normalized_temperature = maybe_normalize_temperature(temperature, model)
 
-        payload = render_payload(messages,
-                                 tools: tools,
-                                 temperature: normalized_temperature,
-                                 model: model,
-                                 stream: block_given?)
+        payload = deep_merge(
+          options,
+          render_payload(
+            messages,
+            tools: tools,
+            temperature: normalized_temperature,
+            model: model,
+            stream: block_given?
+          )
+        )
 
         if block_given?
           stream_response connection, payload, &
         else
           sync_response connection, payload
+        end
+      end
+
+      def deep_merge(options, payload)
+        options.merge(payload) do |key, options_value, payload_value|
+          options_value.is_a?(Hash) && payload_value.is_a?(Hash) ? deep_merge(options_value, payload_value) : payload_value
         end
       end
 

--- a/spec/fixtures/vcr_cassettes/chat_with_options_anthropic_claude-3-5-haiku-20241022_supports_service_tier_option.yml
+++ b/spec/fixtures/vcr_cassettes/chat_with_options_anthropic_claude-3-5-haiku-20241022_supports_service_tier_option.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"service_tier":"standard_only","model":"claude-3-5-haiku-20241022","messages":[{"role":"user","content":[{"type":"text","text":"What
+        is the square root of 64? Answer with a JSON object with the key `result`."}]}],"temperature":0.7,"stream":false,"max_tokens":8192}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      X-Api-Key:
+      - "<ANTHROPIC_API_KEY>"
+      Anthropic-Version:
+      - '2023-06-01'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 29 Jun 2025 04:50:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Input-Tokens-Limit:
+      - '25000'
+      Anthropic-Ratelimit-Input-Tokens-Remaining:
+      - '25000'
+      Anthropic-Ratelimit-Input-Tokens-Reset:
+      - '2025-06-29T04:50:58Z'
+      Anthropic-Ratelimit-Output-Tokens-Limit:
+      - '5000'
+      Anthropic-Ratelimit-Output-Tokens-Remaining:
+      - '5000'
+      Anthropic-Ratelimit-Output-Tokens-Reset:
+      - '2025-06-29T04:50:59Z'
+      Anthropic-Ratelimit-Requests-Limit:
+      - '5'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '4'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2025-06-29T04:51:09Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '30000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '30000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2025-06-29T04:50:58Z'
+      Request-Id:
+      - "<REQUEST_ID>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Anthropic-Organization-Id:
+      - 40072724-019e-4d79-83c0-8afb86354812
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Robots-Tag:
+      - none
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"msg_01UZyKC52tfiHLRy1rvMXg7N","type":"message","role":"assistant","model":"claude-3-5-haiku-20241022","content":[{"type":"text","text":"{\n    \"result\":
+        8\n}"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":27,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":13,"service_tier":"standard"}}'
+  recorded_at: Sun, 29 Jun 2025 04:50:59 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/chat_with_options_bedrock_anthropic_claude-3-5-haiku-20241022-v1_0_supports_top_k_option.yml
+++ b/spec/fixtures/vcr_cassettes/chat_with_options_bedrock_anthropic_claude-3-5-haiku-20241022-v1_0_supports_top_k_option.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://bedrock-runtime.<AWS_REGION>.amazonaws.com/model/anthropic.claude-3-5-haiku-20241022-v1:0/invoke
+    body:
+      encoding: UTF-8
+      string: '{"top_k":5,"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":[{"type":"text","text":"What
+        is the square root of 64? Answer with a JSON object with the key `result`."}]}],"temperature":0.7,"max_tokens":4096}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Host:
+      - bedrock-runtime.<AWS_REGION>.amazonaws.com
+      X-Amz-Date:
+      - 20250629T054919Z
+      X-Amz-Content-Sha256:
+      - 2737f3d02cae7cb6849cf4092f7029eb8a68bd328033e5dbf3d7a08f6819bcf6
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<AWS_ACCESS_KEY_ID>/20250629/<AWS_REGION>/bedrock/aws4_request,
+        SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=ae978f3d73488d6c716c2af3bd74741c8e495583b4bba38f3266309f643ba26f
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 29 Jun 2025 05:49:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '268'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 146785ac-7eee-4c55-9ec7-b524a01365b3
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '533'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '13'
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: '{"id":"msg_bdrk_01CfsXd7H3GjFAHtTPU9Fm9W","type":"message","role":"assistant","model":"claude-3-5-haiku-20241022","content":[{"type":"text","text":"{\n    \"result\":
+        8\n}"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":27,"output_tokens":13}}'
+  recorded_at: Sun, 29 Jun 2025 05:49:19 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/chat_with_options_deepseek_deepseek-chat_supports_response_format_option.yml
+++ b/spec/fixtures/vcr_cassettes/chat_with_options_deepseek_deepseek-chat_supports_response_format_option.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.deepseek.com/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"response_format":{"type":"json_object"},"model":"deepseek-chat","messages":[{"role":"user","content":"What
+        is the square root of 64? Answer with a JSON object with the key `result`."}],"stream":false,"temperature":0.7}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - Bearer <DEEPSEEK_API_KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 29 Jun 2025 04:19:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - origin, access-control-request-method, access-control-request-headers
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Ds-Trace-Id:
+      - b881c21fbf8c99f00c9ea57b0d2342a6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<COOKIE>"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"e9d187a6-6a6b-43da-a445-8456c7e46545","object":"chat.completion","created":1751170796,"model":"deepseek-chat","choices":[{"index":0,"message":{"role":"assistant","content":"{\n  \"result\":
+        8\n}"},"logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":39,"completion_tokens":13,"total_tokens":52,"prompt_tokens_details":{"cached_tokens":0},"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":39},"system_fingerprint":"fp_8802369eaa_prod0623_fp8_kvcache"}'
+  recorded_at: Sun, 29 Jun 2025 04:20:00 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/chat_with_options_gemini_gemini-2_0-flash_supports_responseschema_option.yml
+++ b/spec/fixtures/vcr_cassettes/chat_with_options_gemini_gemini-2_0-flash_supports_responseschema_option.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
+    body:
+      encoding: UTF-8
+      string: '{"generationConfig":{"responseMimeType":"application/json","responseSchema":{"type":"OBJECT","properties":{"result":{"type":"NUMBER"}}},"temperature":0.7},"contents":[{"role":"user","parts":[{"text":"What
+        is the square root of 64? Answer with a JSON object with the key `result`."}]}]}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      X-Goog-Api-Key:
+      - "<GEMINI_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Sun, 29 Jun 2025 05:24:48 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Server-Timing:
+      - gfet4t7; dur=548
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "candidates": [
+            {
+              "content": {
+                "parts": [
+                  {
+                    "text": "{\n  \"result\": 8\n}"
+                  }
+                ],
+                "role": "model"
+              },
+              "finishReason": "STOP",
+              "avgLogprobs": -0.0243309885263443
+            }
+          ],
+          "usageMetadata": {
+            "promptTokenCount": 24,
+            "candidatesTokenCount": 10,
+            "totalTokenCount": 34,
+            "promptTokensDetails": [
+              {
+                "modality": "TEXT",
+                "tokenCount": 24
+              }
+            ],
+            "candidatesTokensDetails": [
+              {
+                "modality": "TEXT",
+                "tokenCount": 10
+              }
+            ]
+          },
+          "modelVersion": "gemini-2.0-flash",
+          "responseId": "IM5gaOycBMGRhMIPo4HP-Qk"
+        }
+  recorded_at: Sun, 29 Jun 2025 05:24:48 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/chat_with_options_ollama_qwen3_supports_response_format_option.yml
+++ b/spec/fixtures/vcr_cassettes/chat_with_options_ollama_qwen3_supports_response_format_option.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<OLLAMA_API_BASE>/chat/completions"
+    body:
+      encoding: UTF-8
+      string: '{"response_format":{"type":"json_object"},"model":"qwen3","messages":[{"role":"user","content":"What
+        is the square root of 64? Answer with a JSON object with the key `result`."}],"stream":false,"temperature":0.7}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 29 Jun 2025 03:59:18 GMT
+      Content-Length:
+      - '301'
+    body:
+      encoding: UTF-8
+      string: '{"id":"chatcmpl-570","object":"chat.completion","created":1751169558,"model":"qwen3","system_fingerprint":"fp_ollama","choices":[{"index":0,"message":{"role":"assistant","content":"{\n  \"result\":
+        8\n}"},"finish_reason":"stop"}],"usage":{"prompt_tokens":29,"completion_tokens":10,"total_tokens":39}}
+
+        '
+  recorded_at: Sun, 29 Jun 2025 03:59:18 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/chat_with_options_openai_gpt-4_1-nano_supports_response_format_option.yml
+++ b/spec/fixtures/vcr_cassettes/chat_with_options_openai_gpt-4_1-nano_supports_response_format_option.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"response_format":{"type":"json_object"},"model":"gpt-4.1-nano","messages":[{"role":"user","content":"What
+        is the square root of 64? Answer with a JSON object with the key `result`."}],"stream":false,"temperature":0.7}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 29 Jun 2025 04:12:34 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - "<OPENAI_ORGANIZATION>"
+      Openai-Processing-Ms:
+      - '141'
+      Openai-Version:
+      - '2020-10-01'
+      X-Envoy-Upstream-Service-Time:
+      - '144'
+      X-Ratelimit-Limit-Requests:
+      - '500'
+      X-Ratelimit-Limit-Tokens:
+      - '200000'
+      X-Ratelimit-Remaining-Requests:
+      - '499'
+      X-Ratelimit-Remaining-Tokens:
+      - '199977'
+      X-Ratelimit-Reset-Requests:
+      - 120ms
+      X-Ratelimit-Reset-Tokens:
+      - 6ms
+      X-Request-Id:
+      - "<X_REQUEST_ID>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<COOKIE>"
+      - "<COOKIE>"
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-Bndh48hI90SJjTfRqmkqK6ZWnVykz",
+          "object": "chat.completion",
+          "created": 1751170354,
+          "model": "gpt-4.1-nano-2025-04-14",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "{\n  \"result\": 8\n}",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 27,
+            "completion_tokens": 9,
+            "total_tokens": 36,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_38343a2f8f"
+        }
+  recorded_at: Sun, 29 Jun 2025 04:12:34 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/chat_with_options_openrouter_anthropic_claude-3_5-haiku_supports_response_format_option.yml
+++ b/spec/fixtures/vcr_cassettes/chat_with_options_openrouter_anthropic_claude-3_5-haiku_supports_response_format_option.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://openrouter.ai/api/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"response_format":{"type":"json_object"},"model":"anthropic/claude-3.5-haiku","messages":[{"role":"user","content":"What
+        is the square root of 64? Answer with a JSON object with the key `result`."}],"stream":false,"temperature":0.7}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - Bearer <OPENROUTER_API_KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 29 Jun 2025 04:04:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Clerk-Auth-Message:
+      - Invalid JWT form. A JWT consists of three parts separated by dots. (reason=token-invalid,
+        token-carrier=header)
+      X-Clerk-Auth-Reason:
+      - token-invalid
+      X-Clerk-Auth-Status:
+      - signed-out
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+    body:
+      encoding: ASCII-8BIT
+      string: "\n         \n{\"id\":\"gen-1751169884-9UMTTOHBjnu40hPVmq0i\",\"provider\":\"Google\",\"model\":\"anthropic/claude-3.5-haiku\",\"object\":\"chat.completion\",\"created\":1751169884,\"choices\":[{\"logprobs\":null,\"finish_reason\":\"stop\",\"native_finish_reason\":\"stop\",\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"{\\n
+        \   \\\"result\\\": 8\\n}\",\"refusal\":null,\"reasoning\":null}}],\"usage\":{\"prompt_tokens\":27,\"completion_tokens\":13,\"total_tokens\":40}}"
+  recorded_at: Sun, 29 Jun 2025 04:04:44 GMT
+recorded_with: VCR 6.3.1

--- a/spec/ruby_llm/chat_options_spec.rb
+++ b/spec/ruby_llm/chat_options_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Chat do
+  include_context 'with configured RubyLLM'
+
+  describe 'with options' do
+    CHAT_MODELS.select { |model_info| [:deepseek, :openai, :openrouter, :ollama].include?(model_info[:provider])}.each do |model_info|
+      model = model_info[:model]
+      provider = model_info[:provider]
+      it "#{provider}/#{model} supports response_format option" do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+        chat = RubyLLM
+          .chat(model: model, provider: provider)
+          .with_options(response_format: {type: "json_object"})
+
+        response = chat.ask("What is the square root of 64? Answer with a JSON object with the key `result`.")
+
+        json_object = JSON.parse(response.content)
+        expect(json_object).to eq({"result" => 8})
+
+        expect(response.role).to eq(:assistant)
+        expect(response.input_tokens).to be_positive
+        expect(response.output_tokens).to be_positive
+      end
+    end
+
+    CHAT_MODELS.select { |model_info| [:anthropic].include?(model_info[:provider])}.each do |model_info|
+      model = model_info[:model]
+      provider = model_info[:provider]
+      it "#{provider}/#{model} supports service_tier option" do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+        chat = RubyLLM
+          .chat(model: model, provider: provider)
+          .with_options(service_tier: "standard_only")
+
+        response = chat.ask("What is the square root of 64? Answer with a JSON object with the key `result`.")
+
+        json_object = JSON.parse(response.content)
+        expect(json_object).to eq({"result" => 8})
+
+        expect(response.role).to eq(:assistant)
+        expect(response.input_tokens).to be_positive
+        expect(response.output_tokens).to be_positive
+      end
+    end
+
+    CHAT_MODELS.select { |model_info| [:gemini].include?(model_info[:provider])}.each do |model_info|
+      model = model_info[:model]
+      provider = model_info[:provider]
+      it "#{provider}/#{model} supports responseSchema option" do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+        chat = RubyLLM
+          .chat(model: model, provider: provider)
+          .with_options(generationConfig: {
+            responseMimeType: "application/json",
+            responseSchema: {
+              type: "OBJECT",
+              properties: { result: {type: "NUMBER"} }
+            }
+          })
+
+        response = chat.ask("What is the square root of 64? Answer with a JSON object with the key `result`.")
+
+        json_object = JSON.parse(response.content)
+        expect(json_object).to eq({"result" => 8})
+
+        expect(response.role).to eq(:assistant)
+        expect(response.input_tokens).to be_positive
+        expect(response.output_tokens).to be_positive
+      end
+    end
+
+    CHAT_MODELS.select { |model_info| [:bedrock].include?(model_info[:provider])}.each do |model_info|
+      model = model_info[:model]
+      provider = model_info[:provider]
+      it "#{provider}/#{model} supports top_k option" do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+        chat = RubyLLM
+          .chat(model: model, provider: provider)
+          .with_options(top_k: 5)
+
+        response = chat.ask("What is the square root of 64? Answer with a JSON object with the key `result`.")
+
+        json_object = JSON.parse(response.content)
+        expect(json_object).to eq({"result" => 8})
+
+        expect(response.role).to eq(:assistant)
+        expect(response.input_tokens).to be_positive
+        expect(response.output_tokens).to be_positive
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this does

Implements `with_options` with @crmne's suggestions from comment https://github.com/crmne/ruby_llm/pull/130#pullrequestreview-2914164578 and tested against all providers.

This allows users to set arbitrary options on the payload before it's sent to the provider's API endpoint. The render_payload takes precedence.

Demo:

```ruby
chat = RubyLLM
  .chat(model: "qwen3", provider: :ollama)
  .with_options(response_format: {type: "json_object"})
  .with_instructions("Answer with a JSON object with the key `result` and a numerical value.")
response = chat.ask("What is the square root of 64?")
response.content
=> "{\n  \"result\": 8\n}"
```

This is a power-user feature, and is specific to each provider (and model, to a lesser extent), so I did not update documentation.

For tests: different providers supported different options, so tests are divided by provider.

(Note that `deep_merge` is required for Gemini in particular because it relies on a top-level `generationConfig` object.)

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [X] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [X] This aligns with RubyLLM's focus on **LLM communication**
- [X] This isn't application-specific logic that belongs in user code
- [X] This benefits most users, not just my specific use case

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [X] I tested my changes thoroughly
- [ ] I updated documentation if needed
- [X] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [X] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

- #130
- #131
- #221 