### PR TITLE
Fix alias generation for Claude 4.x Bedrock models

### DIFF
--- a/lib/tasks/models.rake
+++ b/lib/tasks/models.rake
@@ -353,8 +353,8 @@ def generate_aliases # rubocop:disable Metrics/PerceivedComplexity
   end
 
   models['bedrock'].each do |bedrock_model|
-    next unless bedrock_model.start_with?('anthropic.')
-    next unless bedrock_model =~ /anthropic\.(claude-[\d.]+-[a-z]+)/
+    next unless bedrock_model.include?('anthropic.')
+    next unless bedrock_model =~ /anthropic\.(claude-[a-z0-9.-]+)-\d{8}/
 
     base_name = Regexp.last_match(1)
     anthropic_name = base_name.tr('.', '-')


### PR DESCRIPTION
## What this does

brief screencast overview https://www.loom.com/share/8abf7418f1cf4604ad4c6b8b948bec69

Fixes #560 - Updates alias generation to handle Claude 4.x Bedrock models with region prefixes and new naming convention.

Claude 4.x models like `us.anthropic.claude-opus-4-5-20251101-v1:0` were not getting aliases because:

1. `start_with?('anthropic.')` excluded models with region prefix (`us.`, `eu.`, `ap.`)
2. Regex expected `claude-<digits>-<name>` (e.g., `claude-3-opus`) but Claude 4.x uses `claude-<name>-<digits>` (e.g., `claude-opus-4-5`)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

Fixes #560
Related to #459, #545

## Verification

After this fix, `rake models:aliases` correctly generates Claude 4.x aliases:
- `claude-opus-4-5` → `us.anthropic.claude-opus-4-5-20251101-v1:0`
- `claude-opus-4` → `us.anthropic.claude-opus-4-20250514-v1:0`
- `claude-opus-4-1` → `us.anthropic.claude-opus-4-1-20250805-v1:0`
- `claude-sonnet-4` → `us.anthropic.claude-sonnet-4-20250514-v1:0`
- `claude-sonnet-4-5` → `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
- `claude-haiku-4-5` → `us.anthropic.claude-haiku-4-5-20251001-v1:0`

Existing Claude 3.x aliases still generate correctly:
- `claude-3-opus` → `anthropic.claude-3-opus-20240229-v1:0`
- `claude-3-sonnet` → `anthropic.claude-3-sonnet-20240229-v1:0`
- `claude-3-haiku` → `anthropic.claude-3-haiku-20240307-v1:0`
- `claude-3-5-haiku` → `anthropic.claude-3-5-haiku-20241022-v1:0`
- `claude-3-5-sonnet` → `anthropic.claude-3-5-sonnet-20240620-v1:0`
- `claude-3-7-sonnet` → `us.anthropic.claude-3-7-sonnet-20250219-v1:0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)