### PR TITLE
Fix Vertex AI tool response roles

### DIFF
--- a/lib/ruby_llm/providers/vertexai/chat.rb
+++ b/lib/ruby_llm/providers/vertexai/chat.rb
@@ -5,8 +5,30 @@ module RubyLLM
     class VertexAI
       # Chat methods for the Vertex AI implementation
       module Chat
+        def render_payload(...)
+          payload = super
+          payload[:contents] = normalize_tool_response_roles(payload[:contents])
+          payload
+        end
+
         def completion_url
           "projects/#{@config.vertexai_project_id}/locations/#{@config.vertexai_location}/publishers/google/models/#{@model}:generateContent" # rubocop:disable Layout/LineLength
+        end
+
+        private
+
+        def normalize_tool_response_roles(contents)
+          Array(contents).map do |content|
+            next content unless tool_response_content?(content)
+
+            content.merge(role: 'user')
+          end
+        end
+
+        def tool_response_content?(content)
+          content[:role] == 'function' && Array(content[:parts]).any? do |part|
+            part[:functionResponse]
+          end
         end
       end
     end

--- a/spec/ruby_llm/providers/vertex_ai_spec.rb
+++ b/spec/ruby_llm/providers/vertex_ai_spec.rb
@@ -36,4 +36,28 @@ RSpec.describe RubyLLM::Providers::VertexAI do
       end
     end
   end
+
+  describe '#render_payload' do
+    let(:location) { 'us-central1' }
+    let(:model) { instance_double(RubyLLM::Model::Info, id: 'gemini-3.1-flash-lite-preview') }
+
+    it 'normalizes tool response roles to user for Vertex AI' do
+      messages = [
+        RubyLLM::Message.new(
+          role: :assistant,
+          content: '',
+          tool_calls: {
+            'call_1' => RubyLLM::ToolCall.new(id: 'call_1', name: 'weather', arguments: {})
+          }
+        ),
+        RubyLLM::Message.new(role: :tool, content: 'Sunny', tool_call_id: 'call_1')
+      ]
+
+      payload = provider.send(:render_payload, messages, tools: [], temperature: nil, model: model)
+
+      expect(payload[:contents].last[:role]).to eq('user')
+      expect(payload[:contents].last[:parts][0][:functionResponse][:name]).to eq('weather')
+      expect(payload[:contents].last[:parts][0][:functionResponse][:response]).to include(name: 'weather')
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- normalize Gemini-style tool response messages to `role: 'user'` when Vertex AI builds `generateContent` payloads
- keep the fix scoped to the Vertex AI chat wrapper without changing Gemini's native payload shape
- add a focused provider spec proving function-response payloads use the Vertex AI-compatible role while preserving the existing function response structure

## Validation
- `bundle exec rspec spec/ruby_llm/providers/vertex_ai_spec.rb`
- `bundle exec rubocop lib/ruby_llm/providers/vertexai/chat.rb spec/ruby_llm/providers/vertex_ai_spec.rb`