### PR TITLE
Fix Anthropic streaming crash on non-hash SSE payloads

### DIFF
--- a/lib/ruby_llm/streaming.rb
+++ b/lib/ruby_llm/streaming.rb
@@ -30,7 +30,7 @@ module RubyLLM
 
     def handle_stream(&block)
       build_on_data_handler do |data|
-        block.call(build_chunk(data)) if data
+        block.call(build_chunk(data)) if data.is_a?(Hash)
       end
     end
 

--- a/spec/ruby_llm/streaming_spec.rb
+++ b/spec/ruby_llm/streaming_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Streaming do
+  let(:test_obj) do
+    Object.new.tap do |obj|
+      obj.extend(described_class)
+      obj.define_singleton_method(:build_chunk) { |data| "chunk:#{data['x']}" }
+    end
+  end
+
+  let(:env) { Struct.new(:status).new(200) }
+
+  before do
+    stub_const('Faraday::VERSION', '2.0.0')
+  end
+
+  it 'skips non-hash SSE payloads' do
+    yielded_chunks = []
+    handler = test_obj.send(:handle_stream) { |chunk| yielded_chunks << chunk }
+
+    expect { handler.call("data: true\n\n", 0, env) }.not_to raise_error
+    expect(yielded_chunks).to eq([])
+  end
+
+  it 'processes hash SSE payloads' do
+    yielded_chunks = []
+    handler = test_obj.send(:handle_stream) { |chunk| yielded_chunks << chunk }
+
+    handler.call("data: {\"x\":\"ok\"}\n\n", 0, env)
+
+    expect(yielded_chunks).to eq(['chunk:ok'])
+  end
+end


### PR DESCRIPTION
## What this does

Prevents streaming parsers from passing non-Hash SSE payloads into provider `build_chunk` methods.

`handle_data` can parse valid JSON scalars (like `true`) from `data:` frames. Those values are truthy and previously passed `if data`, which crashes provider chunk builders that assume a Hash and call `dig`.

This change narrows the guard in `handle_stream` to `data.is_a?(Hash)`.

## Why this is minimal

- One-line runtime behavior change in shared streaming handler
- No provider-specific branching
- Keeps existing behavior for all normal Hash event payloads

## Tests

- Added `spec/ruby_llm/streaming_spec.rb`
- Verifies non-Hash SSE payloads are ignored without raising
- Verifies Hash SSE payloads still flow to `build_chunk`

Fixes #656
