### PR TITLE
Add Ollama Cloud provider with native Ollama API support

### DIFF
--- a/lib/ruby_llm.rb
+++ b/lib/ruby_llm.rb
@@ -29,7 +29,9 @@ loader.inflector.inflect(
   'perplexity' => 'Perplexity',
   'ruby_llm' => 'RubyLLM',
   'vertexai' => 'VertexAI',
-  'xai' => 'XAI'
+  'xai' => 'XAI',
+  'ollama' => 'Ollama',
+  'ollama_cloud' => 'OllamaCloud',
 )
 loader.ignore("#{__dir__}/tasks")
 loader.ignore("#{__dir__}/generators")
@@ -102,6 +104,7 @@ RubyLLM::Provider.register :gpustack, RubyLLM::Providers::GPUStack
 RubyLLM::Provider.register :mistral, RubyLLM::Providers::Mistral
 RubyLLM::Provider.register :ollama, RubyLLM::Providers::Ollama
 RubyLLM::Provider.register :openai, RubyLLM::Providers::OpenAI
+RubyLLM::Provider.register :ollama_cloud, RubyLLM::Providers::OllamaCloud
 RubyLLM::Provider.register :openrouter, RubyLLM::Providers::OpenRouter
 RubyLLM::Provider.register :perplexity, RubyLLM::Providers::Perplexity
 RubyLLM::Provider.register :vertexai, RubyLLM::Providers::VertexAI

--- a/lib/ruby_llm/configuration.rb
+++ b/lib/ruby_llm/configuration.rb
@@ -25,6 +25,7 @@ module RubyLLM
                   :openrouter_api_key,
                   :xai_api_key,
                   :ollama_api_base,
+                  :ollama_api_key,
                   :gpustack_api_base,
                   :gpustack_api_key,
                   :mistral_api_key,

--- a/lib/ruby_llm/models.rb
+++ b/lib/ruby_llm/models.rb
@@ -29,6 +29,7 @@ module RubyLLM
       xai
       azure
       ollama
+      ollama_cloud
       gpustack
     ].freeze
 

