### PR TITLE
Display tool calls in message template

### DIFF
--- a/lib/generators/ruby_llm/chat_ui/templates/views/messages/_message.html.erb.tt
+++ b/lib/generators/ruby_llm/chat_ui/templates/views/messages/_message.html.erb.tt
@@ -4,6 +4,15 @@
     <%%= <%= message_model_name.underscore %>.role&.capitalize %>
   </div>
   <div style="white-space: pre-wrap;"><%%= <%= message_model_name.underscore %>.content %></div>
+  <%% if <%= message_model_name.underscore %>.tool_calls.any? %>
+    <div style="display: flex; flex-direction: column; gap: 3px; align-items: flex-start; font-family: monospace;">
+      <%% <%= message_model_name.underscore %>.tool_calls.each do |tool_call| %>
+        <div style="background: #eee; padding: 5px; border-radius: 4px;">
+          <%%= tool_call.name %>(<%%= tool_call.arguments.to_json %>)
+        </div>
+      <%% end %>
+    </div>
+  <%% end %>
   <div style="font-size: 0.85em; color: #666; margin-top: 5px;">
     <%%= <%= message_model_name.underscore %>.created_at&.strftime("%I:%M %p") %>
   </div>


### PR DESCRIPTION
## Summary
- Added visualization of tool calls in the chat UI message partial
- Tool calls are displayed with function name and arguments in JSON format
- Styled with monospace font and gray background for better readability

## Test plan
- [ ] Generate a chat UI with the updated template
- [ ] Verify tool calls are displayed correctly in messages
- [ ] Check that messages without tool calls render normally

🤖 Generated with [Claude Code](https://claude.ai/code)