### PR TITLE
Correct helper reference in `UpgradeToV17Generator`

### DIFF
--- a/lib/generators/ruby_llm/upgrade_to_v1_7/upgrade_to_v1_7_generator.rb
+++ b/lib/generators/ruby_llm/upgrade_to_v1_7/upgrade_to_v1_7_generator.rb
@@ -9,7 +9,7 @@ module RubyLLM
     # Generator to upgrade existing RubyLLM apps to v1.7 with new Rails-like API
     class UpgradeToV17Generator < Rails::Generators::Base
       include Rails::Generators::Migration
-      include RubyLLM::GeneratorHelpers
+      include RubyLLM::Generators::GeneratorHelpers
 
       namespace 'ruby_llm:upgrade_to_v1_7'
       source_root File.expand_path('templates', __dir__)


### PR DESCRIPTION
## What this does

Corrects the `GeneratorHelpers` namespace, which was updated in 8823739d3dc49d07a894de91dd9a8ae8ebe2ad49, in the V1.7 upgrade generator. Corrects `uninitialized constant RubyLLM::GeneratorHelpers (NameError)`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [ ] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
