### PR TITLE
Fix agent not propagating assume_model_exists from class config

### DIFF
--- a/lib/ruby_llm/agent.rb
+++ b/lib/ruby_llm/agent.rb
@@ -120,7 +120,6 @@ module RubyLLM
 
         input_values, = partition_inputs(kwargs)
         record = resolved_chat_model.find(id)
-        record.assume_model_exists = chat_kwargs[:assume_model_exists] if record.respond_to?(:assume_model_exists=)
         apply_configuration(record, input_values:, persist_instructions: false)
 
         record
@@ -131,6 +130,7 @@ module RubyLLM
 
         input_values, = partition_inputs(kwargs)
         record = chat_or_id.is_a?(resolved_chat_model) ? chat_or_id : resolved_chat_model.find(chat_or_id)
+        apply_assume_model_exists(record)
         runtime = runtime_context(chat: record, inputs: input_values)
         instructions_value = resolved_instructions_value(record, runtime, inputs: input_values)
         return record if instructions_value.nil?
@@ -229,7 +229,16 @@ module RubyLLM
       end
 
       def llm_chat_for(chat_object)
+        apply_assume_model_exists(chat_object)
         chat_object.respond_to?(:to_llm) ? chat_object.to_llm : chat_object
+      end
+
+      def apply_assume_model_exists(chat_object)
+        return unless chat_kwargs.key?(:assume_model_exists) &&
+                      resolved_chat_model &&
+                      chat_object.is_a?(resolved_chat_model)
+
+        chat_object.assume_model_exists = chat_kwargs[:assume_model_exists]
       end
 
       def evaluate(value, runtime)

--- a/spec/ruby_llm/agent_rails_spec.rb
+++ b/spec/ruby_llm/agent_rails_spec.rb
@@ -188,6 +188,33 @@ RSpec.describe RubyLLM::Agent do
     expect { SpecAssumeExistsAgent.find(created.id) }.not_to raise_error
   end
 
+  it 'propagates assume_model_exists from class config when using sync_instructions! with id' do
+    agent_class = Class.new(RubyLLM::Agent) do
+      chat_model Chat
+      model 'not-a-real-model', provider: :openai, assume_model_exists: true
+      instructions 'Hello'
+    end
+
+    stub_const('SpecAssumeExistsSyncAgent', agent_class)
+
+    created = SpecAssumeExistsSyncAgent.create!
+    expect { SpecAssumeExistsSyncAgent.sync_instructions!(created.id) }.not_to raise_error
+  end
+
+  it 'propagates assume_model_exists from class config when initializing with a reloaded chat record' do
+    agent_class = Class.new(RubyLLM::Agent) do
+      chat_model Chat
+      model 'not-a-real-model', provider: :openai, assume_model_exists: true
+      instructions 'Hello'
+    end
+
+    stub_const('SpecAssumeExistsInitAgent', agent_class)
+
+    created = SpecAssumeExistsInitAgent.create!
+    reloaded = Chat.find(created.id)
+    expect { SpecAssumeExistsInitAgent.new(chat: reloaded) }.not_to raise_error
+  end
+
   it 'raises when .sync_instructions! is used without chat_model' do
     agent_class = Class.new(RubyLLM::Agent) do
       model 'gpt-4.1-nano'


### PR DESCRIPTION
## What this does

Fixes #679 

Fix Agent.find not propagating assume_model_exists from class-level config.

This is most likely to be encountered when attempting to "continue" a previous chat with an Agent.

Agent.find loads a chat record from the database and then calls apply_configuration, which triggers to_llm. to_llm creates a new RubyLLM::Chat using the record's assume_model_exists attribute — but since this is a transient attr_accessor, it defaults to nil/false after an ActiveRecord load. This causes Models.resolve to raise ModelNotFoundError for models not in the registry, even when the agent class declares assume_model_exists: true.

with_rails_chat_record (used by create/create!) doesn't have this problem because it spreads **chat_kwargs into the record constructor, which includes assume_model_exists: true:

record = resolved_chat_model.public_send(method_name, **chat_kwargs, **chat_options)

The find path was missing the equivalent propagation. This fix adds it by setting assume_model_exists from chat_kwargs on the loaded record before apply_configuration runs.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

<!-- Skip this section for bug fixes and documentation -->

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: #___

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [-] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [-] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
