### PR TITLE
Add with_messages for scoping chat messages

### DIFF
--- a/lib/ruby_llm/active_record/acts_as_legacy.rb
+++ b/lib/ruby_llm/active_record/acts_as_legacy.rb
@@ -160,6 +160,11 @@ module RubyLLM
         self
       end
 
+      def with_messages(...)
+        to_llm.with_messages(...)
+        self
+      end
+
       def on_new_message(&block)
         to_llm
 

--- a/lib/ruby_llm/active_record/chat_methods.rb
+++ b/lib/ruby_llm/active_record/chat_methods.rb
@@ -154,6 +154,11 @@ module RubyLLM
         self
       end
 
+      def with_messages(...)
+        to_llm.with_messages(...)
+        self
+      end
+
       def on_new_message(&block)
         to_llm
 

--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -18,6 +18,7 @@ module RubyLLM
       with_model(model_id, provider: provider, assume_exists: assume_model_exists)
       @temperature = nil
       @messages = []
+      @messages_scope = nil
       @tools = {}
       @tool_prefs = { choice: nil, calls: nil }
       @params = {}
@@ -112,6 +113,16 @@ module RubyLLM
       self
     end
 
+    def with_messages(&block)
+      if block.nil?
+        @messages_scope = nil
+        return self
+      end
+
+      @messages_scope = block
+      self
+    end
+
     def on_new_message(&block)
       @on[:new_message] = block
       self
@@ -138,7 +149,7 @@ module RubyLLM
 
     def complete(&) # rubocop:disable Metrics/PerceivedComplexity
       response = @provider.complete(
-        messages,
+        scoped_messages,
         tools: @tools,
         tool_prefs: @tool_prefs,
         temperature: @temperature,
@@ -219,6 +230,10 @@ module RubyLLM
     def sanitize_schema_name(name)
       sanitized = name.to_s.gsub(/[^a-zA-Z0-9_-]/, '_')
       sanitized.empty? ? 'response' : sanitized
+    end
+
+    def scoped_messages
+       @messages_scope.present? ? @messages_scope.call(messages) : messages
     end
 
     def wrap_streaming_block(&block)

--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -233,7 +233,7 @@ module RubyLLM
     end
 
     def scoped_messages
-       @messages_scope.present? ? @messages_scope.call(messages) : messages
+       @messages_scope ? @messages_scope.call(messages) : messages
     end
 
     def wrap_streaming_block(&block)

--- a/spec/ruby_llm/chat_messages_scope_spec.rb
+++ b/spec/ruby_llm/chat_messages_scope_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Chat do
+  include_context 'with configured RubyLLM'
+
+  describe '#with_messages' do
+    it 'uses all messages by default when no scope is configured' do
+      chat = RubyLLM.chat
+      provider = chat.instance_variable_get(:@provider)
+
+      allow(provider).to receive(:complete).and_return(
+        RubyLLM::Message.new(role: :assistant, content: 'Test response')
+      )
+
+      chat.add_message(role: :user, content: 'one')
+      chat.add_message(role: :assistant, content: 'two')
+
+      chat.complete
+
+      expect(provider).to have_received(:complete).with(
+        chat.messages,
+        hash_including(
+          tools: chat.tools,
+          temperature: anything,
+          model: chat.model,
+          params: chat.params,
+          headers: chat.headers,
+          schema: chat.schema
+        )
+      )
+    end
+
+    it 'applies a callable scope to the messages passed to the provider' do
+      chat = RubyLLM.chat
+      provider = chat.instance_variable_get(:@provider)
+
+      allow(provider).to receive(:complete).and_return(
+        RubyLLM::Message.new(role: :assistant, content: 'Scoped response')
+      )
+
+      first = chat.add_message(role: :user, content: 'first')
+      second = chat.add_message(role: :assistant, content: 'second')
+
+      chat.with_messages { |msgs| [msgs.last] }
+
+      chat.complete
+
+      expect(provider).to have_received(:complete) do |messages_arg, **_options|
+        expect(messages_arg).to eq([second])
+        expect(messages_arg).not_to include(first)
+      end
+    end
+
+    it 'can clear the scope by calling without a block' do
+      chat = RubyLLM.chat
+      provider = chat.instance_variable_get(:@provider)
+
+      allow(provider).to receive(:complete).and_return(
+        RubyLLM::Message.new(role: :assistant, content: 'Cleared scope response')
+      )
+
+      chat.add_message(role: :user, content: 'one')
+      chat.add_message(role: :assistant, content: 'two')
+
+      chat.with_messages { |msgs| [msgs.last] }
+      chat.with_messages
+
+      chat.complete
+
+      expect(provider).to have_received(:complete).with(
+        chat.messages,
+        hash_including(
+          tools: chat.tools,
+          temperature: anything,
+          model: chat.model,
+          params: chat.params,
+          headers: chat.headers,
+          schema: chat.schema
+        )
+      )
+    end
+
+  end
+end
+
+


### PR DESCRIPTION
## What this does

Adds a `with_messages` method to `RubyLLM::Chat` that allows filtering messages before they're sent to the provider. This enables fine-grained control over which messages are included in API requests, which is particularly useful for managing context windows, implementing sliding window strategies, or selectively including only recent messages.

Ref discussion: https://github.com/crmne/ruby_llm/discussions/495

I considered creating a new chat and associating them, but I ended up not wanting to mix the application chat/message data model with something only needed for the llm call. This approach keeps message scoping logic separate from the application's data model. 

When called with a block, the block receives all messages and returns the filtered subset that will be sent to the provider. When called without a block, it clears any previously set scope and returns to using all messages.

**Usage example:**
```ruby
# Scope to only the most recent 3 messages
chat = chat.with_messages { |msgs| msgs.last(3) }
chat.complete # Only sends the most recent 3 messages to the provider

# Clear the scope to use all messages again
chat = chat.with_messages
chat.complete # Uses all messages again
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [x] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes