### PR TITLE
Add deepseek-v3.2 model support for Aliyun Bailian

### DIFF
--- a/lib/ruby_llm/models.json
+++ b/lib/ruby_llm/models.json
@@ -19514,6 +19514,57 @@
     }
   },
   {
+    "id": "deepseek-v3.2",
+    "name": "DeepSeek V3.2",
+    "provider": "deepseek",
+    "family": "deepseek",
+    "created_at": "2025-12-01 00:00:00 UTC",
+    "context_window": 64000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.28,
+          "output_per_million": 0.42,
+          "cached_input_per_million": 0.028
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "deepseek",
+      "source": "models.dev",
+      "provider_id": "deepseek",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-12-01",
+      "cost": {
+        "input": 0.28,
+        "output": 0.42,
+        "cache_read": 0.028
+      },
+      "limit": {
+        "context": 64000,
+        "output": 8192
+      },
+      "knowledge": "2024-07"
+    }
+  },
+  {
     "id": "aqa",
     "name": "Model that performs Attributed Question Answering.",
     "provider": "gemini",

--- a/lib/ruby_llm/providers/deepseek/capabilities.rb
+++ b/lib/ruby_llm/providers/deepseek/capabilities.rb
@@ -9,14 +9,14 @@ module RubyLLM
 
         def context_window_for(model_id)
           case model_id
-          when /deepseek-(?:chat|reasoner)/ then 64_000
+          when /deepseek-(?:chat|reasoner|v3)/ then 64_000
           else 32_768
           end
         end
 
         def max_tokens_for(model_id)
           case model_id
-          when /deepseek-(?:chat|reasoner)/ then 8_192
+          when /deepseek-(?:chat|reasoner|v3)/ then 8_192
           else 4_096
           end
         end
@@ -38,7 +38,7 @@ module RubyLLM
         end
 
         def supports_functions?(model_id)
-          model_id.match?(/deepseek-chat/)
+          model_id.match?(/deepseek-(?:chat|v3)/)
         end
 
         def supports_tool_choice?(_model_id)
@@ -57,6 +57,7 @@ module RubyLLM
           case model_id
           when 'deepseek-chat' then 'DeepSeek V3'
           when 'deepseek-reasoner' then 'DeepSeek R1'
+          when /deepseek-v3/ then 'DeepSeek V3'
           else
             model_id.split('-')
                     .map(&:capitalize)
@@ -71,6 +72,7 @@ module RubyLLM
         def model_family(model_id)
           case model_id
           when /deepseek-reasoner/ then :reasoner
+          when /deepseek-v3/ then :chat
           else :chat
           end
         end
@@ -110,7 +112,7 @@ module RubyLLM
         def capabilities_for(model_id)
           capabilities = ['streaming']
 
-          capabilities << 'function_calling' if model_id.match?(/deepseek-chat/)
+          capabilities << 'function_calling' if model_id.match?(/deepseek-(?:chat|v3)/)
 
           capabilities
         end

--- a/lib/ruby_llm/providers/deepseek/capabilities.rb
+++ b/lib/ruby_llm/providers/deepseek/capabilities.rb
@@ -55,9 +55,8 @@ module RubyLLM
 
         def format_display_name(model_id)
           case model_id
-          when 'deepseek-chat' then 'DeepSeek V3'
+          when 'deepseek-chat', /deepseek-v3/ then 'DeepSeek V3'
           when 'deepseek-reasoner' then 'DeepSeek R1'
-          when /deepseek-v3/ then 'DeepSeek V3'
           else
             model_id.split('-')
                     .map(&:capitalize)
@@ -70,11 +69,9 @@ module RubyLLM
         end
 
         def model_family(model_id)
-          case model_id
-          when /deepseek-reasoner/ then :reasoner
-          when /deepseek-v3/ then :chat
-          else :chat
-          end
+          return :reasoner if model_id.match?(/deepseek-reasoner/)
+
+          :chat
         end
 
         PRICES = {

--- a/spec/support/models_to_test.rb
+++ b/spec/support/models_to_test.rb
@@ -12,6 +12,7 @@ chat_models = [
   { provider: :azure, model: 'Kimi-K2.5' },
   { provider: :bedrock, model: 'amazon.nova-2-lite-v1:0' },
   { provider: :deepseek, model: 'deepseek-chat' },
+  { provider: :deepseek, model: 'deepseek-v3.2' },
   { provider: :gemini, model: 'gemini-2.5-flash' },
   { provider: :gpustack, model: 'qwen3' },
   { provider: :mistral, model: 'mistral-small-latest' },


### PR DESCRIPTION
## Summary

This PR adds support for the `deepseek-v3.2` model when using the DeepSeek provider with Aliyun Bailian API endpoint.

## Changes

### 1. Model Registry (`lib/ruby_llm/models.json`)
- Registered `deepseek-v3.2` model with:
  - 64,000 token context window
  - 8,192 max output tokens
  - Function calling and streaming capabilities
  - Pricing aligned with DeepSeek Chat

### 2. Capabilities (`lib/ruby_llm/providers/deepseek/capabilities.rb`)
Updated model capability detection to recognize `deepseek-v3.x` models:
- `context_window_for` - 64K context
- `max_tokens_for` - 8,192 max output
- `supports_functions?` - enables tool/function calling
- `format_display_name` - displays as "DeepSeek V3"
- `model_family` - maps to `:chat` family
- `capabilities_for` - includes function calling capability

### 3. Test Configuration (`spec/support/models_to_test.rb`)
- Added `deepseek-v3.2` to chat models test suite

## Usage

```ruby
# Configure for Aliyun Bailian
RubyLLM.configure do |config|
  config.deepseek_api_key = ENV['ALIYUN_BAILIAN_API_KEY']
  config.deepseek_api_base = 'https://dashscope.aliyuncs.com/compatible-mode/v1'
end

# Use deepseek-v3.2 with tool calling
chat = RubyLLM.chat(model: 'deepseek-v3.2')
chat.with_tool(YourTool).ask("Your question")
```

## Verification

All capabilities verified:
- ✅ Model lookup works
- ✅ Function calling enabled
- ✅ Context window: 64,000 tokens
- ✅ Max output: 8,192 tokens
- ✅ Streaming support

## Related

This change is backwards compatible and does not affect existing `deepseek-chat` or `deepseek-reasoner` models.