### PR TITLE
Use apply instead of fetch_access_token for GAuth on vertex AI

### DIFF
--- a/lib/ruby_llm/providers/vertexai.rb
+++ b/lib/ruby_llm/providers/vertexai.rb
@@ -21,7 +21,7 @@ module RubyLLM
 
       def headers
         if defined?(VCR) && !VCR.current_cassette.recording?
-          {'Authorization' => "Bearer test-token"}
+          { 'Authorization' => 'Bearer test-token' }
         else
           initialize_authorizer unless @authorizer
           @authorizer.apply({})
@@ -47,7 +47,8 @@ module RubyLLM
           ]
         )
       rescue LoadError
-        raise Error, 'The googleauth gem ~> 1.15 is required for Vertex AI. Please add it to your Gemfile: gem "googleauth"'
+        raise Error,
+              'The googleauth gem ~> 1.15 is required for Vertex AI. Please add it to your Gemfile: gem "googleauth"'
       end
     end
   end


### PR DESCRIPTION
## What this does

<!-- Clear description of what this PR does and why -->

## Type of change

- [x ] Bug fix

## Scope check

- [x ] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x ] This aligns with RubyLLM's focus on **LLM communication**
- [ x] This isn't application-specific logic that belongs in user code
- [ x] This benefits most users, not just my specific use case

## Quality check

- [x ] I ran `overcommit --install` and all hooks pass
- [ ] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [ ] All tests pass: `bundle exec rspec`
- [x ] I updated documentation if needed
- [x ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [x ] Changed method signatures
- [x ] No API changes

## Related issues

Fixes #484 
