### PR TITLE
Set adapter to be net_http instead of Faraday.default_adapter.

### DIFF
--- a/lib/ruby_llm/connection.rb
+++ b/lib/ruby_llm/connection.rb
@@ -85,7 +85,7 @@ module RubyLLM
     def setup_middleware(faraday)
       faraday.request :json
       faraday.response :json
-      faraday.adapter Faraday.default_adapter
+      faraday.adapter :net_http
       faraday.use :llm_errors, provider: @provider
     end
 


### PR DESCRIPTION
## What this does
It updates the Faraday middleware to specifically use the `:net_http` adapter instead of whatever the environment default is/was.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues
Fixes #428 
