### PR TITLE
Improve RSpec configuration

### DIFF
--- a/spec/ruby_llm/providers/anthropic/tools_spec.rb
+++ b/spec/ruby_llm/providers/anthropic/tools_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe RubyLLM::Providers::Anthropic::Tools do
 
   describe '.format_tool_call' do
     let(:msg) do
-      instance_double(Message,
+      instance_double(RubyLLM::Message,
                       content: 'Some content',
                       tool_calls: {
-                        'tool_123' => instance_double(ToolCall,
+                        'tool_123' => instance_double(RubyLLM::ToolCall,
                                                       id: 'tool_123',
                                                       name: 'test_tool',
                                                       arguments: { 'arg1' => 'value1' })
@@ -36,10 +36,10 @@ RSpec.describe RubyLLM::Providers::Anthropic::Tools do
 
     context 'when message has no content' do
       let(:msg) do
-        instance_double(Message,
+        instance_double(RubyLLM::Message,
                         content: nil,
                         tool_calls: {
-                          'tool_123' => instance_double(ToolCall,
+                          'tool_123' => instance_double(RubyLLM::ToolCall,
                                                         id: 'tool_123',
                                                         name: 'test_tool',
                                                         arguments: { 'arg1' => 'value1' })
@@ -65,10 +65,10 @@ RSpec.describe RubyLLM::Providers::Anthropic::Tools do
 
     context 'when message has empty content' do
       let(:msg) do
-        instance_double(Message,
+        instance_double(RubyLLM::Message,
                         content: '',
                         tool_calls: {
-                          'tool_123' => instance_double(ToolCall,
+                          'tool_123' => instance_double(RubyLLM::ToolCall,
                                                         id: 'tool_123',
                                                         name: 'test_tool',
                                                         arguments: { 'arg1' => 'value1' })

--- a/spec/support/rspec_configuration.rb
+++ b/spec/support/rspec_configuration.rb
@@ -17,4 +17,19 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  # TODO: Switch to `:random` spec order for surfacing order dependencies.
+  # Currently set to `:ordered` due to significantly slower execution with
+  # randomization and concerns about API calls (see crmne/ruby_llm#372).
+  config.order = :defined
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
Improve RSpec configuration

- Prefix doubled classes in `providers/anthropic/tools_spec.rb` with the
  `RubyLLM` module to avoid load order issues and conflicts with
  root-level `Message` and `ToolCall` definitions in ActiveRecord specs,
  ensuring clearer scoping and more reliable test execution.
- Explicitly set `config.order = :defined` in RSpec configuration.
  Although running specs in random order helps surface order
  dependencies, it significantly slows down the test suite for this
  project. Therefore, we retain ordered execution for faster spec runs.
- This explicit setting also overrides any randomization preferences
  that may be set in the project's top-level `.rspec` or inherited from
  other `.rspec` files, ensuring consistent test order regardless of
  external configuration.

Ref: #319


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

Related to #319
