### PR TITLE
Enable retry for POST requests in streaming error handling

### DIFF
--- a/lib/ruby_llm/connection.rb
+++ b/lib/ruby_llm/connection.rb
@@ -77,7 +77,8 @@ module RubyLLM
         interval_randomness: @config.retry_interval_randomness,
         backoff_factor: @config.retry_backoff_factor,
         exceptions: retry_exceptions,
-        retry_statuses: [429, 500, 502, 503, 504, 529]
+        retry_statuses: [429, 500, 502, 503, 504, 529],
+        methods: %i[delete get head options patch post put]
       }
     end
 

--- a/spec/fixtures/vcr_cassettes/chat_error_handling_with_vertexai_gemini-2_5-flash_faraday_version_1_retries_the_request.yml
+++ b/spec/fixtures/vcr_cassettes/chat_error_handling_with_vertexai_gemini-2_5-flash_faraday_version_1_retries_the_request.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/oauth2/v4/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJsdWlnaS1zZXJ2ZXJsZXNzQGFjaG1lZC1rYy5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsImF1ZCI6Imh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL29hdXRoMi92NC90b2tlbiIsImV4cCI6MTc2NDYwNjE4MywiaWF0IjoxNzY0NjA2MDYzLCJzY29wZSI6Imh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL2F1dGgvY2xvdWQtcGxhdGZvcm0gaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9nZW5lcmF0aXZlLWxhbmd1YWdlLnJldHJpZXZlciJ9.FEAjh0sb7Dbyk-d8cEC1BBnITXID3zRpiMMgz2u7Fk3Gd_E0PAPbgPGGeRqQ6bWnxx2FvIQ1CePPbyDKaCue6EKcNshraXeSOpC3LpZ9m5chLQvfs2sc_JlI0_KzySkdM9bS09q3ceXYJkgWjFV7Fl_wodC5x8CSxnZ2HiFLoc_1pVug0TlNsqoKaiHrJ8T1K4fp72jjcGWB8McfLQkMPHOlFt8JaiB5cYDf_zM4swPcQZ76-qA64zJAx8WK3c-zE4ZxqRtWvIFx_4dYt4_VHalQ0BRTNZ0KeKT45gzbidD9d1TCpaXRe1fvR6GMVmKPBlaq_yrIhi3whM6lYMwgpQ
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 01 Dec 2025 16:22:03 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"<GOOGLE_ACCESS_TOKEN>","expires_in":3599,"token_type":"Bearer"}'
+  recorded_at: Mon, 01 Dec 2025 16:22:03 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/chat_error_handling_with_vertexai_gemini-2_5-flash_faraday_version_2_retries_the_request.yml
+++ b/spec/fixtures/vcr_cassettes/chat_error_handling_with_vertexai_gemini-2_5-flash_faraday_version_2_retries_the_request.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/oauth2/v4/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJsdWlnaS1zZXJ2ZXJsZXNzQGFjaG1lZC1rYy5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsImF1ZCI6Imh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL29hdXRoMi92NC90b2tlbiIsImV4cCI6MTc2NDYwNjE4MywiaWF0IjoxNzY0NjA2MDYzLCJzY29wZSI6Imh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL2F1dGgvY2xvdWQtcGxhdGZvcm0gaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9nZW5lcmF0aXZlLWxhbmd1YWdlLnJldHJpZXZlciJ9.FEAjh0sb7Dbyk-d8cEC1BBnITXID3zRpiMMgz2u7Fk3Gd_E0PAPbgPGGeRqQ6bWnxx2FvIQ1CePPbyDKaCue6EKcNshraXeSOpC3LpZ9m5chLQvfs2sc_JlI0_KzySkdM9bS09q3ceXYJkgWjFV7Fl_wodC5x8CSxnZ2HiFLoc_1pVug0TlNsqoKaiHrJ8T1K4fp72jjcGWB8McfLQkMPHOlFt8JaiB5cYDf_zM4swPcQZ76-qA64zJAx8WK3c-zE4ZxqRtWvIFx_4dYt4_VHalQ0BRTNZ0KeKT45gzbidD9d1TCpaXRe1fvR6GMVmKPBlaq_yrIhi3whM6lYMwgpQ
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 01 Dec 2025 16:22:04 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"<GOOGLE_ACCESS_TOKEN>","expires_in":3599,"token_type":"Bearer"}'
+  recorded_at: Mon, 01 Dec 2025 16:22:04 GMT
+recorded_with: VCR 6.3.1

