### PR TITLE
Fix chat response job template to use String#empty? instead of #blank? when streaming

### DIFF
--- a/lib/generators/ruby_llm/chat_ui/templates/jobs/chat_response_job.rb.tt
+++ b/lib/generators/ruby_llm/chat_ui/templates/jobs/chat_response_job.rb.tt
@@ -3,7 +3,7 @@ class <%= chat_job_class_name %> < ApplicationJob
     <%= chat_variable_name %> = <%= chat_model_name %>.find(<%= chat_variable_name %>_id)
 
     <%= chat_variable_name %>.ask(content) do |chunk|
-      if chunk.content && !chunk.content.blank?
+      if chunk.content && !chunk.content.empty?
         <%= message_variable_name %> = <%= chat_variable_name %>.<%= message_table_name %>.last
         <%= message_variable_name %>.broadcast_append_chunk(chunk.content)
       end


### PR DESCRIPTION
## What this does

Use `empty?` instead of `blank?` so whitespace-only chunks (e.g., "\n" or "  ") aren’t dropped

## Why
```ruby
"\n".blank?  # => true
"\n".empty?  # => false
"".empty?    # => true
```

For example, LLM output is often whitespace-sensitive (think Markdown): dropping streamed newlines or spaces can change the rendered result, even if HTML would ignore them

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
