### PR TITLE
Fix create_table migrations to prevent foreign key errors (#409)

### DIFF
--- a/lib/generators/ruby_llm/install/install_generator.rb
+++ b/lib/generators/ruby_llm/install/install_generator.rb
@@ -32,12 +32,12 @@ module RubyLLM
       migration_template 'create_chats_migration.rb.tt',
                          "db/migrate/create_#{chat_table_name}.rb"
 
-      # Then create messages table (must come before tool_calls due to foreign key)
+      # Then create messages table
       sleep 1 # Ensure different timestamp
       migration_template 'create_messages_migration.rb.tt',
                          "db/migrate/create_#{message_table_name}.rb"
 
-      # Then create tool_calls table (references messages)
+      # Then create tool_calls table
       sleep 1 # Ensure different timestamp
       migration_template 'create_tool_calls_migration.rb.tt',
                          "db/migrate/create_#{tool_call_table_name}.rb"
@@ -46,6 +46,12 @@ module RubyLLM
       sleep 1 # Ensure different timestamp
       migration_template 'create_models_migration.rb.tt',
                          "db/migrate/create_#{model_table_name}.rb"
+
+      # Add references to chats, tool_calls and messages.
+      sleep 1 # Ensure different timestamp
+      migration_template 'add_references_to_chats_tool_calls_and_messages_migration.rb.tt',
+                         'db/migrate/add_references_to_' \
+                         "#{chat_table_name}_#{tool_call_table_name}_and_#{message_table_name}.rb"
     end
 
     def create_model_files

--- a/lib/generators/ruby_llm/install/templates/add_references_to_chats_tool_calls_and_messages_migration.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/add_references_to_chats_tool_calls_and_messages_migration.rb.tt
@@ -1,0 +1,9 @@
+class AddReferencesTo<%= "#{chat_model_name.gsub('::', '').pluralize}#{tool_call_model_name.gsub('::', '').pluralize}And#{message_model_name.gsub('::', '').pluralize}" %> < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_reference :<%= chat_table_name %>, :<%= model_table_name.singularize %>, foreign_key: true
+    add_reference :<%= tool_call_table_name %>, :<%= message_table_name.singularize %>, null: false, foreign_key: true
+    add_reference :<%= message_table_name %>, :<%= chat_table_name.singularize %>, null: false, foreign_key: true
+    add_reference :<%= message_table_name %>, :<%= model_table_name.singularize %>, foreign_key: true
+    add_reference :<%= message_table_name %>, :<%= tool_call_table_name.singularize %>, foreign_key: true
+  end
+end

--- a/lib/generators/ruby_llm/install/templates/create_chats_migration.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/create_chats_migration.rb.tt
@@ -1,7 +1,6 @@
 class Create<%= chat_model_name.gsub('::', '').pluralize %> < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :<%= chat_table_name %> do |t|
-      t.references :<%= model_table_name.singularize %>, foreign_key: true
       t.timestamps
     end
   end

--- a/lib/generators/ruby_llm/install/templates/create_messages_migration.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/create_messages_migration.rb.tt
@@ -1,13 +1,10 @@
 class Create<%= message_model_name.gsub('::', '').pluralize %> < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :<%= message_table_name %> do |t|
-      t.references :<%= chat_table_name.singularize %>, null: false, foreign_key: true
       t.string :role, null: false
       t.text :content
-      t.references :<%= model_table_name.singularize %>, foreign_key: true
       t.integer :input_tokens
       t.integer :output_tokens
-      t.references :<%= tool_call_table_name.singularize %>, foreign_key: true
       t.timestamps
     end
 

--- a/lib/generators/ruby_llm/install/templates/create_tool_calls_migration.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/create_tool_calls_migration.rb.tt
@@ -2,7 +2,6 @@
 class Create<%= tool_call_model_name.gsub('::', '').pluralize %> < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :<%= tool_call_table_name %> do |t|
-      t.references :<%= message_table_name.singularize %>, null: false, foreign_key: true
       t.string :tool_call_id, null: false
       t.string :name, null: false
       t.<%= postgresql? ? 'jsonb' : 'json' %> :arguments, default: {}


### PR DESCRIPTION
## Description 
This PR fixes issue #409 where the rails generate ruby_llm:install generator creates migrations with foreign key references to tables that haven't been created yet, causing migration failures.

## Problem
When running the install generator on a fresh Rails application, the generated migrations contain t.references calls that try to create foreign key constraints to tables that are created in later migrations. This causes PostgreSQL (and other databases) to fail with "relation does not exist" errors because the referenced tables haven't been created yet.

## Solution
1. Removes the t.references lines from the initial table creation migrations
2. Creates a new migration that runs after all tables are created to add the foreign key references.

This can be tested with a brand new rails app by adding the gem from this branch:
`gem "ruby_llm", git: "https://github.com/matiasmoya/ruby_llm", branch: "409-fix-install-migrations"`

## What this does

- Remove t.reference calls from initial table creation migrations
- Add new migration generator template for adding references separately
- Update install generator to create tables first, then add references

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [x] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

Fixes #409 
