### PR TITLE
Fix acts_as_message inflection for parent_tool_call causes nil association

### DIFF
--- a/docs/_advanced/rails.md
+++ b/docs/_advanced/rails.md
@@ -999,7 +999,8 @@ class ChatMessage < ApplicationRecord
                   chat_class: 'Conversation',  # Optional if inferrable
                   tool_calls: :ai_tool_calls,
                   tool_call_class: 'AIToolCall',  # Required for non-standard naming
-                  model: :ai_model
+                  model: :ai_model,
+                  parent_tool_call_foreign_key: :ai_tool_call_id
 end
 
 # app/models/ai_tool_call.rb (instead of ToolCall)

--- a/lib/ruby_llm/active_record/acts_as.rb
+++ b/lib/ruby_llm/active_record/acts_as.rb
@@ -93,7 +93,7 @@ module RubyLLM
 
         def acts_as_message(chat: :chat, chat_class: nil, chat_foreign_key: nil, touch_chat: false, # rubocop:disable Metrics/ParameterLists
                             tool_calls: :tool_calls, tool_call_class: nil, tool_calls_foreign_key: nil,
-                            model: :model, model_class: nil, model_foreign_key: nil)
+                            parent_tool_call_foreign_key: nil, model: :model, model_class: nil, model_foreign_key: nil)
           include RubyLLM::ActiveRecord::MessageMethods
 
           class_attribute :chat_association_name, :tool_calls_association_name, :model_association_name,
@@ -118,7 +118,7 @@ module RubyLLM
 
           belongs_to :parent_tool_call,
                      class_name: self.tool_call_class,
-                     foreign_key: ActiveSupport::Inflector.foreign_key(tool_calls.to_s.singularize),
+                     foreign_key: parent_tool_call_foreign_key || ActiveSupport::Inflector.foreign_key(tool_calls.to_s.singularize),
                      optional: true
 
           has_many :tool_results,

--- a/spec/ruby_llm/active_record/acts_as_spec.rb
+++ b/spec/ruby_llm/active_record/acts_as_spec.rb
@@ -550,6 +550,115 @@ RSpec.describe RubyLLM::ActiveRecord::ActsAs do
       end
     end
 
+    describe 'custom parent_tool_call_foreign_key' do
+      before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Migration.create_table :ptc_chats, force: true do |t|
+            t.string :model_id
+            t.timestamps
+          end
+
+          ActiveRecord::Migration.create_table :ptc_tool_calls, force: true do |t|
+            t.references :ptc_message
+            t.string :tool_call_id
+            t.string :name
+            t.json :arguments
+            t.timestamps
+          end
+
+          ActiveRecord::Migration.create_table :ptc_messages, force: true do |t|
+            t.references :ptc_chat
+            t.string :role
+            t.text :content
+            t.json :content_raw
+            t.string :model_id
+            t.integer :input_tokens
+            t.integer :output_tokens
+            t.integer :cached_tokens
+            t.integer :cache_creation_tokens
+            t.integer :ptc_tool_call_id
+            t.timestamps
+          end
+        end
+      end
+
+      after(:all) do # rubocop:disable RSpec/BeforeAfterAll
+        ActiveRecord::Migration.suppress_messages do
+          %i[ptc_messages ptc_tool_calls ptc_chats].each do |t|
+            ActiveRecord::Migration.drop_table(t) if ActiveRecord::Base.connection.table_exists?(t)
+          end
+        end
+      end
+
+      class PtcChat < ActiveRecord::Base # rubocop:disable Lint/ConstantDefinitionInBlock,RSpec/LeakyConstantDeclaration
+        acts_as_chat messages: :ptc_messages, message_class: 'PtcMessage'
+        self.table_name = 'ptc_chats'
+      end
+
+      class PtcMessage < ActiveRecord::Base # rubocop:disable Lint/ConstantDefinitionInBlock,RSpec/LeakyConstantDeclaration
+        acts_as_message chat: :ptc_chat, chat_class: 'PtcChat',
+                        tool_calls: :ptc_tool_calls, tool_call_class: 'PtcToolCall',
+                        parent_tool_call_foreign_key: 'ptc_tool_call_id'
+        self.table_name = 'ptc_messages'
+      end
+
+      class PtcToolCall < ActiveRecord::Base # rubocop:disable Lint/ConstantDefinitionInBlock,RSpec/LeakyConstantDeclaration
+        acts_as_tool_call message: :ptc_message, message_class: 'PtcMessage',
+                          result_class: 'PtcMessage',
+                          result_foreign_key: 'ptc_tool_call_id'
+        self.table_name = 'ptc_tool_calls'
+      end
+
+      it 'uses the custom foreign key for the parent_tool_call association' do
+        chat = PtcChat.create!(model: model)
+        chat.ptc_messages.create!(role: 'user', content: 'Calculate something')
+
+        tool_call_msg = chat.ptc_messages.create!(role: 'assistant', content: nil)
+        tool_call = tool_call_msg.ptc_tool_calls.create!(
+          tool_call_id: 'call_ptc_1',
+          name: 'calculator',
+          arguments: { expression: '2 + 2' }.to_json
+        )
+
+        tool_result_msg = chat.ptc_messages.create!(
+          role: 'tool',
+          content: '4',
+          ptc_tool_call_id: tool_call.id
+        )
+
+        expect(tool_result_msg.parent_tool_call).to eq(tool_call)
+        expect(tool_call.result).to eq(tool_result_msg)
+      end
+
+      it 'cleans up orphaned tool results with custom parent_tool_call_foreign_key' do
+        chat = PtcChat.create!(model: model)
+        chat.ptc_messages.create!(role: 'user', content: 'Do calculations')
+
+        tool_call_msg = chat.ptc_messages.create!(role: 'assistant', content: nil)
+        tool_call1 = tool_call_msg.ptc_tool_calls.create!(
+          tool_call_id: 'call_ptc_2',
+          name: 'calculator',
+          arguments: { expression: '2 + 2' }.to_json
+        )
+        tool_call_msg.ptc_tool_calls.create!(
+          tool_call_id: 'call_ptc_3',
+          name: 'calculator',
+          arguments: { expression: '3 + 3' }.to_json
+        )
+
+        # Only one tool result exists — the other is missing
+        chat.ptc_messages.create!(
+          role: 'tool',
+          content: '4',
+          ptc_tool_call_id: tool_call1.id
+        )
+
+        expect do
+          chat.send(:cleanup_orphaned_tool_results)
+        end.to change { chat.ptc_messages.count }.by(-2)
+      end
+    end
+
     describe 'to_llm conversion' do
       it 'correctly converts custom messages to RubyLLM format' do
         bot_chat = Assistants::BotChat.create!(model: model)


