### PR TITLE
Extract RubyLLM::Prompt from Agent's private prompt rendering

### DIFF
--- a/lib/ruby_llm.rb
+++ b/lib/ruby_llm.rb
@@ -95,6 +95,10 @@ module RubyLLM
       UploadedFile.download(...)
     end
 
+    def render_prompt(name, **locals)
+      Prompt.render(name, **locals)
+    end
+
     def models
       Models.instance
     end

--- a/lib/ruby_llm/agent.rb
+++ b/lib/ruby_llm/agent.rb
@@ -183,14 +183,8 @@ module RubyLLM
       end
 
       def render_prompt(name, chat:, inputs:, locals:)
-        path = prompt_path_for(name)
-        unless File.exist?(path)
-          raise RubyLLM::PromptNotFoundError,
-                "Prompt file not found for #{self}: #{path}. Create the file or use inline instructions."
-        end
-
         resolved_locals = resolve_prompt_locals(locals, runtime: runtime_context(chat:, inputs:), chat:, inputs:)
-        ERB.new(File.read(path)).result_with_hash(resolved_locals)
+        Prompt.new("#{prompt_agent_path}/#{name}").render(**resolved_locals)
       end
 
       def partition_inputs(kwargs)
@@ -382,23 +376,9 @@ module RubyLLM
         end
       end
 
-      def prompt_path_for(name)
-        filename = name.to_s
-        filename += '.txt.erb' unless filename.end_with?('.txt.erb')
-        prompt_root.join(prompt_agent_path, filename)
-      end
-
       def prompt_agent_path
         class_name = name || 'agent'
         Utils.underscore(class_name.gsub('::', '/')).tr('-', '_')
-      end
-
-      def prompt_root
-        if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
-          Rails.root.join('app/prompts')
-        else
-          Pathname.new(Dir.pwd).join('app/prompts')
-        end
       end
 
       def resolved_chat_model

--- a/lib/ruby_llm/agent.rb
+++ b/lib/ruby_llm/agent.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'erb'
 require 'forwardable'
-require 'pathname'
 require 'ruby_llm/schema'
 
 module RubyLLM
@@ -184,7 +182,7 @@ module RubyLLM
 
       def render_prompt(name, chat:, inputs:, locals:)
         resolved_locals = resolve_prompt_locals(locals, runtime: runtime_context(chat:, inputs:), chat:, inputs:)
-        Prompt.new("#{prompt_agent_path}/#{name}").render(**resolved_locals)
+        RubyLLM.render_prompt("#{prompt_agent_path}/#{name}", **resolved_locals)
       end
 
       def partition_inputs(kwargs)

--- a/lib/ruby_llm/prompt.rb
+++ b/lib/ruby_llm/prompt.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  # Renders ERB prompt templates from the prompts directory.
+  class Prompt
+    attr_reader :name, :path
+
+    def initialize(name)
+      @name = name.to_s
+      @path = self.class.root.join(
+        @name.end_with?('.txt.erb') ? @name : "#{@name}.txt.erb"
+      )
+    end
+
+    def render(**locals)
+      raise PromptNotFoundError, "Prompt file not found: #{@path}" unless File.exist?(@path)
+
+      ERB.new(File.read(@path)).result_with_hash(locals)
+    end
+
+    def self.render(name, **locals)
+      new(name).render(**locals)
+    end
+
+    def self.root
+      if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
+        Rails.root.join('app/prompts')
+      else
+        Pathname.new(Dir.pwd).join('app/prompts')
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/prompt.rb
+++ b/lib/ruby_llm/prompt.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'erb'
+require 'pathname'
+
 module RubyLLM
   # Renders ERB prompt templates from the prompts directory.
   class Prompt

--- a/spec/ruby_llm/prompt_spec.rb
+++ b/spec/ruby_llm/prompt_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+
+RSpec.describe RubyLLM::Prompt do
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:prompt_dir) { Pathname.new(tmpdir).join('app/prompts') }
+
+  before do
+    prompt_dir.mkpath
+    allow(described_class).to receive(:root).and_return(prompt_dir)
+  end
+
+  after do
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  def create_prompt(name, content)
+    path = prompt_dir.join("#{name}.txt.erb")
+    path.dirname.mkpath
+    path.write(content)
+  end
+
+  describe '.render' do
+    it 'renders a prompt with locals' do
+      create_prompt('friend', 'Hello, <%= name %>!')
+      expect(described_class.render('friend', name: 'Andrey')).to eq('Hello, Andrey!')
+    end
+
+    it 'renders a nested prompt path' do
+      create_prompt('work_assistant/instructions', 'You assist <%= user %>.')
+      expect(described_class.render('work_assistant/instructions', user: 'Bob')).to eq('You assist Bob.')
+    end
+
+    it 'renders without locals' do
+      create_prompt('simple', 'Just a static prompt.')
+      expect(described_class.render('simple')).to eq('Just a static prompt.')
+    end
+
+    it 'raises PromptNotFoundError for missing prompts' do
+      expect { described_class.render('nonexistent') }.to raise_error(RubyLLM::PromptNotFoundError)
+    end
+  end
+
+  describe '#render' do
+    it 'renders the prompt with locals' do
+      create_prompt('greeting', 'Hi <%= name %>, welcome!')
+      prompt = described_class.new('greeting')
+      expect(prompt.render(name: 'Andrey')).to eq('Hi Andrey, welcome!')
+    end
+
+    it 'exposes name and path' do
+      prompt = described_class.new('greeting')
+      expect(prompt.name).to eq('greeting')
+      expect(prompt.path).to eq(prompt_dir.join('greeting.txt.erb'))
+    end
+  end
+end

--- a/spec/ruby_llm/prompt_spec.rb
+++ b/spec/ruby_llm/prompt_spec.rb
@@ -56,4 +56,20 @@ RSpec.describe RubyLLM::Prompt do
       expect(prompt.path).to eq(prompt_dir.join('greeting.txt.erb'))
     end
   end
+
+  describe 'RubyLLM.render_prompt' do
+    it 'renders a prompt with locals through the top-level entrypoint' do
+      create_prompt('friend', 'Hello, <%= name %>!')
+      expect(RubyLLM.render_prompt('friend', name: 'Andrey')).to eq('Hello, Andrey!')
+    end
+
+    it 'renders a nested prompt path' do
+      create_prompt('work_assistant/instructions', 'You assist <%= user %>.')
+      expect(RubyLLM.render_prompt('work_assistant/instructions', user: 'Bob')).to eq('You assist Bob.')
+    end
+
+    it 'raises PromptNotFoundError for missing prompts' do
+      expect { RubyLLM.render_prompt('nonexistent') }.to raise_error(RubyLLM::PromptNotFoundError)
+    end
+  end
 end


### PR DESCRIPTION
Moves prompt root resolution, path construction, and ERB rendering into a standalone RubyLLM::Prompt class so prompts can be rendered without subclassing Agent.

Closes crmne/ruby_llm#667

## What this does

Extracts `RubyLLM::Prompt` from Agent's private `prompt_path_for` and `prompt_root` methods. This lets users render prompts following the gem's own `app/prompts/` convention without subclassing Agent:

```ruby
RubyLLM::Prompt.render('friend', name: 'Andrey')
```

Agent's `render_prompt` now delegates to `Prompt`, preserving its existing class-name scoping and runtime context resolution.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

- [x] I opened an issue **before** writing code and received maintainer approval
- [x] Linked issue: #667

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [x] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes