### PR TITLE
Allow local providers to fetch model list

### DIFF
--- a/lib/ruby_llm/providers/ollama.rb
+++ b/lib/ruby_llm/providers/ollama.rb
@@ -7,6 +7,7 @@ module RubyLLM
       extend OpenAI
       extend Ollama::Chat
       extend Ollama::Media
+      extend Ollama::Models
 
       module_function
 

--- a/lib/ruby_llm/providers/ollama/models.rb
+++ b/lib/ruby_llm/providers/ollama/models.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    module Ollama
+      # Models methods of the Ollama API integration
+      module Models
+        module_function
+
+        def models_url
+          'models'
+        end
+
+        def parse_list_models_response(response, slug, _capabilities)
+          Array(response.body['data']).map do |model_data|
+            Model::Info.new(
+              id: model_data['id'],
+              name: model_data['id'],
+              provider: slug,
+              family: 'ollama',
+              created_at: model_data['created'] ? Time.at(model_data['created']) : nil,
+              modalities: {
+                input: %w[text image], # Ollama models don't advertise input modalities, so we assume text and image
+                output: ['text'] # Ollama models don't expose output modalities, so we assume text
+              },
+              capabilities: %w[streaming function_calling structured_output],
+              pricing: {}, # Ollama does not provide pricing details
+              metadata: {}
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this does

This prevents model capabilities inaccurate warning from happening while keeping local model registry check in place.

```ruby
# This outputs a warning, which can be silenced, but silencing it disables local model registry check
RubyLLM.chat(provider: :ollama, model: "llama3.2:latest").ask("hello?")
# W, [2025-07-23T21:22:09.067904 #50236]  WARN -- RubyLLM: Assuming model 'llama3.2:latest' exists for provider 'RubyLLM::Providers::Ollama'. Capabilities may not be accurately reflected.

# Fetching model list puts them into a local in-memory registry
RubyLLM.models.refresh!
RubyLLM.chat(provider: :ollama, model: "llama3.2:latest").ask("hello?")
# No warning
```

Basically an alternative to silencing `log_assume_model_exists`, which still validates the model's presence.

Includes model list fetching for Ollama. Since both GPUStack and Ollama can now fetch model lists running `RubyLLM.models.refresh!` is all that's needed to verify's model availability.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [X] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [X] This aligns with RubyLLM's focus on **LLM communication**
- [X] This isn't application-specific logic that belongs in user code
- [X] This benefits most users, not just my specific use case (mostly for local model users)

## Quality check

- [X] I ran `overcommit --install` and all hooks pass
- [X] I tested my changes thoroughly
- [ ] I updated documentation if needed (should I update Ollama and GPUStack manuals?)
- [X] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [X] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
