### PR TITLE
Switch default image generation model to gpt-image-1

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,7 +74,7 @@ RubyLLM.configure do |config|
   # Used by RubyLLM.chat, RubyLLM.embed, RubyLLM.paint if no model is specified.
   config.default_model = 'gpt-4.1-nano'               # Default: 'gpt-4.1-nano'
   config.default_embedding_model = 'text-embedding-3-small'  # Default: 'text-embedding-3-small'
-  config.default_image_model = 'dall-e-3'            # Default: 'dall-e-3'
+  config.default_image_model = 'gpt-image-1'            # Default: 'gpt-image-1'
 
   # --- Connection Settings ---
   config.request_timeout = 120  # Request timeout in seconds (default: 120)
@@ -154,7 +154,7 @@ These settings determine which models are used by the top-level helper methods (
 
 *   `config.default_model`: Used by `RubyLLM.chat`. Default: `'gpt-4.1-nano'`.
 *   `config.default_embedding_model`: Used by `RubyLLM.embed`. Default: `'text-embedding-3-small'`.
-*   `config.default_image_model`: Used by `RubyLLM.paint`. Default: `'dall-e-3'`.
+*   `config.default_image_model`: Used by `RubyLLM.paint`. Default: `'gpt-image-1'`.
 
 Choose defaults that match your most common use case and provider availability.
 

--- a/docs/guides/image-generation.md
+++ b/docs/guides/image-generation.md
@@ -64,10 +64,10 @@ The `paint` method abstracts the differences between provider APIs.
 
 ## Choosing Models
 
-By default, RubyLLM uses the model specified in `config.default_image_model` (defaults to `dall-e-3`), but you can specify a different one.
+By default, RubyLLM uses the model specified in `config.default_image_model` (defaults to `gpt-image-1`), but you can specify a different one.
 
 ```ruby
-# Explicitly use DALL-E 3
+# Use DALL-E 3
 image_dalle = RubyLLM.paint(
   "Impressionist painting of a Parisian cafe",
   model: "dall-e-3"
@@ -92,7 +92,7 @@ You can configure the default model globally:
 
 ```ruby
 RubyLLM.configure do |config|
-  config.default_image_model = "dall-e-3" # Or another available image model ID
+  config.default_image_model = "gpt-image-1" # Or another available image model ID
 end
 ```
 

--- a/lib/ruby_llm/configuration.rb
+++ b/lib/ruby_llm/configuration.rb
@@ -57,7 +57,7 @@ module RubyLLM
       # Default models
       @default_model = 'gpt-4.1-nano'
       @default_embedding_model = 'text-embedding-3-small'
-      @default_image_model = 'dall-e-3'
+      @default_image_model = 'gpt-image-1'
 
       # Logging configuration
       @log_file = $stdout


### PR DESCRIPTION
## What this does

<!-- Clear description of what this PR does and why -->
Switch default image generation model to gpt-image-1

## Type of change

- [x] Breaking change
- [x] Documentation

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [x] Breaking change

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
Resolves #320 