### PR TITLE
Fix: changing the order of migrations, as it is being referenced in later model

### DIFF
--- a/lib/generators/ruby_llm/install/install_generator.rb
+++ b/lib/generators/ruby_llm/install/install_generator.rb
@@ -28,7 +28,13 @@ module RubyLLM
 
     def create_migration_files
       # Create migrations with timestamps to ensure proper order
-      # First create chats table
+
+      # Create models table first since it is being referenced by other models
+      migration_template 'create_models_migration.rb.tt',
+                         "db/migrate/create_#{model_table_name}.rb"
+
+      # Create chats table
+      sleep 1 # Ensure different timestamp
       migration_template 'create_chats_migration.rb.tt',
                          "db/migrate/create_#{chat_table_name}.rb"
 
@@ -41,11 +47,6 @@ module RubyLLM
       sleep 1 # Ensure different timestamp
       migration_template 'create_tool_calls_migration.rb.tt',
                          "db/migrate/create_#{tool_call_table_name}.rb"
-
-      # Create models table
-      sleep 1 # Ensure different timestamp
-      migration_template 'create_models_migration.rb.tt',
-                         "db/migrate/create_#{model_table_name}.rb"
     end
 
     def create_model_files

--- a/spec/lib/generators/ruby_llm/install_generator_spec.rb
+++ b/spec/lib/generators/ruby_llm/install_generator_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe RubyLLM::InstallGenerator, type: :generator do
   describe 'migration templates' do
     let(:expected_migration_files) do
       [
+        'create_models_migration.rb.tt',
         'create_chats_migration.rb.tt',
         'create_messages_migration.rb.tt',
-        'create_tool_calls_migration.rb.tt',
-        'create_models_migration.rb.tt'
+        'create_tool_calls_migration.rb.tt'
       ]
     end
 
@@ -87,10 +87,10 @@ RSpec.describe RubyLLM::InstallGenerator, type: :generator do
   describe 'model templates' do
     let(:expected_model_files) do
       [
+        'model_model.rb.tt',
         'chat_model.rb.tt',
         'message_model.rb.tt',
-        'tool_call_model.rb.tt',
-        'model_model.rb.tt'
+        'tool_call_model.rb.tt'
       ]
     end
 
@@ -241,20 +241,20 @@ RSpec.describe RubyLLM::InstallGenerator, type: :generator do
       migration_section = generator_content[/def create_migration_files.*?\n    end/m]
 
       # Look for the table name references which are in the migration paths
+      models_position = migration_section.index('model_table_name')
       chats_position = migration_section.index('chat_table_name')
       messages_position = migration_section.index('message_table_name')
       tool_calls_position = migration_section.index('tool_call_table_name')
-      models_position = migration_section.index('model_table_name')
 
       expect(chats_position).not_to be_nil
       expect(messages_position).not_to be_nil
       expect(tool_calls_position).not_to be_nil
 
+      # Models migration should come first if present
+      expect(models_position).to be < chats_position if models_position
+
       expect(chats_position).to be < messages_position
       expect(messages_position).to be < tool_calls_position
-
-      # Models migration should come last if present
-      expect(models_position).to be > tool_calls_position if models_position
     end
 
     it 'has comments explaining the order' do


### PR DESCRIPTION
This PR fixes #409 issue. When running `rails generate ruby_llm:install` it creates model migration later but it is being referenced in other models which are generated before, it is causing the migration failures.

## Changes

Instead of creating the model migration later, this PR creates those migration before so that migration failures don't occur again.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues
#409 
<!-- Link issues: "Fixes #123" or "Related to #123" -->
