### PR TITLE
Models helps should return all supporting modalities

### DIFF
--- a/lib/ruby_llm/models.rb
+++ b/lib/ruby_llm/models.rb
@@ -194,15 +194,15 @@ module RubyLLM
     end
 
     def embedding_models
-      self.class.new(all.select { |m| m.type == 'embedding' })
+      self.class.new(all.select { |m| m.type == 'embedding' || m.modalities.output.include?('embeddings') })
     end
 
     def audio_models
-      self.class.new(all.select { |m| m.type == 'audio' })
+      self.class.new(all.select { |m| m.type == 'audio' || m.modalities.output.include?('audio') })
     end
 
     def image_models
-      self.class.new(all.select { |m| m.type == 'image' })
+      self.class.new(all.select { |m| m.type == 'image' || m.modalities.output.include?('image') })
     end
 
     def by_family(family)

--- a/spec/ruby_llm/models_spec.rb
+++ b/spec/ruby_llm/models_spec.rb
@@ -103,31 +103,47 @@ RSpec.describe RubyLLM::Models do
   end
 
   describe '#embedding_models' do
-    it 'filters to only embedding models' do
+    it 'filters to models that are embedding-capable' do
       embedding_models = RubyLLM.models.embedding_models
 
       expect(embedding_models).to be_a(described_class)
-      expect(embedding_models.all).to all(have_attributes(type: 'embedding'))
       expect(embedding_models.all).not_to be_empty
+
+      expect(embedding_models.all).to all(
+        satisfy('has type=embedding or output includes embeddings') { |m|
+          m.type == 'embedding' || Array(m.modalities&.output).include?('embeddings')
+        }
+      )
     end
   end
 
   describe '#audio_models' do
-    it 'filters to only audio models' do
+    it 'filters to models that are audio-capable' do
       audio_models = RubyLLM.models.audio_models
 
       expect(audio_models).to be_a(described_class)
-      expect(audio_models.all).to all(have_attributes(type: 'audio'))
+      expect(audio_models.all).not_to be_empty
+
+      expect(audio_models.all).to all(
+        satisfy('has type=audio or output includes audio') { |m|
+          m.type == 'audio' || Array(m.modalities&.output).include?('audio')
+        }
+      )
     end
   end
 
   describe '#image_models' do
-    it 'filters to only image models' do
+    it 'filters to models that are image-capable' do
       image_models = RubyLLM.models.image_models
 
       expect(image_models).to be_a(described_class)
-      expect(image_models.all).to all(have_attributes(type: 'image'))
       expect(image_models.all).not_to be_empty
+
+      expect(image_models.all).to all(
+        satisfy('has type=image or output includes image') { |m|
+          m.type == 'image' || Array(m.modalities&.output).include?('image')
+        }
+      )
     end
   end
 


### PR DESCRIPTION
image_models, audio_models, and embedding_models should all return models that output their modality

## What this does

<!-- Clear description of what this PR does and why -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
