### PR TITLE
Make overrides of #instance_variables method public

### DIFF
--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -163,6 +163,10 @@ module RubyLLM
       @messages.clear
     end
 
+    def instance_variables
+      super - %i[@connection @config]
+    end
+
     private
 
     def wrap_streaming_block(&block)
@@ -203,10 +207,6 @@ module RubyLLM
       tool = tools[tool_call.name.to_sym]
       args = tool_call.arguments
       tool.call(args)
-    end
-
-    def instance_variables
-      super - %i[@connection @config]
     end
   end
 end

--- a/lib/ruby_llm/connection.rb
+++ b/lib/ruby_llm/connection.rb
@@ -48,6 +48,10 @@ module RubyLLM
       end
     end
 
+    def instance_variables
+      super - %i[@config @connection]
+    end
+
     private
 
     def setup_timeout(faraday)
@@ -117,10 +121,6 @@ module RubyLLM
 
       raise ConfigurationError,
             "#{@provider.name} provider is not configured. Add this to your initialization:\n\n#{config_block}"
-    end
-
-    def instance_variables
-      super - %i[@config @connection]
     end
   end
 end


### PR DESCRIPTION
## What this does

This makes the overriden methods `#instance_variables` public for the Chat and Connection classes.

The purpose of this change is to make the `ls` command in IRB work. This command relies on the `#instance_variables` method to list the object's instance variables. For current Chat and Connection objects this fails and raises an error instead.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [ ] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

This change is orthogonal to LLM communication.

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [x] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
