### PR TITLE
Remove Tools reference from Messages in docs (rails.md)

### DIFF
--- a/docs/guides/rails.md
+++ b/docs/guides/rails.md
@@ -93,7 +93,6 @@ class CreateMessages < ActiveRecord::Migration[7.1]
       t.string :model_id
       t.integer :input_tokens
       t.integer :output_tokens
-      t.references :tool_call # Links tool result message to the initiating call
       t.timestamps
     end
   end


### PR DESCRIPTION
When I tried to run the Rails integration migrations as documented on [rubyllm.com](https://rubyllm.com/guides/rails), they fail (at least with Postgres backing) due to the `CreateMessages` migration referencing the Tools model, which at that point does not exist.

In `class CreateMessages`:
```rb
t.references :tool_call # Links tool result message to the initiating call
```

Does Messages need to reference Tools in that way? I noted that the `acts_as_message` concern has `has_many :tool_calls` and `belongs_to :parent_tool_call`, which suggests the column isn't needed on the Messages table, as presumably it uses the column on the Tools table to fulfill that relationship?

## What this does

Removes line in docs that suggests the Messages model needs a `t.references` to Tools.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [ ] I tested my changes thoroughly
- [x] I updated documentation if needed
- [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

None