### PR TITLE
Detect context length exceeded errors on HTTP 400 responses

### DIFF
--- a/lib/ruby_llm/error.rb
+++ b/lib/ruby_llm/error.rb
@@ -63,6 +63,10 @@ module RubyLLM
         when 200..399
           message
         when 400
+          if context_length_exceeded?(message)
+            raise ContextLengthExceededError.new(response, message || 'Context length exceeded')
+          end
+
           raise BadRequestError.new(response, message || 'Invalid request - please check your input')
         when 401
           raise UnauthorizedError.new(response, message || 'Invalid API key - check your credentials')


### PR DESCRIPTION
## What this does

OpenAI returns HTTP 400 (not 429) when the context length is exceeded. The error message looks like:

> This model's maximum context length is 8192 tokens. However, your messages resulted in 10061 tokens (7911 in the messages, 2150 in the functions). Please reduce the length of the messages or functions.

Currently, `ErrorMiddleware` only checks `context_length_exceeded?` on 429 responses. This means OpenAI's context length errors surface as `BadRequestError` instead of `ContextLengthExceededError`, which breaks any downstream logic that relies on catching `ContextLengthExceededError` (e.g. conversation compaction, retry strategies).

This PR adds the same `context_length_exceeded?` check to the 400 handler, so context length errors are correctly classified regardless of whether the provider returns 400 or 429.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

N/A — this is a bug fix.

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes