### PR TITLE
Add Claude 4.x model family patterns and pricing for Bedrock

### DIFF
--- a/lib/ruby_llm/providers/bedrock/capabilities.rb
+++ b/lib/ruby_llm/providers/bedrock/capabilities.rb
@@ -67,7 +67,15 @@ module RubyLLM
         end
 
         # Model family patterns for capability lookup
+        # Note: More specific patterns must come before less specific ones
         MODEL_FAMILIES = {
+          # Claude 4.x families
+          /anthropic\.claude-opus-4-5/ => :claude_opus_4_5,
+          /anthropic\.claude-opus-4/ => :claude_opus_4,
+          /anthropic\.claude-sonnet-4-5/ => :claude_sonnet_4_5,
+          /anthropic\.claude-sonnet-4/ => :claude_sonnet_4,
+          /anthropic\.claude-haiku-4-5/ => :claude_haiku_4_5,
+          # Claude 3.x families
           /anthropic\.claude-3-opus/ => :claude3_opus,
           /anthropic\.claude-3-sonnet/ => :claude3_sonnet,
           /anthropic\.claude-3-5-sonnet/ => :claude3_sonnet,
@@ -84,6 +92,13 @@ module RubyLLM
 
         # Pricing information for Bedrock models (per million tokens)
         PRICES = {
+          # Claude 4.x pricing
+          claude_opus_4: { input: 15.0, output: 75.0 },
+          claude_opus_4_5: { input: 5.0, output: 25.0 },
+          claude_sonnet_4: { input: 3.0, output: 15.0 },
+          claude_sonnet_4_5: { input: 3.0, output: 15.0 },
+          claude_haiku_4_5: { input: 1.0, output: 5.0 },
+          # Claude 3.x pricing
           claude3_opus: { input: 15.0, output: 75.0 },
           claude3_sonnet: { input: 3.0, output: 15.0 },
           claude3_haiku: { input: 0.25, output: 1.25 },

--- a/spec/ruby_llm/providers/bedrock/capabilities_spec.rb
+++ b/spec/ruby_llm/providers/bedrock/capabilities_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::Bedrock::Capabilities do
+  describe '.model_family' do
+    it 'identifies Claude 4.x model families' do
+      {
+        'anthropic.claude-opus-4-5-20251101-v1:0' => :claude_opus_4_5,
+        'anthropic.claude-opus-4-20250514-v1:0' => :claude_opus_4,
+        'anthropic.claude-sonnet-4-5-20250929-v1:0' => :claude_sonnet_4_5,
+        'anthropic.claude-sonnet-4-20250514-v1:0' => :claude_sonnet_4,
+        'anthropic.claude-haiku-4-5-20251001-v1:0' => :claude_haiku_4_5
+      }.each do |model_id, expected_family|
+        expect(described_class.model_family(model_id)).to eq(expected_family)
+      end
+    end
+
+    it 'identifies Claude 4.x model families with region prefix' do
+      {
+        'us.anthropic.claude-opus-4-5-20251101-v1:0' => :claude_opus_4_5,
+        'us.anthropic.claude-opus-4-20250514-v1:0' => :claude_opus_4,
+        'eu.anthropic.claude-sonnet-4-5-20250929-v1:0' => :claude_sonnet_4_5,
+        'ap.anthropic.claude-sonnet-4-20250514-v1:0' => :claude_sonnet_4,
+        'us.anthropic.claude-haiku-4-5-20251001-v1:0' => :claude_haiku_4_5
+      }.each do |model_id, expected_family|
+        expect(described_class.model_family(model_id)).to eq(expected_family)
+      end
+    end
+
+    it 'identifies Claude 3.x model families' do
+      {
+        'anthropic.claude-3-opus-20240229-v1:0' => :claude3_opus,
+        'anthropic.claude-3-5-sonnet-20241022-v2:0' => :claude3_sonnet,
+        'anthropic.claude-3-7-sonnet-20250219-v1:0' => :claude3_sonnet,
+        'anthropic.claude-3-haiku-20240307-v1:0' => :claude3_haiku,
+        'anthropic.claude-3-5-haiku-20241022-v1:0' => :claude3_5_haiku
+      }.each do |model_id, expected_family|
+        expect(described_class.model_family(model_id)).to eq(expected_family)
+      end
+    end
+  end
+
+  describe '.input_price_for and .output_price_for' do
+    it 'returns correct pricing for Claude 4.x models' do
+      {
+        'us.anthropic.claude-opus-4-5-20251101-v1:0' => { input: 5.0, output: 25.0 },
+        'us.anthropic.claude-opus-4-20250514-v1:0' => { input: 15.0, output: 75.0 },
+        'us.anthropic.claude-sonnet-4-5-20250929-v1:0' => { input: 3.0, output: 15.0 },
+        'us.anthropic.claude-sonnet-4-20250514-v1:0' => { input: 3.0, output: 15.0 },
+        'us.anthropic.claude-haiku-4-5-20251001-v1:0' => { input: 1.0, output: 5.0 }
+      }.each do |model_id, expected_prices|
+        expect(described_class.input_price_for(model_id)).to eq(expected_prices[:input])
+        expect(described_class.output_price_for(model_id)).to eq(expected_prices[:output])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this does

brief screencast overview

Fixes #459 - Adds missing Claude 4.x model family patterns and pricing to the Bedrock capabilities module.

Bedrock Claude 4.x models (Haiku 4.5, Sonnet 4, Sonnet 4.5, Opus 4, Opus 4.5) were falling through to the `:other` family and receiving default pricing of $0.10/$0.20 per million tokens instead of their correct prices.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

Fixes #459

## Notes

After merging, `models.json` will need to be regenerated with `rake models:update` (requires AWS Bedrock credentials) to include the corrected pricing for existing Bedrock Claude 4.x model entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)