### PR TITLE
Handle tool hallucination gracefully

### DIFF
--- a/docs/_core_features/tools.md
+++ b/docs/_core_features/tools.md
@@ -85,6 +85,15 @@ end
 > ```
 {: .note }
 
+> If a model attempts to call a tool that doesn't exist (sometimes called "tool hallucination"), RubyLLM handles this gracefully by:
+>
+> 1. Returning an error message to the model indicating which tool it tried to call
+> 2. Listing the actually available tools
+> 3. Allowing the conversation to continue so the model can correct itself
+>
+> This prevents crashes and gives the model a chance to use the correct tool or respond appropriately.
+{: .note }
+
 ## Declaring Parameters
 
 RubyLLM ships with two complementary approaches:

--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -209,6 +209,13 @@ module RubyLLM
 
     def execute_tool(tool_call)
       tool = tools[tool_call.name.to_sym]
+      if tool.nil?
+        return {
+          error: "Model tried to call unavailable tool `#{tool_call.name}`. " \
+                 "Available tools: #{tools.keys.to_json}."
+        }
+      end
+
       args = tool_call.arguments
       tool.call(args)
     end


### PR DESCRIPTION
## What this does

While asking `what tools do you support?` I managed to have the underlying LLM hallucinate it could call a tool `list_tools` which ended up failing with a NPE (`nil.call(args)`) because I didn't have such tool available...

This is an attempt at dealing with this hallucination in a nicer way, inspired by what others are doing (eg. [Vercel
AI](https://github.com/vercel/ai/blob/52fc8fb2b9e797550e8e1ce7bde3afdf9e47f35c/packages/ai/src/error/no-such-tool-error.ts#L16)).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes


