### PR TITLE
Fix ToolsCalls generator

### DIFF
--- a/lib/generators/ruby_llm/install/templates/create_tool_calls_migration.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/create_tool_calls_migration.rb.tt
@@ -5,7 +5,11 @@ class Create<%= options[:tool_call_model_name].pluralize %> < ActiveRecord::Migr
       t.references :<%= options[:message_model_name].tableize.singularize %>, null: false, foreign_key: true
       t.string :tool_call_id, null: false
       t.string :name, null: false
-      t.<%= postgresql? ? 'jsonb' : 'json' %> :arguments, default: {}
+      <% if postgresql? %>
+      t.jsonb :arguments, default: {}
+      <% else %>
+      t.json :arguments, null: false
+      <% end %>
       t.timestamps
     end
 

--- a/lib/generators/ruby_llm/install/templates/tool_call_model.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/tool_call_model.rb.tt
@@ -1,3 +1,4 @@
 class <%= options[:tool_call_model_name] %> < ApplicationRecord
+  after_initialize { self.arguments ||= {} }
   <%= acts_as_tool_call_declaration %>
 end


### PR DESCRIPTION
## What this resolves
<img width="1216" height="554" alt="Screenshot 2025-08-30 at 10 24 45 AM" src="https://github.com/user-attachments/assets/31160fc6-484d-4db2-86dc-767feaadf450" />

Resolves how to generate the migration for the tools_calls table on Non-PosgreSQL databases.

<!-- Clear description of what this PR does and why -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [ ] This aligns with RubyLLM's focus on **LLM communication**
- [ ] This isn't application-specific logic that belongs in user code
- [ ] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
