### PR TITLE
Fix incorrect reference for renamed model associations

### DIFF
--- a/lib/ruby_llm/active_record/chat_methods.rb
+++ b/lib/ruby_llm/active_record/chat_methods.rb
@@ -125,7 +125,7 @@ module RubyLLM
         self.assume_model_exists = assume_exists
         resolve_model_from_strings
         save!
-        to_llm.with_model(model.model_id, provider: model.provider.to_sym, assume_exists:)
+        to_llm.with_model(model_association.model_id, provider: model_association.provider.to_sym, assume_exists:)
         self
       end
 


### PR DESCRIPTION
## What this does

Resolves `unknown attribute 'model' for CustomMessageClass` error which occurs when you try to use `with_model` on an `ActiveRecord` Chat class that has a custom `Message` class name using the `acts_as`.

It appears to be a small typo.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] ~For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`~ N/A
  - [x] All tests pass: `bundle exec rspec`
- [ ] ~I updated documentation if needed~ N/A
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [ ] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
