### PR TITLE
Fix namespaced model table names in upgrade generator

### DIFF
--- a/lib/generators/ruby_llm/upgrade_to_v1_7/templates/migration.rb.tt
+++ b/lib/generators/ruby_llm/upgrade_to_v1_7/templates/migration.rb.tt
@@ -6,33 +6,33 @@ class MigrateToRubyLLMModelReferences < ActiveRecord::Migration<%= migration_ver
 
     # Then check for any models in existing data that aren't in models.json
     say_with_time "Checking for additional models in existing data" do
-      collect_and_create_models(chat_class, :<%= chat_model_name.tableize %>, model_class)
-      collect_and_create_models(message_class, :<%= message_model_name.tableize %>, model_class)
+      collect_and_create_models(chat_class, :<%= chat_table_name %>, model_class)
+      collect_and_create_models(message_class, :<%= message_table_name %>, model_class)
       model_class.count
     end
 
     # Migrate foreign keys
-    migrate_foreign_key(:<%= chat_model_name.tableize %>, chat_class, model_class, :<%= model_model_name.underscore %>)
-    migrate_foreign_key(:<%= message_model_name.tableize %>, message_class, model_class, :<%= model_model_name.underscore %>)
+    migrate_foreign_key(:<%= chat_table_name %>, chat_class, model_class, :<%= model_model_name.underscore %>)
+    migrate_foreign_key(:<%= message_table_name %>, message_class, model_class, :<%= model_model_name.underscore %>)
   end
 
   def down
     # Remove foreign key references
-    if column_exists?(:<%= message_model_name.tableize %>, :<%= model_model_name.underscore %>_id)
-      remove_reference :<%= message_model_name.tableize %>, :<%= model_model_name.underscore %>, foreign_key: true
+    if column_exists?(:<%= message_table_name %>, :<%= model_model_name.underscore %>_id)
+      remove_reference :<%= message_table_name %>, :<%= model_model_name.underscore %>, foreign_key: true
     end
 
-    if column_exists?(:<%= chat_model_name.tableize %>, :<%= model_model_name.underscore %>_id)
-      remove_reference :<%= chat_model_name.tableize %>, :<%= model_model_name.underscore %>, foreign_key: true
+    if column_exists?(:<%= chat_table_name %>, :<%= model_model_name.underscore %>_id)
+      remove_reference :<%= chat_table_name %>, :<%= model_model_name.underscore %>, foreign_key: true
     end
 
     # Restore original model_id string columns
-    if column_exists?(:<%= message_model_name.tableize %>, :model_id_string)
-      rename_column :<%= message_model_name.tableize %>, :model_id_string, :model_id
+    if column_exists?(:<%= message_table_name %>, :model_id_string)
+      rename_column :<%= message_table_name %>, :model_id_string, :model_id
     end
 
-    if column_exists?(:<%= chat_model_name.tableize %>, :model_id_string)
-      rename_column :<%= chat_model_name.tableize %>, :model_id_string, :model_id
+    if column_exists?(:<%= chat_table_name %>, :model_id_string)
+      rename_column :<%= chat_table_name %>, :model_id_string, :model_id
     end
   end
 


### PR DESCRIPTION
## Description

This PR fixes issue #397 where the upgrade generator produces invalid table names for namespaced models.

## Problem

When using custom model names with namespaces (like `Assistant::Chat`, `Assistant::Message`, etc.) and running the upgrade generator:

```bash
rails g ruby_llm:upgrade_to_v1_7 chat:Assistant::Chat message:Assistant::Message
```

The migration would generate invalid table names like `:assistant/chats` instead of `:assistant_chats`.

## Solution

The issue was that the generator was using `.tableize` which produces forward slashes for namespaced models. This has been fixed by using `.underscore.pluralize.tr('/', '_')` which properly converts namespaced model names to valid table names.

### Changes:
- Added `table_name_for` helper method that correctly handles namespaced models
- Added helper methods for each model type (`chat_table_name`, `message_table_name`, etc.)
- Updated migration template to use the new helper methods instead of `.tableize`

## Testing

Tested with namespaced models to confirm:
- `Assistant::Chat` → `assistant_chats` ✓
- `Assistant::Message` → `assistant_messages` ✓
- `Assistant::ToolCall` → `assistant_tool_calls` ✓
- `Assistant::Model` → `assistant_models` ✓

Regular models continue to work as expected:
- `Chat` → `chats` ✓
- `Message` → `messages` ✓

Fixes #397