### PR TITLE
[BUG] Fix schema name sanitization for OpenAI API compatibility

### DIFF
--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -217,7 +217,8 @@ module RubyLLM
     end
 
     def sanitize_schema_name(name)
-      name.to_s.gsub(/[^a-zA-Z0-9_-]/, '_')
+      sanitized = name.to_s.gsub(/[^a-zA-Z0-9_-]/, '_')
+      sanitized.empty? ? 'response' : sanitized
     end
 
     def wrap_streaming_block(&block)

--- a/spec/ruby_llm/chat_schema_spec.rb
+++ b/spec/ruby_llm/chat_schema_spec.rb
@@ -117,6 +117,16 @@ RSpec.describe RubyLLM::Chat do
 
         expect(chat.schema[:name]).to eq('response')
       end
+
+      it 'uses response as default name when provided name is empty' do
+        chat = RubyLLM.chat
+        chat.with_schema({
+                           name: '',
+                           schema: { type: 'object', properties: {} }
+                         })
+
+        expect(chat.schema[:name]).to eq('response')
+      end
     end
 
     # Regression test for schema + tool calls interaction


### PR DESCRIPTION
## What this does

Sanitizes schema names in `build_schema_payload` by replacing characters that don't match `[a-zA-Z0-9_-]` with `_`.

Since v1.13.0, `normalize_schema_payload` preserves the `:name` key from `to_json_schema`. When using `ruby_llm-schema`, the schema name defaults to the full Ruby class name (e.g. `MyApp::Nested::Schema`) which contains `::`. OpenAI requires `response_format.json_schema.name` to match `^[a-zA-Z0-9_-]+$`, so the request is rejected with a `BadRequestError`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

Fixes #654