--- a/spec/ruby_llm/chat_error_spec.rb
+++ b/spec/ruby_llm/chat_error_spec.rb
@@ -29,6 +29,12 @@ end
 RSpec.describe RubyLLM::Chat do
   include_context 'with configured RubyLLM'
 
+  before do
+    RubyLLM.configure do |config|
+      config.max_retries = 0
+    end
+  end
+
   describe 'error handling' do
     CHAT_MODELS.each do |model_info|
       model = model_info[:model]

--- a/spec/ruby_llm/chat_streaming_spec.rb
+++ b/spec/ruby_llm/chat_streaming_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe RubyLLM::Chat do
               end
             end.to raise_error(expected_error_for(provider))
           end
+
+          it 'retries the request' do
+            stub_error_response(provider, :chunk)
+
+            expect do
+              chat.ask('Count from 1 to 3') do |chunk|
+                chunks << chunk
+              end
+            end.to raise_error(expected_error_for(provider))
+
+            expect(WebMock).to have_requested(:post, expected_url_for(provider)).times(3)
+          end
         end
 
         describe 'Faraday version 2' do # rubocop:disable RSpec/NestedGroups
@@ -123,6 +135,18 @@ RSpec.describe RubyLLM::Chat do
                 chunks << chunk
               end
             end.to raise_error(expected_error_for(provider))
+          end
+
+          it 'retries the request' do
+            stub_error_response(provider, :chunk)
+
+            expect do
+              chat.ask('Count from 1 to 3') do |chunk|
+                chunks << chunk
+              end
+            end.to raise_error(expected_error_for(provider))
+
+            expect(WebMock).to have_requested(:post, expected_url_for(provider)).times(3)
           end
         end
       end

--- a/spec/support/rubyllm_configuration.rb
+++ b/spec/support/rubyllm_configuration.rb
@@ -28,10 +28,10 @@ RSpec.shared_context 'with configured RubyLLM' do
       config.vertexai_location = ENV.fetch('GOOGLE_CLOUD_LOCATION', 'us-central1')
 
       config.request_timeout = 240
-      config.max_retries = 10
-      config.retry_interval = 1
-      config.retry_backoff_factor = 3
-      config.retry_interval_randomness = 0.5
+      config.max_retries = 2
+      config.retry_interval = 0.01
+      config.retry_backoff_factor = 0.1
+      config.retry_interval_randomness = 0.01
 
       config.model_registry_class = 'Model'
     end

--- a/spec/support/streaming_error_helpers.rb
+++ b/spec/support/streaming_error_helpers.rb
@@ -154,6 +154,10 @@ module StreamingErrorHelpers
     ERROR_HANDLING_CONFIGS[provider][:expected_error]
   end
 
+  def expected_url_for(provider)
+    ERROR_HANDLING_CONFIGS[provider][:url]
+  end
+
   def stub_error_response(provider, type)
     config = ERROR_HANDLING_CONFIGS[provider]
     return unless config


### PR DESCRIPTION
## What this does

- Add POST method to Faraday retry configuration (not retried by default)
- Add tests verifying retry behavior for both Faraday 1.x and 2.x code paths
- Add `expected_url_for` helper for URL assertions in error tests
- Reduce retry intervals in test configuration for faster test execution

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

Fixes #417
