### PR TITLE
Improve `RubyLLM::Chat#with_params` (#265) by allowing to override default params

### DIFF
--- a/lib/ruby_llm/provider.rb
+++ b/lib/ruby_llm/provider.rb
@@ -14,7 +14,6 @@ module RubyLLM
         normalized_temperature = maybe_normalize_temperature(temperature, model)
 
         payload = Utils.deep_merge(
-          params,
           render_payload(
             messages,
             tools: tools,
@@ -22,8 +21,11 @@ module RubyLLM
             model: model,
             stream: block_given?,
             schema: schema
-          )
+          ),
+          params
         )
+
+        payload.compact!
 
         if block_given?
           stream_response connection, payload, &

--- a/lib/ruby_llm/utils.rb
+++ b/lib/ruby_llm/utils.rb
@@ -24,12 +24,12 @@ module RubyLLM
       end
     end
 
-    def deep_merge(params, payload)
-      params.merge(payload) do |_key, params_value, payload_value|
-        if params_value.is_a?(Hash) && payload_value.is_a?(Hash)
-          deep_merge(params_value, payload_value)
+    def deep_merge(hash1, hash2)
+      hash1.merge(hash2) do |_key, value1, value2|
+        if value1.is_a?(Hash) && value2.is_a?(Hash)
+          deep_merge(value1, value2)
         else
-          payload_value
+          value2
         end
       end
     end

--- a/spec/fixtures/vcr_cassettes/chat_with_params_anthropic_claude-3-5-haiku-20241022_can_override_max_tokens_param_with_a_custom_value.yml
+++ b/spec/fixtures/vcr_cassettes/chat_with_params_anthropic_claude-3-5-haiku-20241022_can_override_max_tokens_param_with_a_custom_value.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"model":"claude-3-5-haiku-20241022","messages":[{"role":"user","content":[{"type":"text","text":"Always
+        answer with \"Once upon a time\""}]}],"temperature":0.7,"stream":false,"max_tokens":2}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.4
+      X-Api-Key:
+      - "<ANTHROPIC_API_KEY>"
+      Anthropic-Version:
+      - '2023-06-01'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 28 Jul 2025 16:36:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Input-Tokens-Limit:
+      - '100000'
+      Anthropic-Ratelimit-Input-Tokens-Remaining:
+      - '100000'
+      Anthropic-Ratelimit-Input-Tokens-Reset:
+      - '2025-07-28T16:36:30Z'
+      Anthropic-Ratelimit-Output-Tokens-Limit:
+      - '20000'
+      Anthropic-Ratelimit-Output-Tokens-Remaining:
+      - '20000'
+      Anthropic-Ratelimit-Output-Tokens-Reset:
+      - '2025-07-28T16:36:30Z'
+      Anthropic-Ratelimit-Requests-Limit:
+      - '1000'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '999'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2025-07-28T16:36:30Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '120000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '120000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2025-07-28T16:36:30Z'
+      Request-Id:
+      - "<REQUEST_ID>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Anthropic-Organization-Id:
+      - "<ANTHROPIC_ORGANIZATION_ID>"
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Robots-Tag:
+      - none
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"msg_01RsFPoB8wheUAgoR2SQ6HkY","type":"message","role":"assistant","model":"claude-3-5-haiku-20241022","content":[{"type":"text","text":"Once
+        upon"}],"stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":16,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2,"service_tier":"standard"}}'
+  recorded_at: Mon, 28 Jul 2025 16:36:30 GMT
+recorded_with: VCR 6.3.1

--- a/spec/ruby_llm/chat_request_options_spec.rb
+++ b/spec/ruby_llm/chat_request_options_spec.rb
@@ -78,6 +78,21 @@ RSpec.describe RubyLLM::Chat do
         json_response = JSON.parse('{' + response.content) # rubocop:disable Style/StringConcatenation
         expect(json_response).to eq({ 'result' => 8 })
       end
+
+      it "#{provider}/#{model} can override max_tokens param with a custom value" do # rubocop:disable RSpec/ExampleLength
+        chat = RubyLLM
+               .chat(model: model, provider: provider)
+               .with_params(max_tokens: 2)
+
+        chat.add_message(
+          role: :user,
+          content: 'Always answer with "Once upon a time"'
+        )
+
+        response = chat.complete
+
+        expect(response.content).to eq('Once upon') # Only 2 tokens
+      end
     end
 
     # Providers [:openrouter, :bedrock] supports a {top_k: ...} param to remove low-probability next tokens.


### PR DESCRIPTION
## What this does

This PR slightly improves what #265 does by allowing the override of default parameters.

I just inverted the order of the `deep_merge` between payload and params, refactored the `Utils` method to make it more generic and added an Anthropic test.

This small PR solves many issues that we encountered:

 * `max_tokens` is mandatory in the Anthropic API, and this gem sets it as the maximum tokens allowed by the model, but sometimes we want to force a lower value.

 * We use this gem for Mistral by setting `openai_api_base` as `https://api.mistral.ai/v1` because it's almost compatible. The only issue we encountered was that Mistral doesn't support the `stream_options: { include_usage: true }` parameter that is always added to the request for OpenAI. Now we can just add `.with_params(stream_options: nil)` to make it compatible.

 * `payload.compact!` also clean the extra param when we want to use the default model temperature with `with_temperature(nil)`

My intuition is that it could help other people fix similar situations.

@compumike suggested this, but I feel that this PR is even simpler:

> ## Future proposal: fully general block passing
> It's possible that in addition to this #with_options, we may want the ability to pass in a block that allows modifying the payload after it's deep_merged but before it's actually sent. For example, this might look like:
> ```
> chat = RubyLLM
>   .chat(model: "gpt-4o-search-preview", provider: :openai)
>   .with_options(web_search_options: {search_context_size: "medium"}) do |payload|
>     payload.delete(:temperature)
>  end
> chat.ask(...)
> ```
> Not necessary in this case, since with_temperature(nil) works. But allows future customization for power users.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

Related to #265 
