### PR TITLE
Handle Gemini maxOutputTokens attribute properly

### DIFF
--- a/lib/ruby_llm/providers/gemini.rb
+++ b/lib/ruby_llm/providers/gemini.rb
@@ -22,6 +22,14 @@ module RubyLLM
         }
       end
 
+      private
+
+      def parameter_mappings
+        {
+          max_tokens: %i[generationConfig maxOutputTokens]
+        }
+      end
+
       class << self
         def capabilities
           Gemini::Capabilities

--- a/spec/fixtures/vcr_cassettes/chat_with_params_gemini_gemini-2_5-flash_automatically_maps_max_tokens_to_maxoutputtokens.yml
+++ b/spec/fixtures/vcr_cassettes/chat_with_params_gemini_gemini-2_5-flash_automatically_maps_max_tokens_to_maxoutputtokens.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+    body:
+      encoding: UTF-8
+      string: '{"contents":[{"role":"user","parts":[{"text":"Say hello in 3 words."}]}],"generationConfig":{"maxOutputTokens":100}}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.4
+      X-Goog-Api-Key:
+      - "<GEMINI_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Wed, 01 Oct 2025 19:13:17 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Server-Timing:
+      - gfet4t7; dur=6012
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "candidates": [
+            {
+              "content": {
+                "parts": [
+                  {
+                    "text": "Well, hello there!"
+                  }
+                ],
+                "role": "model"
+              },
+              "finishReason": "STOP",
+              "index": 0
+            }
+          ],
+          "usageMetadata": {
+            "promptTokenCount": 8,
+            "candidatesTokenCount": 5,
+            "totalTokenCount": 555,
+            "promptTokensDetails": [
+              {
+                "modality": "TEXT",
+                "tokenCount": 8
+              }
+            ],
+            "thoughtsTokenCount": 542
+          },
+          "modelVersion": "gemini-2.5-flash",
+          "responseId": "TX3daKXSCOvnvdIP-63HUA"
+        }
+  recorded_at: Wed, 01 Oct 2025 19:13:17 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## What this does

The change introduces a way to handle generation params that might be different from a provider to another, in this specific PR there is also a fix for issue #386 related specifically to how Gemini handles max tokens.

This handles the issue with Gemini, but might be with other providers as well. I'm open to check the rest if the the maintainers are good with the idea.

<!-- Clear description of what this PR does and why -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [ ] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [x] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues
Fixes #386

<!-- Link issues: "Fixes #123" or "Related to #123" -->
