### PR TITLE
Add Zeitwerk eager loading check to CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -68,6 +68,9 @@ jobs:
     - name: Check code format
       run: bundle exec rubocop
 
+    - name: Check Zeitwerk eager loading
+      run: bundle exec ruby -e "require 'ruby_llm'; Zeitwerk::Loader.eager_load_all"
+
     - name: Run tests
       if: matrix.ruby-version != '3.4' || matrix.rails-version != 'rails-8.0'
       run: bundle exec appraisal ${{ matrix.rails-version }} rspec --tag '~generator'


### PR DESCRIPTION
## Summary

Adds Zeitwerk eager loading validation to CI to catch autoloading issues before release.

## Problem

Lack of CI check for catching eager loading issues. Recent example: ActiveRecord dependency bug (PR #504) would have been caught by this check.

## Solution

Add `Zeitwerk::Loader.eager_load_all` check after linter step:

```ruby
bundle exec ruby -e "require 'ruby_llm'; Zeitwerk::Loader.eager_load_all"
```

**Placement**: After linter, before tests
- Structural validation happens together  
- Fast fail (~2s) before expensive test matrix

## Blocked

**This PR depends on #504** (ActiveRecord dependency fix).

Without #504, the eager loading check fails with:
```
NameError: uninitialized constant RubyLLM::ActiveRecord::ActsAs::ActiveSupport
```

After #504 is merged: ✅ Passes

## Benefits

- Catches inflector issues
- Catches constant definition issues  
- Catches missing conditional checks
- Fast fail (~2s check)
- Prevents production crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)