### PR TITLE
Fix temperature normalization for gpt-5 search models

### DIFF
--- a/lib/ruby_llm/providers/openai/capabilities.rb
+++ b/lib/ruby_llm/providers/openai/capabilities.rb
@@ -224,12 +224,12 @@ module RubyLLM
         end
 
         def self.normalize_temperature(temperature, model_id)
-          if model_id.match?(/^(o\d|gpt-5)/)
-            RubyLLM.logger.debug "Model #{model_id} requires temperature=1.0, ignoring provided value"
-            1.0
-          elsif model_id.match?(/-search/)
+          if model_id.match?(/-search/)
             RubyLLM.logger.debug "Model #{model_id} does not accept temperature parameter, removing"
             nil
+          elsif model_id.match?(/^(o\d|gpt-5)/)
+            RubyLLM.logger.debug "Model #{model_id} requires temperature=1.0, ignoring provided value"
+            1.0
           else
             temperature
           end

--- a/spec/ruby_llm/providers/open_ai/capabilities_spec.rb
+++ b/spec/ruby_llm/providers/open_ai/capabilities_spec.rb
@@ -10,8 +10,14 @@ RSpec.describe RubyLLM::Providers::OpenAI::Capabilities do
       end
     end
 
+    it 'forces temperature to 1.0 for GPT-5 models' do
+      %w[gpt-5 gpt-5-mini gpt-5-nano].each do |model|
+        expect(described_class.normalize_temperature(0.7, model)).to eq(1.0)
+      end
+    end
+
     it 'returns nil for search preview models' do
-      %w[gpt-4o-search-preview gpt-4o-mini-search-preview].each do |model|
+      %w[gpt-4o-search-preview gpt-4o-mini-search-preview gpt-5-search-api].each do |model|
         expect(described_class.normalize_temperature(0.7, model)).to be_nil
       end
     end


### PR DESCRIPTION
Models like gpt-5-search-api were incorrectly matching the gpt-5 pattern and getting temperature=1.0, when they should match the -search pattern and get nil.

Reordered conditions to check for -search models first, ensuring the more specific pattern takes precedence.

## What this does

Fixes a bug in `normalize_temperature` where the condition order caused search models in the GPT-5 family (e.g., `gpt-5-search-api`) to incorrectly receive `temperature=1.0` instead of `nil`. 

The fix reorders the pattern matching so the more specific `-search` check happens before the broader `gpt-5` check, ensuring search models don't accept the temperature parameter as required by the OpenAI API.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and ⚠️ some hooks failed, but in files unrelated to the fix.
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

