### PR TITLE
Try parse JSON because openai stopped giving us response header of content type

### DIFF
--- a/lib/ruby_llm/providers/openai/chat.rb
+++ b/lib/ruby_llm/providers/openai/chat.rb
@@ -39,7 +39,7 @@ module RubyLLM
         end
 
         def parse_completion_response(response)
-          data = response.body
+          data = try_parse_json(response.body)
           return if data.empty?
 
           raise Error.new(response, data.dig('error', 'message')) if data.dig('error', 'message')


### PR DESCRIPTION
## What this does

Fix #359 

<!-- Clear description of what this PR does and why -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [ ] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
