### PR TITLE
Fix streaming to preserve whitespace chunks in chat UI template

### DIFF
--- a/lib/generators/ruby_llm/chat_ui/templates/jobs/chat_response_job.rb.tt
+++ b/lib/generators/ruby_llm/chat_ui/templates/jobs/chat_response_job.rb.tt
@@ -3,7 +3,7 @@ class <%= chat_job_class_name %> < ApplicationJob
     <%= chat_variable_name %> = <%= chat_model_name %>.find(<%= chat_variable_name %>_id)
 
     <%= chat_variable_name %>.ask(content) do |chunk|
-      if chunk.content && !chunk.content.blank?
+      if chunk.content && !chunk.content.empty?
         <%= message_variable_name %> = <%= chat_variable_name %>.<%= message_table_name %>.last
         <%= message_variable_name %>.broadcast_append_chunk(chunk.content)
       end


### PR DESCRIPTION
## Summary

`String#blank?` drops whitespace-only chunks (newlines, spaces) during streaming. LLM output can include content where whitespace is significant for correct rendering (e.g. Markdown), so use `String#empty?` instead to only skip truly empty chunks.

Replaces #537 (was opened from main by mistake).