### PR TITLE
Fix acts_as_tool_call ignoring custom message: option

### DIFF
--- a/lib/ruby_llm/active_record/chat_methods.rb
+++ b/lib/ruby_llm/active_record/chat_methods.rb
@@ -218,8 +218,8 @@ module RubyLLM
         if last.tool_call?
           last.destroy
         elsif last.tool_result?
-          tool_call_message = last.parent_tool_call.message
-          expected_results = tool_call_message.tool_calls.pluck(:id)
+          tool_call_message = last.parent_tool_call.message_association
+          expected_results = tool_call_message.tool_calls_association.pluck(:id)
           actual_results = tool_call_message.tool_results.pluck(:tool_call_id)
 
           if expected_results.sort != actual_results.sort

--- a/spec/ruby_llm/active_record/acts_as_spec.rb
+++ b/spec/ruby_llm/active_record/acts_as_spec.rb
@@ -391,6 +391,34 @@ RSpec.describe RubyLLM::ActiveRecord::ActsAs do
         bot_chat.with_model('claude-3-5-haiku-20241022')
         expect(bot_chat.reload.model_id).to eq('claude-3-5-haiku-20241022')
       end
+
+      it 'cleans up incomplete tool interactions with custom message association' do
+        bot_chat = Assistants::BotChat.create!(model: model)
+
+        bot_chat.bot_messages.create!(role: 'user', content: 'Do multiple calculations')
+
+        tool_call_msg = bot_chat.bot_messages.create!(role: 'assistant', content: nil)
+        tool_call1 = tool_call_msg.bot_tool_calls.create!(
+          tool_call_id: 'call_1',
+          name: 'calculator',
+          arguments: { expression: '2 + 2' }.to_json
+        )
+        tool_call_msg.bot_tool_calls.create!(
+          tool_call_id: 'call_2',
+          name: 'calculator',
+          arguments: { expression: '3 + 3' }.to_json
+        )
+
+        bot_chat.bot_messages.create!(
+          role: 'tool',
+          content: '4',
+          parent_tool_call: tool_call1
+        )
+
+        expect do
+          bot_chat.send(:cleanup_orphaned_tool_results)
+        end.to change { bot_chat.bot_messages.count }.by(-2)
+      end
     end
 
     describe 'namespaced chat models with custom foreign keys' do


### PR DESCRIPTION
The `cleanup_orphaned_tool_results` method was hardcoding `.message` and `.tool_calls` associations instead of using the dynamic helper `methods message_association` and `tool_calls_association`.

This caused NoMethodError when using custom association names like:
```ruby
  acts_as_tool_call message: :llm_message
  acts_as_message tool_calls: :bot_tool_calls
```

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [X] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [X] This aligns with RubyLLM's focus on **LLM communication**
- [X] This isn't application-specific logic that belongs in user code
- [X] This benefits most users, not just my specific use case

## Quality check

- [X] I ran `overcommit --install` and all hooks pass
- [X] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [X] All tests pass: `bundle exec rspec`
- [X] I updated documentation if needed
- [X] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [X] No API changes

## Related issues

Fixes #514
