### PR TITLE
Fix Openrouter Error Parser to Handle Detailed Error Messages

### DIFF
--- a/lib/ruby_llm/providers/openrouter.rb
+++ b/lib/ruby_llm/providers/openrouter.rb
@@ -16,6 +16,33 @@ module RubyLLM
         }
       end
 
+      def parse_error(response)
+        return if response.body.empty?
+
+        body = try_parse_json(response.body)
+        case body
+        when Hash
+          parse_error_part_message body
+        when Array
+          body.map do |part|
+            parse_error_part_message part
+          end.join('. ')
+        else
+          body
+        end
+      end
+
+      def parse_error_part_message(part)
+        message = part.dig('error', 'message')
+        raw = try_parse_json(part.dig('error', 'metadata', 'raw'))
+        return message unless raw.is_a?(Hash)
+
+        raw_message = raw.dig('error', 'message')
+        return [message, raw_message].join(' - ') if raw_message
+
+        message
+      end
+
       class << self
         def configuration_requirements
           %i[openrouter_api_key]


### PR DESCRIPTION
# Fix Openrouter Error Parser to Handle Detailed Error Messages

## Problem
Currently, when Openrouter returns detailed error information, the error parser only extracts the generic "Provider returned error" message, losing valuable context from the nested error details.

## Solution
Enhanced the Openrouter error parser to combine both the main error message and the detailed error message from metadata when available.

**Before:**

```
Error: Provider returned error
```

**After:**

```
Error: Provider returned error - Country, region, or territory not supported
```

## Example Error Response

```json
{
  "error": {
    "message": "Provider returned error",
    "code": 403,
    "metadata": {
      "raw": "{\"error\":{\"code\":\"unsupported_country_region_territory\",\"message\":\"Country, region, or territory not supported\",\"param\":null,\"type\":\"request_forbidden\"}}",
      "provider_name": "OpenAI"
    }
  },
  "user_id": "user_2"
}
```

## Benefits

- 🔍 Better debugging: Users get specific error details instead of generic messages
- 🌍 Regional issues: Clearer feedback for geographic restrictions
- 🛠️ Developer experience: More actionable error information

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## API Changes

-  No API changes