### PR TITLE
Add User-Agent header to Anthropic provider

### DIFF
--- a/lib/ruby_llm/providers/anthropic.rb
+++ b/lib/ruby_llm/providers/anthropic.rb
@@ -18,7 +18,8 @@ module RubyLLM
       def headers
         {
           'x-api-key' => @config.anthropic_api_key,
-          'anthropic-version' => '2023-06-01'
+          'anthropic-version' => '2023-06-01',
+          'User-Agent' => "ruby_llm/#{RubyLLM::VERSION}"
         }
       end
 

--- a/spec/ruby_llm/providers/anthropic/headers_spec.rb
+++ b/spec/ruby_llm/providers/anthropic/headers_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::Anthropic do
+  subject(:provider) { described_class.new(config) }
+
+  let(:config) do
+    instance_double(
+      RubyLLM::Configuration,
+      request_timeout: 300,
+      max_retries: 3,
+      retry_interval: 0.1,
+      retry_interval_randomness: 0.5,
+      retry_backoff_factor: 2,
+      http_proxy: nil,
+      anthropic_api_key: 'test-key'
+    )
+  end
+
+  describe '#headers' do
+    it 'includes User-Agent header' do
+      headers = provider.headers
+      expect(headers['User-Agent']).to match(/^ruby_llm\//)
+    end
+
+    it 'sets User-Agent to ruby_llm/<version>' do
+      headers = provider.headers
+      expect(headers['User-Agent']).to eq("ruby_llm/#{RubyLLM::VERSION}")
+    end
+
+    it 'includes x-api-key header' do
+      headers = provider.headers
+      expect(headers['x-api-key']).to eq('test-key')
+    end
+
+    it 'includes anthropic-version header' do
+      headers = provider.headers
+      expect(headers['anthropic-version']).to eq('2023-06-01')
+    end
+  end
+end


### PR DESCRIPTION
## What this does

Sets User-Agent to "ruby_llm/{VERSION}" on all Anthropic API requests for better request identification and debugging. Helps track which SDKs are get

## Type of change

- [X] Bug fix
- [X] New feature

## Scope check

- [X] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [X] This aligns with RubyLLM's focus on **LLM communication**
- [X] This isn't application-specific logic that belongs in user code
- [X] This benefits most users, not just my specific use case

## Required for new features

This is a small feature request / bug fix boundary. Let me know if you actually want the overhead of an issue for such a small change!

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [X] I tested my changes thoroughly
  - [X] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [X] All tests pass: `bundle exec rspec`
- [X] I updated documentation if needed
- [X] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [X] I used AI tools to help write this code
- [X] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [X] No API changes
