### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ RubyLLM.configure do |config|
   # ... see Configuration guide for all options ...
 end
 ```
-See the [Installation Guide](https://rubyllm.com/installation) for full details.
+See the [Installation Guide](https://rubyllm.com/getting-started/#installation) for full details.
 
 ## Rails Integration
 
@@ -149,7 +149,7 @@ See the [Rails Integration Guide](https://rubyllm.com/guides/rails) for details.
 
 Dive deeper with the official documentation:
 
--   [Installation](https://rubyllm.com/installation)
+-   [Installation](https://rubyllm.com/getting-started/#installation)
 -   [Configuration](https://rubyllm.com/configuration)
 -   **Guides:**
     -   [Getting Started](https://rubyllm.com/guides/getting-started)


### PR DESCRIPTION
Replaced broken installation link

## What this does

- The old link https://rubyllm.com/installation is not working anymore
- Replaced it with a working link https://rubyllm.com/getting-started/#installation

- Clicking on the old link gives the following error

<img width="1920" height="863" alt="Page-not-found-·-GitHub-Pages-08-15-2025_06_42_PM" src="https://github.com/user-attachments/assets/230cb480-1954-4f82-b43a-c0bb9f5b400c" />


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [ ] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [ ] I tested my changes thoroughly
- [ ] I updated documentation if needed
- [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
