### PR TITLE
Fix: remove `tool_choice: auto` param for open ai

### DIFF
--- a/lib/ruby_llm/providers/openai/chat.rb
+++ b/lib/ruby_llm/providers/openai/chat.rb
@@ -21,9 +21,7 @@ module RubyLLM
           # Only include temperature if it's not nil (some models don't accept it)
           payload[:temperature] = temperature unless temperature.nil?
 
-          if tools.any?
-            payload[:tools] = tools.map { |_, tool| tool_for(tool) }
-          end
+          payload[:tools] = tools.map { |_, tool| tool_for(tool) } if tools.any?
 
           if schema
             # Use strict mode from schema if specified, default to true


### PR DESCRIPTION
## What this does
Removes the `tool_choice: 'auto'` from Openai's `render_payload` which allows it to be overwritten with `with_params`.
Open [defaults to auto](https://platform.openai.com/docs/api-reference/chat/create#chat_create-tool_choice) when tools are present.
<!-- Clear description of what this PR does and why -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [x] I updated documentation if needed
- [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
Fixes #317 