### PR TITLE
fix(#403): Don't specify default values on mysql json

### DIFF
--- a/lib/generators/ruby_llm/generator_helpers.rb
+++ b/lib/generators/ruby_llm/generator_helpers.rb
@@ -120,6 +120,12 @@ module RubyLLM
         false
       end
 
+      def mysql?
+        ::ActiveRecord::Base.connection.adapter_name.downcase.include?('mysql')
+      rescue StandardError
+        false
+      end
+
       def table_exists?(table_name)
         ::ActiveRecord::Base.connection.table_exists?(table_name)
       rescue StandardError

--- a/lib/generators/ruby_llm/install/templates/create_models_migration.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/create_models_migration.rb.tt
@@ -14,6 +14,11 @@ class Create<%= model_model_name.gsub('::', '').pluralize %> < ActiveRecord::Mig
       t.jsonb :capabilities, default: []
       t.jsonb :pricing, default: {}
       t.jsonb :metadata, default: {}
+<% elsif mysql? %>
+      t.json :modalities
+      t.json :capabilities
+      t.json :pricing
+      t.json :metadata
 <% else %>
       t.json :modalities, default: {}
       t.json :capabilities, default: []

--- a/lib/generators/ruby_llm/install/templates/create_tool_calls_migration.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/create_tool_calls_migration.rb.tt
@@ -4,7 +4,13 @@ class Create<%= tool_call_model_name.gsub('::', '').pluralize %> < ActiveRecord:
     create_table :<%= tool_call_table_name %> do |t|
       t.string :tool_call_id, null: false
       t.string :name, null: false
-      t.<%= postgresql? ? 'jsonb' : 'json' %> :arguments, default: {}
+<% if postgresql? %>
+      t.jsonb :arguments, default: {}
+<% elsif mysql? %>
+      t.json :arguments
+<% else %>
+      t.json :arguments, default: {}
+<% end %>
       t.timestamps
     end
 


### PR DESCRIPTION
## What this does

Add logic branches for MySQL to skip the defaults.

## Type of change

- [x] Bug fix

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [ ] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

Fixes #403 

