### PR TITLE
Add missing code block ending in the docs

### DIFF
--- a/docs/_core_features/embeddings.md
+++ b/docs/_core_features/embeddings.md
@@ -138,6 +138,7 @@ puts embedding.vectors.first.length # => 1536
 
 # The model used
 puts embedding.model  # => "text-embedding-3-small"
+```
 
 ## Using Embedding Results
 


### PR DESCRIPTION
## What this does

In the docs, there is a missing code block ending, see [this](https://rubyllm.com/embeddings/#vector-properties). The PR adds it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