### PR DESCRIPTION
# What this does
* add `parent_tool_call_foreign_key` to `acts_as_message` and use that value if specified, otherwise fall back on original assumtpion.

# Bug Description
When you have a custom column name for the `parent_tool_call_id` foreign key, the current code does:
```ruby
belongs_to :parent_tool_call,
           class_name: self.tool_call_class,
           foreign_key: ActiveSupport::Inflector.foreign_key(tool_calls.to_s.singularize),
           optional: true
```
but `ActiveSupport::Inflector.foreign_key(tool_calls.to_s.singularize)` doesn't assume correctly if `tool_calls == :tool_call` but the `tool_call_class: 'SomethingElse'`.

## Recreation steps

### Setup:
```ruby
before(:all) do # rubocop:disable RSpec/BeforeAfterAll
  ActiveRecord::Migration.suppress_messages do
    # ...

    ActiveRecord::Migration.create_table :ai_tool_calls, force: true do |t|
      t.references :ai_message
      t.string :ai_tool_call_id
      # ...
    end

    ActiveRecord::Migration.create_table :ai_messages, force: true do |t|
      t.references :ai_chat
      # ...
      t.integer :ai_tool_call_id # <<< Note this
    end

    # ...

  end
end

# ...

class AiMessage
  acts_as_message(
    chat_class: 'AiChat',
    chat_foreign_key: :ai_chat_id,
    tool_call_class: 'AiToolCall', 
    tool_calls_foreign_key: :ai_message_id,
    model_class: 'AiModel', 
    model_foreign_key: 'AiModel')
  # ...
end    

# ...
```
### Test:
`AiMessage.where("ai_tool_call_id IS NOT NULL").first.parent_tool_call`
- **Expected result**: _instance of AiToolCall_
- **Current result**: `nil`

## Solution
Considered updating the inflection method, but decided it's better to be explicit in this non-standard case. Configuration over convention for once since it's more clear.

# Details
## Type of change

- [x] Bug fix
- [x] New feature
  - (since it adds a new config option)
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code
- [x] I used AI tools to help write this code
    - I generated the spec with claude's help. Checked it and tested edge cases. We should split up that file in the future.
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
  - _added_ to method signature... does that count?
- [ ] No API changes
