### PR TITLE
Add with_image_config for Gemini image generation

### DIFF
--- a/spec/ruby_llm/chat_image_config_spec.rb
+++ b/spec/ruby_llm/chat_image_config_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Chat do
+  include_context 'with configured RubyLLM'
+
+  describe '#with_image_config' do
+    let(:chat) { RubyLLM.chat(model: 'gemini-2.5-flash', provider: :gemini) }
+
+    it 'returns self for method chaining' do
+      result = chat.with_image_config(aspect_ratio: '16:9')
+      expect(result).to eq(chat)
+    end
+
+    it 'sets aspect_ratio as aspectRatio' do
+      chat.with_image_config(aspect_ratio: '16:9')
+      expect(chat.image_config).to eq({ aspectRatio: '16:9' })
+    end
+
+    it 'sets image_size as imageSize' do
+      chat.with_image_config(image_size: '2K')
+      expect(chat.image_config).to eq({ imageSize: '2K' })
+    end
+
+    it 'sets both aspect_ratio and image_size' do
+      chat.with_image_config(aspect_ratio: '16:9', image_size: '2K')
+      expect(chat.image_config).to eq({ aspectRatio: '16:9', imageSize: '2K' })
+    end
+
+    it 'sets image_config to nil when no options provided' do
+      chat.with_image_config
+      expect(chat.image_config).to be_nil
+    end
+
+    it 'can be chained with other methods' do
+      result = chat
+               .with_temperature(1.0)
+               .with_image_config(aspect_ratio: '16:9', image_size: '2K')
+
+      expect(result.image_config).to eq({ aspectRatio: '16:9', imageSize: '2K' })
+    end
+  end
+
+  describe 'effective_params with image_config' do
+    let(:chat) { RubyLLM.chat(model: 'gemini-2.5-flash', provider: :gemini) }
+
+    it 'merges image_config into generationConfig' do
+      chat.with_image_config(aspect_ratio: '16:9')
+      effective = chat.send(:effective_params)
+
+      expect(effective[:generationConfig][:imageConfig]).to eq({ aspectRatio: '16:9' })
+    end
+
+    it 'preserves existing params when merging image_config' do
+      chat.with_params(generationConfig: { temperature: 0.5 })
+      chat.with_image_config(aspect_ratio: '16:9')
+      effective = chat.send(:effective_params)
+
+      expect(effective[:generationConfig][:temperature]).to eq(0.5)
+      expect(effective[:generationConfig][:imageConfig]).to eq({ aspectRatio: '16:9' })
+    end
+
+    it 'returns params unchanged when image_config is nil' do
+      chat.with_params(generationConfig: { temperature: 0.5 })
+      effective = chat.send(:effective_params)
+
+      expect(effective).to eq({ generationConfig: { temperature: 0.5 } })
+      expect(effective[:generationConfig]).not_to have_key(:imageConfig)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `with_image_config(aspect_ratio:, image_size:)` method to `Chat` class for Gemini's native image generation models
- Supports `aspectRatio` values: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"
- Supports `imageSize` values: "1K", "2K", "4K"

## Usage

```ruby
chat = RubyLLM.chat(model: "gemini-3-pro-image-preview")
  .with_temperature(1.0)
  .with_image_config(aspect_ratio: "16:9", image_size: "2K")

response = chat.ask("Generate a landscape photo of mountains")
```

## Implementation

Uses the existing `params` deep merge mechanism—no changes to the provider interface required. Snake_case parameters (`aspect_ratio`) are converted to camelCase (`aspectRatio`) for the Gemini API.

## Test plan

- [x] Unit tests for `#with_image_config` method chaining
- [x] Unit tests for `effective_params` merging behavior
- [x] Unit tests verifying payload structure with `imageConfig`
- [x] All existing tests pass (444 examples, 0 failures)
- [x] All pre-commit hooks pass (RuboCop, Flay, RSpec)

🤖 Generated with [Claude Code](https://claude.ai/code)