### PR TITLE
Add support for customizing the model file path

### DIFF
--- a/lib/ruby_llm/configuration.rb
+++ b/lib/ruby_llm/configuration.rb
@@ -29,6 +29,8 @@ module RubyLLM
                   :gpustack_api_base,
                   :gpustack_api_key,
                   :mistral_api_key,
+                  # Model configuration
+                  :model_file_path,
                   # Default models
                   :default_model,
                   :default_embedding_model,
@@ -54,6 +56,8 @@ module RubyLLM
       @retry_backoff_factor = 2
       @retry_interval_randomness = 0.5
       @http_proxy = nil
+
+      @model_file_path = File.expand_path('models.json', __dir__)
 
       # Default models
       @default_model = 'gpt-4.1-nano'

--- a/lib/ruby_llm/models.rb
+++ b/lib/ruby_llm/models.rb
@@ -22,7 +22,7 @@ module RubyLLM
       end
 
       def models_file
-        File.expand_path('models.json', __dir__)
+        RubyLLM.config.model_file_path
       end
 
       def refresh!

--- a/spec/ruby_llm/models_spec.rb
+++ b/spec/ruby_llm/models_spec.rb
@@ -11,6 +11,22 @@ RSpec.describe RubyLLM::Models do
     described_class.instance_variable_set(:@instance, nil)
   end
 
+  describe 'models file' do
+    it 'uses the bundled model file by default' do
+      expect(described_class.models_file).to eq(
+        File.expand_path(File.join(__dir__, '..', '..', 'lib', 'ruby_llm', 'models.json'))
+      )
+    end
+
+    it 'supports customization' do
+      RubyLLM.config.model_file_path = File.join(Dir.tmpdir, 'foobar.json')
+
+      expect(described_class.models_file).to eq(
+        File.join(Dir.tmpdir, 'foobar.json')
+      )
+    end
+  end
+
   describe 'filtering and chaining' do
     it 'filters models by provider' do
       openai_models = RubyLLM.models.by_provider('openai')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -144,6 +144,8 @@ RSpec.shared_context 'with configured RubyLLM' do
       config.retry_interval = 1
       config.retry_backoff_factor = 3
       config.retry_interval_randomness = 0.5
+
+      config.model_file_path = File.expand_path(File.join(__dir__, '..', 'lib', 'ruby_llm', 'models.json'))
     end
   end
 end


### PR DESCRIPTION
## What this does
This PR allows users to configure where the model file path lives. This is important on ephemeral file systems where updates to the model file might not persist between app restarts (like Heroku).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [x] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