--- a/lib/ruby_llm/providers/ollama_cloud.rb
+++ b/lib/ruby_llm/providers/ollama_cloud.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    # Ollama Cloud API integration using native Ollama API format.
+    # Connects to https://ollama.com for cloud-hosted models.
+    class OllamaCloud < Provider
+      include OllamaCloud::Chat
+      include OllamaCloud::Media
+      include OllamaCloud::Models
+      include OllamaCloud::Embeddings
+
+      def api_base
+        @config.ollama_api_base || 'https://ollama.com'
+      end
+
+      def headers
+        {
+          'Authorization' => "Bearer #{@config.ollama_api_key}"
+        }.compact
+      end
+
+      class << self
+        def configuration_requirements
+          %i[ollama_api_key]
+        end
+
+        def local?
+          false
+        end
+
+        def assume_models_exist?
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/ollama_cloud/chat.rb
+++ b/lib/ruby_llm/providers/ollama_cloud/chat.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class OllamaCloud
+      # Chat methods using native Ollama API format
+      module Chat
+        def completion_url
+          'api/chat'
+        end
+
+        def render_payload(messages, tools:, temperature:, model:, stream: false, schema: nil, thinking: nil) # rubocop:disable Metrics/ParameterLists
+          payload = {
+            model: model.id,
+            messages: format_messages(messages),
+            stream: stream
+          }
+
+          payload[:temperature] = temperature unless temperature.nil?
+
+          payload[:tools] = tools.map { |_, tool| format_tool(tool) } if tools.any?
+
+          payload[:format] = schema if schema
+
+          # Ollama supports 'think' parameter for reasoning models
+          if thinking
+            payload[:think] = thinking.is_a?(Hash) ? thinking[:effort] : thinking
+          end
+
+          payload
+        end
+
+        def parse_completion_response(response)
+          data = response.body
+          return if data.empty?
+
+          raise Error.new(response, data.dig('error', 'message')) if data.dig('error', 'message')
+
+          message_data = data.dig('message')
+          return unless message_data
+
+          usage = data.dig('usage') || {}
+
+          Message.new(
+            role: :assistant,
+            content: message_data['content'],
+            tool_calls: parse_tool_calls(message_data['tool_calls']),
+            input_tokens: usage['prompt_tokens'],
+            output_tokens: usage['completion_tokens'],
+            model_id: data['model'],
+            raw: response
+          )
+        end
+
+        def format_messages(messages)
+          messages.map do |msg|
+            {
+              role: msg.role.to_s,
+              content: msg.content.to_s
+            }.tap do |formatted|
+              # Add tool calls if present
+              formatted[:tool_calls] = msg.tool_calls if msg.tool_calls && !msg.tool_calls.empty?
+            end
+          end
+        end
+
+        def format_tool(tool)
+          {
+            type: 'function',
+            function: {
+              name: tool.name,
+              description: tool.description,
+              parameters: tool.parameters&.transform_keys(&:to_s)
+            }
+          }
+        end
+
+        def parse_tool_calls(tool_calls)
+          return nil unless tool_calls
+
+          tool_calls.map do |tc|
+            ToolCall.new(
+              id: tc.dig('id') || tc.dig('function', 'name'),
+              name: tc.dig('function', 'name'),
+              arguments: tc.dig('function', 'arguments')
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/ollama_cloud/embeddings.rb
+++ b/lib/ruby_llm/providers/ollama_cloud/embeddings.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class OllamaCloud
+      # Embeddings methods for the Ollama Cloud API
+      module Embeddings
+        def embedding_url(model:)
+          'api/embed'
+        end
+
+        def render_embedding_payload(text, model:, dimensions: nil)
+          {
+            model: model.id,
+            input: text
+          }
+
+          # Ollama doesn't directly support dimensions parameter
+          # but some models have specific embedding sizes
+        end
+
+        def parse_embedding_response(response, model:, text:)
+          data = response.body
+
+          raise Error, data.dig('error', 'message') || 'Embedding failed' if data['error']
+
+          embeddings = data['embeddings']
+
+          if text.is_a?(Array)
+            # Batch embedding
+            embeddings.map.with_index do |embedding, i|
+              Embedding.new(
+                text: text[i],
+                embedding: embedding,
+                model_id: model.id,
+                input_tokens: data.dig('usage', 'prompt_tokens')
+              )
+            end
+          else
+            # Single embedding
+            Embedding.new(
+              text: text,
+              embedding: embeddings.first,
+              model_id: model.id,
+              input_tokens: data.dig('usage', 'prompt_tokens')
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/ollama_cloud/media.rb
+++ b/lib/ruby_llm/providers/ollama_cloud/media.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class OllamaCloud
+      # Handles formatting of media content for Ollama Cloud APIs
+      module Media
+        extend self
+
+        def format_content(content)
+          return content.value if content.is_a?(RubyLLM::Content::Raw)
+          return content.to_json if content.is_a?(Hash) || content.is_a?(Array)
+          return content unless content.is_a?(Content)
+
+          # For Ollama, we typically send text and image URLs
+          parts = []
+          parts << content.text if content.text
+
+          content.attachments.each do |attachment|
+            case attachment.type
+            when :image
+              # Ollama expects images as base64 or URLs in the content
+              parts << { type: 'image',
+                         source: { type: 'base64', media_type: attachment.mime_type, data: attachment.for_llm } }
+            when :text
+              parts << attachment.for_llm
+            else
+              raise UnsupportedAttachmentError, attachment.mime_type
+            end
+          end
+
+          parts.length == 1 ? parts.first : parts
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/ollama_cloud/models.rb
+++ b/lib/ruby_llm/providers/ollama_cloud/models.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class OllamaCloud
+      # Models methods for the Ollama Cloud API
+      module Models
+        def models_url
+          'api/tags'
+        end
+
+        def parse_list_models_response(response, slug, _capabilities)
+          data = response.body['models'] || []
+          data.map do |model|
+            Model::Info.new(
+              id: model['name'],
+              name: model['name'],
+              provider: slug,
+              family: model.dig('details', 'family') || 'ollama',
+              created_at: begin
+                Time.at(model['modified_at'])
+              rescue StandardError
+                nil
+              end,
+              context_window: model.dig('details', 'context_length'),
+              modalities: {
+                input: %w[text],
+                output: %w[text]
+              },
+              capabilities: infer_capabilities(model),
+              metadata: {
+                size: model['size'],
+                digest: model['digest'],
+                format: model.dig('details', 'format'),
+                quantization: model.dig('details', 'quantization_level')
+              }
+            )
+          end
+        end
+
+        private
+
+        def infer_capabilities(model)
+          caps = %w[streaming]
+
+          # Cloud models often support more features
+          name = model['name'].to_s.downcase
+
+          caps << 'vision' if name.include?('vision') || name.include?('vl')
+
+          caps << 'function_calling' if name.include?('tools') || name.include?('function')
+
+          caps
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
     - Implements Ollama Cloud provider using native Ollama API
     - API base: https://ollama.com (matching Python client)
     - Uses OLLAMA_API_KEY environment variable
     - Supports cloud models with -cloud suffix
     - Implements /api/tags, /api/chat, /api/embed endpoints
     - Adds assume_models_exist? to allow unregistered cloud models

     ## What this does

     This PR allows to use ollama-cloude provider for chatting.

     ## Type of change

     - [x] New feature
     - [ ] Documentation

     ## Scope check

     - [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
     - [x] This aligns with RubyLLM's focus on **LLM communication**
     - [x] This isn't application-specific logic that belongs in user code
     - [x] This benefits most users, not just my specific use case

     ## Required for new features

     - [ ] I opened an issue **before** writing code and received maintainer approval
     - [ ] Linked issue: #___

     **PRs for new features or enhancements without a prior approved issue will be closed.**

     ## Quality check

     - [ ] I ran `overcommit --install` and all hooks pass
     - [ ] I tested my changes thoroughly
       - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake 'vcr:record[provider_name]'`
       - [ ] All tests pass: `bundle exec rspec`
     - [ ] I updated documentation if needed
     - [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

     ## AI-generated code

     - [ ] I used AI tools to help write this code
     - [ ] I have reviewed and understand all generated code (required if above is checked)

     ## API changes

     - [ ] Breaking change
     - [ ] New public methods/classes
     - [ ] Changed method signatures
     - [ ] No API changes


## Example of usage

```
require "ruby_llm"

RubyLLM.configure do |config|
  config.ollama_api_key = "your-api-key"
end

#Use with cloud models (note the -cloud suffix)
chat = RubyLLM.chat model: "gpt-oss:120b-cloud", provider: :ollama_cloud
response = chat.ask "What is Ruby?"
puts response.conten
```