### PR TITLE
Fix POST retries and 504 retry classification

### DIFF
--- a/lib/ruby_llm/connection.rb
+++ b/lib/ruby_llm/connection.rb
@@ -76,6 +76,7 @@ module RubyLLM
         interval: @config.retry_interval,
         interval_randomness: @config.retry_interval_randomness,
         backoff_factor: @config.retry_backoff_factor,
+        methods: Faraday::Retry::Middleware::IDEMPOTENT_METHODS + [:post],
         exceptions: retry_exceptions,
         retry_statuses: [429, 500, 502, 503, 504, 529]
       }

--- a/lib/ruby_llm/error.rb
+++ b/lib/ruby_llm/error.rb
@@ -61,7 +61,7 @@ module RubyLLM
           raise RateLimitError.new(response, message || 'Rate limit exceeded - please wait a moment')
         when 500
           raise ServerError.new(response, message || 'API server error - please try again')
-        when 502..503
+        when 502..504
           raise ServiceUnavailableError.new(response, message || 'API server unavailable - please try again later')
         when 529
           raise OverloadedError.new(response, message || 'Service overloaded - please try again later')

--- a/spec/ruby_llm/connection_retry_spec.rb
+++ b/spec/ruby_llm/connection_retry_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Connection do
+  describe 'retry middleware configuration' do
+    let(:provider) do
+      instance_double(
+        RubyLLM::Provider,
+        api_base: 'https://example.com',
+        configured?: true,
+        headers: {}
+      )
+    end
+
+    let(:config) do
+      instance_double(
+        RubyLLM::Configuration,
+        request_timeout: 300,
+        max_retries: 3,
+        retry_interval: 0.1,
+        retry_interval_randomness: 0.5,
+        retry_backoff_factor: 2,
+        http_proxy: nil
+      )
+    end
+
+    it 'retries POST requests for transient failures' do
+      connection = described_class.new(provider, config).connection
+      retry_handler = connection.builder.handlers.find { |handler| handler.klass == Faraday::Retry::Middleware }
+      retry_options = retry_handler.instance_variable_get(:@args).first
+
+      expect(retry_options[:methods]).to include(:post)
+    end
+  end
+end

--- a/spec/ruby_llm/error_middleware_spec.rb
+++ b/spec/ruby_llm/error_middleware_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::ErrorMiddleware do
+  describe '.parse_error' do
+    let(:provider) { instance_double(RubyLLM::Provider, parse_error: 'provider error') }
+
+    it 'maps 502 to ServiceUnavailableError' do
+      response = Struct.new(:status, :body).new(502, '{"error":{"message":"down"}}')
+
+      expect do
+        described_class.parse_error(provider: provider, response: response)
+      end.to raise_error(RubyLLM::ServiceUnavailableError)
+    end
+
+    it 'maps 503 to ServiceUnavailableError' do
+      response = Struct.new(:status, :body).new(503, '{"error":{"message":"down"}}')
+
+      expect do
+        described_class.parse_error(provider: provider, response: response)
+      end.to raise_error(RubyLLM::ServiceUnavailableError)
+    end
+
+    it 'maps 504 to ServiceUnavailableError' do
+      response = Struct.new(:status, :body).new(504, '{"error":{"message":"timeout"}}')
+
+      expect do
+        described_class.parse_error(provider: provider, response: response)
+      end.to raise_error(RubyLLM::ServiceUnavailableError)
+    end
+  end
+end

--- a/spec/support/rubyllm_configuration.rb
+++ b/spec/support/rubyllm_configuration.rb
@@ -18,7 +18,8 @@ RSpec.shared_context 'with configured RubyLLM' do
       config.gemini_api_key = ENV.fetch('GEMINI_API_KEY', 'test')
       config.gpustack_api_base = ENV.fetch('GPUSTACK_API_BASE', 'http://localhost:11444/v1')
       config.gpustack_api_key = ENV.fetch('GPUSTACK_API_KEY', nil)
-      config.max_retries = 10
+      # Keep retries short in tests to avoid long backoff sleeps.
+      config.max_retries = 2
       config.mistral_api_key = ENV.fetch('MISTRAL_API_KEY', 'test')
       config.model_registry_class = 'Model'
       config.ollama_api_base = ENV.fetch('OLLAMA_API_BASE', 'http://localhost:11434/v1')
@@ -26,9 +27,9 @@ RSpec.shared_context 'with configured RubyLLM' do
       config.openrouter_api_key = ENV.fetch('OPENROUTER_API_KEY', 'test')
       config.perplexity_api_key = ENV.fetch('PERPLEXITY_API_KEY', 'test')
       config.request_timeout = 600
-      config.retry_backoff_factor = 3
-      config.retry_interval = 1
-      config.retry_interval_randomness = 0.5
+      config.retry_backoff_factor = 0.1
+      config.retry_interval = 0.01
+      config.retry_interval_randomness = 0.01
       config.vertexai_location = ENV.fetch('GOOGLE_CLOUD_LOCATION', 'global')
       config.vertexai_project_id = ENV.fetch('GOOGLE_CLOUD_PROJECT', 'test-project')
       config.xai_api_key = ENV.fetch('XAI_API_KEY', 'test')


### PR DESCRIPTION
This follows up on #523 with a minimal patch set:

- enable retries for POST while preserving Faraday default idempotent methods
- map HTTP 504 to `RubyLLM::ServiceUnavailableError` (so retry classification is consistent)
- reduce retry backoff settings in test config to avoid long sleeps in retry/error specs
- add focused specs for retry config and 502/503/504 error mapping

Related: #417
