### PR TITLE
Fix Gemini array parameter handling in tool declarations

### DIFF
--- a/lib/ruby_llm/providers/gemini/tools.rb
+++ b/lib/ruby_llm/providers/gemini/tools.rb
@@ -53,10 +53,15 @@ module RubyLLM
           {
             type: 'OBJECT',
             properties: parameters.transform_values do |param|
-              {
+              property = {
                 type: param_type_for_gemini(param.type),
                 description: param.description
               }.compact
+
+              # Add items field for array types
+              property[:items] = { type: 'STRING' } if param.type.to_s.downcase == 'array'
+
+              property
             end,
             required: parameters.select { |_, p| p.required }.keys.map(&:to_s)
           }

--- a/spec/ruby_llm/providers/gemini/tools_array_parameter_handling_spec.rb
+++ b/spec/ruby_llm/providers/gemini/tools_array_parameter_handling_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ruby_llm/tool'
+
+RSpec.describe RubyLLM::Providers::Gemini::Tools do
+  let(:provider_class) do
+    Class.new do
+      include RubyLLM::Providers::Gemini::Tools
+    end
+  end
+
+  let(:provider) { provider_class.new }
+
+  it 'properly formats tools with array parameters for Gemini API' do
+    # Define a tool with array parameter similar to the error case
+    tool_with_array = Class.new(RubyLLM::Tool) do
+      def self.name
+        'DataFetcher'
+      end
+
+      description 'Fetches data with specific fields'
+      param :fields, type: 'array', desc: 'List of fields to return', required: true
+
+      def execute(fields:)
+        { selected_fields: fields }
+      end
+    end
+
+    # Another tool with array parameter
+    another_tool = Class.new(RubyLLM::Tool) do
+      def self.name
+        'FilterTool'
+      end
+
+      description 'Filters data by criteria'
+      param :fields, type: 'array', desc: 'Fields to filter on', required: true
+      param :query, type: 'string', desc: 'Query string', required: false
+
+      def execute(fields:, query: nil)
+        { filtered_fields: fields, query: query }
+      end
+    end
+
+    tools = {
+      data_fetcher: tool_with_array.new,
+      filter: another_tool.new
+    }
+
+    result = provider.send(:format_tools, tools)
+
+    # Verify the structure matches what Gemini expects
+    expect(result).to be_an(Array)
+    expect(result.first).to have_key(:functionDeclarations)
+
+    function_decls = result.first[:functionDeclarations]
+    expect(function_decls).to be_an(Array)
+    expect(function_decls.size).to eq(2)
+
+    # Check first tool (data_fetcher)
+    first_tool = function_decls[0]
+    expect(first_tool[:name]).to eq('data_fetcher')
+    expect(first_tool[:description]).to eq('Fetches data with specific fields')
+    expect(first_tool[:parameters][:type]).to eq('OBJECT')
+
+    # Most important: verify the array parameter has the 'items' field
+    fields_param = first_tool[:parameters][:properties][:fields]
+    expect(fields_param).to eq({
+                                 type: 'ARRAY',
+                                 description: 'List of fields to return',
+                                 items: { type: 'STRING' }
+                               })
+
+    expect(first_tool[:parameters][:required]).to contain_exactly('fields')
+
+    # Check second tool (filter)
+    second_tool = function_decls[1]
+    expect(second_tool[:name]).to eq('filter')
+
+    # Verify array parameter in second tool also has 'items'
+    filter_fields_param = second_tool[:parameters][:properties][:fields]
+    expect(filter_fields_param).to include(
+      type: 'ARRAY',
+      items: { type: 'STRING' }
+    )
+
+    # Verify string parameter doesn't have items
+    query_param = second_tool[:parameters][:properties][:query]
+    expect(query_param).to eq({
+                                type: 'STRING',
+                                description: 'Query string'
+                              })
+    expect(query_param).not_to have_key(:items)
+
+    # Only required field should be in required array
+    expect(second_tool[:parameters][:required]).to contain_exactly('fields')
+  end
+
+  it 'handles tools without array parameters correctly' do
+    simple_tool = Class.new(RubyLLM::Tool) do
+      def self.name
+        'SimpleTool'
+      end
+
+      description 'A simple tool'
+      param :name, type: 'string', desc: 'Name parameter'
+      param :count, type: 'integer', desc: 'Count parameter'
+
+      def execute(name:, count:)
+        { name: name, count: count }
+      end
+    end
+
+    tools = { simple: simple_tool.new }
+    result = provider.send(:format_tools, tools)
+
+    function_decl = result.first[:functionDeclarations].first
+
+    # Verify non-array parameters don't have items field
+    name_param = function_decl[:parameters][:properties][:name]
+    expect(name_param).to eq({
+                               type: 'STRING',
+                               description: 'Name parameter'
+                             })
+    expect(name_param).not_to have_key(:items)
+
+    count_param = function_decl[:parameters][:properties][:count]
+    expect(count_param).to eq({
+                                type: 'NUMBER',
+                                description: 'Count parameter'
+                              })
+    expect(count_param).not_to have_key(:items)
+  end
+end

--- a/spec/ruby_llm/providers/gemini/tools_spec.rb
+++ b/spec/ruby_llm/providers/gemini/tools_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ruby_llm/tool'
+
+RSpec.describe RubyLLM::Providers::Gemini::Tools do
+  let(:dummy_class) do
+    Class.new do
+      include RubyLLM::Providers::Gemini::Tools
+    end
+  end
+
+  let(:instance) { dummy_class.new }
+
+  describe '#format_parameters' do
+    context 'with array type parameter' do
+      it 'includes items field for array parameters' do
+        parameters = {
+          fields: RubyLLM::Parameter.new('fields', type: 'array', desc: 'List of fields to return')
+        }
+
+        result = instance.send(:format_parameters, parameters)
+
+        expect(result[:type]).to eq('OBJECT')
+        expect(result[:properties][:fields]).to include(
+          type: 'ARRAY',
+          description: 'List of fields to return',
+          items: { type: 'STRING' }
+        )
+      end
+    end
+
+    context 'with mixed parameter types' do
+      it 'correctly formats all parameter types' do
+        parameters = {
+          name: RubyLLM::Parameter.new('name', type: 'string', desc: 'Name field'),
+          age: RubyLLM::Parameter.new('age', type: 'integer', desc: 'Age field'),
+          active: RubyLLM::Parameter.new('active', type: 'boolean', desc: 'Active status'),
+          tags: RubyLLM::Parameter.new('tags', type: 'array', desc: 'List of tags'),
+          metadata: RubyLLM::Parameter.new('metadata', type: 'object', desc: 'Additional metadata')
+        }
+
+        result = instance.send(:format_parameters, parameters)
+
+        expect(result[:type]).to eq('OBJECT')
+
+        # Check string parameter
+        expect(result[:properties][:name]).to eq(
+          type: 'STRING',
+          description: 'Name field'
+        )
+
+        # Check integer parameter
+        expect(result[:properties][:age]).to eq(
+          type: 'NUMBER',
+          description: 'Age field'
+        )
+
+        # Check boolean parameter
+        expect(result[:properties][:active]).to eq(
+          type: 'BOOLEAN',
+          description: 'Active status'
+        )
+
+        # Check array parameter with items field
+        expect(result[:properties][:tags]).to eq(
+          type: 'ARRAY',
+          description: 'List of tags',
+          items: { type: 'STRING' }
+        )
+
+        # Check object parameter
+        expect(result[:properties][:metadata]).to eq(
+          type: 'OBJECT',
+          description: 'Additional metadata'
+        )
+      end
+    end
+
+    context 'with required and optional parameters' do
+      it 'correctly identifies required parameters' do
+        parameters = {
+          required_field: RubyLLM::Parameter.new('required_field', type: 'string', desc: 'Required', required: true),
+          optional_field: RubyLLM::Parameter.new('optional_field', type: 'string', desc: 'Optional', required: false)
+        }
+
+        result = instance.send(:format_parameters, parameters)
+
+        expect(result[:required]).to contain_exactly('required_field')
+      end
+    end
+  end
+
+  describe '#format_tools' do
+    it 'formats tools with array parameters correctly' do
+      tool_class = Class.new(RubyLLM::Tool) do
+        def self.name
+          'ProcessFieldsTool'
+        end
+
+        description 'Process multiple fields'
+        param :fields, type: 'array', desc: 'Fields to process'
+
+        def execute(fields:)
+          "Processed #{fields.length} fields"
+        end
+      end
+
+      tools = { process_fields: tool_class.new }
+      result = instance.send(:format_tools, tools)
+
+      expect(result).to be_an(Array)
+      expect(result.first[:functionDeclarations]).to be_an(Array)
+
+      function_decl = result.first[:functionDeclarations].first
+      expect(function_decl[:name]).to eq('process_fields')
+      expect(function_decl[:parameters][:properties][:fields]).to include(
+        type: 'ARRAY',
+        items: { type: 'STRING' }
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fixes Gemini API errors when using tools with array-type parameters
- Adds required `items` field for array parameters in tool declarations
- Resolves errors like: `GenerateContentRequest.tools[0].function_declarations[2].parameters.properties[fields].items: missing field`

## Problem
The Gemini API requires an `items` field for array-type parameters in tool declarations to specify the type of array elements. Without this field, tools with array parameters fail with missing field errors.

## Solution
Modified the `format_parameters` method in `Gemini::Tools` module to automatically add `items: { type: 'STRING' }` for all array-type parameters when formatting tools for the Gemini provider.

## Changes
- Modified `lib/ruby_llm/providers/gemini/tools.rb` to add items field for array types
- Added comprehensive unit tests in `spec/ruby_llm/providers/gemini/tools_spec.rb`
- Added integration tests in `spec/ruby_llm/providers/gemini/tools_array_parameter_handling_spec.rb`

## Test Plan
- [x] All existing tests pass
- [x] New unit tests for array parameter formatting
- [x] Integration tests verify proper tool formatting with mixed parameter types
- [x] Rubocop linting passes
- [x] Verified fix matches the working monkey patch from production usage

This resolves issues when using tools with array parameters in Gemini models, enabling proper function calling with arrays.

🤖 Generated with [Claude Code](https://claude.ai/code)