### PR TITLE
Wire up on_tool_call when using acts_as_chat rails integration

### DIFF
--- a/lib/ruby_llm/active_record/acts_as.rb
+++ b/lib/ruby_llm/active_record/acts_as.rb
@@ -154,6 +154,11 @@ module RubyLLM
         self
       end
 
+      def on_tool_call(...)
+        to_llm.on_tool_call(...)
+        self
+      end
+
       def create_user_message(content, with: nil)
         message_record = messages.create!(role: :user, content: content)
         persist_content(message_record, with) if with.present?


### PR DESCRIPTION
## What this does

An `on_tool_call` callback was added in `1.4.0` via https://github.com/crmne/ruby_llm/pull/299, but it doens't work with a model using the rails integration via `acts_as_chat`.

This PR wires up the missing method so it works with the integration.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [ ] ~I ran `overcommit --install` and all hooks pass~
  - When I tried to commit the hooks generated a bunch of changes to `models.json` and `aliases.json` and broke a bunch of the specs, so I removed the hooks and ran specs and rubocop manually
- [x] I tested my changes thoroughly
- [x] I updated documentation if needed
  - No need
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
