### PR TITLE
Allow use new capabilities when use assume_exists

### DIFF
--- a/lib/ruby_llm/models.rb
+++ b/lib/ruby_llm/models.rb
@@ -66,7 +66,7 @@ module RubyLLM
             id: model_id,
             name: model_id.tr('-', ' ').capitalize,
             provider: provider_instance.slug,
-            capabilities: %w[function_calling streaming],
+            capabilities: provider_class.capabilities.capabilities_for(model_id),
             modalities: { input: %w[text image], output: %w[text] },
             metadata: { warning: 'Assuming model exists, capabilities may not be accurate' }
           )

--- a/spec/ruby_llm/chat_assume_model_exists_spec.rb
+++ b/spec/ruby_llm/chat_assume_model_exists_spec.rb
@@ -78,5 +78,15 @@ RSpec.describe RubyLLM::Chat do
       expect(chat.model.id).to eq(custom_model)
       expect(chat.model.provider).to eq(provider)
     end
+
+    it 'works with .with_schema method' do
+      chat = RubyLLM.chat(
+        model: 'gemini-pro',
+        provider: 'gemini',
+        assume_model_exists: true
+      )
+
+      expect(chat.model.capabilities).to include('structured_output')
+    end
   end
 end


### PR DESCRIPTION
## What this does

<!-- Clear description of what this PR does and why -->

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [ ] This isn't application-specific logic that belongs in user code
- [ ] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [ ] I tested my changes thoroughly
- [ ] I updated documentation if needed
- [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
