### PR TITLE
Ensure specs run in defined order

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --require spec_helper
 --format documentation
 --color
+--order defined


### PR DESCRIPTION
## What this does

By default, RSpec runs the specs in their defined order. But if a developer has `--order random` set in their environment, such as in the thoughtbot dotfiles [here](https://github.com/thoughtbot/dotfiles/blob/main/rspec), then ruby_llm's specs will fail. Setting this in the repo's `.rspec` will take precedence.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
