### PR TITLE
Add structured output support for Anthropic provider

### DIFF
--- a/lib/ruby_llm/providers/anthropic.rb
+++ b/lib/ruby_llm/providers/anthropic.rb
@@ -11,6 +11,8 @@ module RubyLLM
       include Anthropic::Streaming
       include Anthropic::Tools
 
+      STRUCTURED_OUTPUTS_BETA = 'structured-outputs-2025-11-13'
+
       def api_base
         'https://api.anthropic.com'
       end
@@ -20,6 +22,23 @@ module RubyLLM
           'x-api-key' => @config.anthropic_api_key,
           'anthropic-version' => '2023-06-01'
         }
+      end
+
+      def complete(messages, tools:, temperature:, model:, params: {}, headers: {}, schema: nil, &block) # rubocop:disable Metrics/ParameterLists
+        headers = add_structured_output_beta_header(headers) if schema
+        super
+      end
+
+      private
+
+      def add_structured_output_beta_header(headers)
+        existing_beta = headers['anthropic-beta']
+        new_beta = if existing_beta
+                     "#{existing_beta},#{STRUCTURED_OUTPUTS_BETA}"
+                   else
+                     STRUCTURED_OUTPUTS_BETA
+                   end
+        headers.merge('anthropic-beta' => new_beta)
       end
 
       class << self

--- a/lib/ruby_llm/providers/anthropic/capabilities.rb
+++ b/lib/ruby_llm/providers/anthropic/capabilities.rb
@@ -31,11 +31,25 @@ module RubyLLM
         end
 
         def supports_functions?(model_id)
-          model_id.match?(/claude-3/)
+          claude3_or_newer?(model_id)
         end
 
         def supports_json_mode?(model_id)
-          model_id.match?(/claude-3/)
+          claude3_or_newer?(model_id)
+        end
+
+        def supports_structured_output?(model_id)
+          # Structured outputs supported on Claude 4+ (Sonnet 4.5, Opus 4.1, etc.)
+          # https://docs.anthropic.com/en/docs/build-with-claude/structured-outputs
+          claude4_or_newer?(model_id)
+        end
+
+        def claude3_or_newer?(model_id)
+          model_id.match?(/claude-[34]|claude-(sonnet|opus|haiku)-[4-9]/)
+        end
+
+        def claude4_or_newer?(model_id)
+          model_id.match?(/claude-[4-9]|claude-(sonnet|opus|haiku)-[4-9]/)
         end
 
         def supports_extended_thinking?(model_id)
@@ -92,12 +106,13 @@ module RubyLLM
         def capabilities_for(model_id)
           capabilities = ['streaming']
 
-          if model_id.match?(/claude-3/)
+          if claude3_or_newer?(model_id)
             capabilities << 'function_calling'
             capabilities << 'batch'
           end
 
-          capabilities << 'reasoning' if model_id.match?(/claude-3-7|-4/)
+          capabilities << 'structured_output' if supports_structured_output?(model_id)
+          capabilities << 'reasoning' if model_id.match?(/claude-3-7|claude-[4-9]|claude-(sonnet|opus)-[4-9]/)
           capabilities << 'citations' if model_id.match?(/claude-3\.5|claude-3-7/)
           capabilities
         end


### PR DESCRIPTION
## Summary
- Implements structured outputs using Anthropic's `structured-outputs-2025-11-13` beta API
- Adds structured output capability detection for Claude 4+ models
- Includes comprehensive test coverage for the new functionality

## Changes
- **Anthropic Provider**: Added `complete` method override to inject the structured-outputs beta header when schema is provided
- **Capabilities**: Added `supports_structured_output?` method to detect Claude 4+ models that support structured outputs
- **Chat**: Implemented `output_format` parameter with `json_schema` type in payload rendering
- **Tests**: Added specs for beta header handling and output_format payload generation
- **Refactoring**: Extracted `claude3_or_newer?` and `claude4_or_newer?` helper methods for cleaner version detection

## Test plan
- [x] Added unit tests for beta header handling
- [x] Added unit tests for output_format payload generation
- [x] Verified structured output capability detection for Claude 4+ models
- [ ] Manual testing with actual Anthropic API (recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)