### PR TITLE
Fix explicit provider example

### DIFF
--- a/docs/_getting_started/overview.md
+++ b/docs/_getting_started/overview.md
@@ -148,7 +148,7 @@ chat = RubyLLM.chat(model: "{{ site.models.default_chat }}")  # Uses OpenAI
 chat = RubyLLM.chat(
   model: "{{ site.models.local_llama }}",
   provider: "ollama",
-  base_url: "http://localhost:11434"
+  context: RubyLLM.context { _1.ollama_api_base = "http://localhost:11434/v1" }
 )
 ```
 


### PR DESCRIPTION
## What this does

I was trying ruby_llm for the first time and wanted to try the ollama provider. I searched the documentation and found this snippet that set the ollama provider and the base url at the same time, but in the console it threw an error:

```ruby
unknown keyword: :base_url (ArgumentError)
```

After looking the `RubyLLM::Chat` class I found there is no `base_url` argument and i need to either run `RubyLLM.configure { ... }` of pass a context.

Also, I'm running the latest ollama (0.12.3), and `http://localhost:11434` isn't working for me. I have to append `/v1` for it to work. 

Perhaps there's a better way of doing this (correct me if I'm wrong!) but I wanted to fix the docs, and found this way of doing it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [ ] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [ ] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
