### PR TITLE
fix: correct RubyLLM::Models.resolve method calls in migration

### DIFF
--- a/lib/generators/ruby_llm/upgrade_to_v1_7/templates/migration.rb.tt
+++ b/lib/generators/ruby_llm/upgrade_to_v1_7/templates/migration.rb.tt
@@ -71,7 +71,7 @@ class MigrateToRubyLLMModelReferences < ActiveRecord::Migration<%= migration_ver
     return if model_id.blank?
 
     begin
-      model_info, _provider = RubyLLM.models.resolve(model_id, provider: provider)
+      model_info, _provider = RubyLLM::Models.resolve(model_id, provider: provider)
 
       model_class.find_or_create_by!(
         model_id: model_info.id,


### PR DESCRIPTION
The migration was incorrectly calling resolve as an instance method (RubyLLM.models.resolve) when it's actually a class method.

## What this does

<!-- Clear description of what this PR does and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [ ] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [ ] This aligns with RubyLLM's focus on **LLM communication**
- [ ] This isn't application-specific logic that belongs in user code
- [ ] This benefits most users, not just my specific use case

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [ ] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [ ] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
