### PR TITLE
Fix missing models.dev date handling for created_at metadata

### DIFF
--- a/lib/ruby_llm/models.rb
+++ b/lib/ruby_llm/models.rb
@@ -312,14 +312,15 @@ module RubyLLM
         modalities = normalize_models_dev_modalities(model_data[:modalities])
         capabilities = models_dev_capabilities(model_data, modalities)
 
-        created_date = model_data[:release_date] || model_data[:last_updated]
+        created_date = [model_data[:release_date], model_data[:last_updated]]
+                       .find { |value| !value.to_s.strip.empty? }
 
         data = {
           id: model_data[:id],
           name: model_data[:name] || model_data[:id],
           provider: provider_slug,
           family: model_data[:family],
-          created_at: "#{created_date} 00:00:00 UTC",
+          created_at: created_date ? "#{created_date} 00:00:00 UTC" : nil,
           context_window: model_data.dig(:limit, :context),
           max_output_tokens: model_data.dig(:limit, :output),
           knowledge_cutoff: normalize_models_dev_knowledge(model_data[:knowledge]),

--- a/spec/ruby_llm/models_spec.rb
+++ b/spec/ruby_llm/models_spec.rb
@@ -214,6 +214,13 @@ RSpec.describe RubyLLM::Models do
       data = described_class.models_dev_model_to_info(model_data_with_release_date, 'openai', 'openai')
       expect(data[:created_at]).to eq('2025-03-01 00:00:00 UTC')
     end
+
+    it 'keeps created_at nil when both release_date and last_updated are missing' do
+      model_data_without_dates = model_data.merge(release_date: nil, last_updated: nil)
+      data = described_class.models_dev_model_to_info(model_data_without_dates, 'openai', 'openai')
+
+      expect(data[:created_at]).to be_nil
+    end
   end
 
   describe '#embedding_models' do


### PR DESCRIPTION
## What this does

Fixes an edge case in `Models.models_dev_model_to_info` where `created_at` was built from a blank date when both `release_date` and `last_updated` were missing.

Before this fix, it could build `" 00:00:00 UTC"`, which later parsed to the current date, causing incorrect and non-deterministic `created_at` values in model metadata.

This PR:
- Sets `created_at` only when a non-blank date is present.
- Keeps `created_at` as `nil` when both source dates are missing.
- Adds a regression test covering this nil-date case.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

<!-- Skip this section for bug fixes and documentation -->

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: #___

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
- [ ] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
