### PR TITLE
Fix OpenAI search model temperature normalization

### DIFF
--- a/lib/ruby_llm/providers/openai/temperature.rb
+++ b/lib/ruby_llm/providers/openai/temperature.rb
@@ -8,12 +8,12 @@ module RubyLLM
         module_function
 
         def normalize(temperature, model_id)
-          if model_id.match?(/^(o\d|gpt-5)/) && !temperature.nil? && !temperature_close_to_one?(temperature)
-            RubyLLM.logger.debug { "Model #{model_id} requires temperature=1.0, setting that instead." }
-            1.0
-          elsif model_id.include?('-search')
+          if model_id.include?('-search')
             RubyLLM.logger.debug { "Model #{model_id} does not accept temperature parameter, removing" }
             nil
+          elsif model_id.match?(/^(o\d|gpt-5)/) && !temperature.nil? && !temperature_close_to_one?(temperature)
+            RubyLLM.logger.debug { "Model #{model_id} requires temperature=1.0, setting that instead." }
+            1.0
           else
             temperature
           end

--- a/spec/ruby_llm/providers/open_ai/temperature_spec.rb
+++ b/spec/ruby_llm/providers/open_ai/temperature_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe RubyLLM::Providers::OpenAI::Temperature do
       end
     end
 
-    it 'returns nil for search preview models' do
-      %w[gpt-4o-search-preview gpt-4o-mini-search-preview].each do |model|
+    it 'returns nil for search models' do
+      %w[gpt-4o-search-preview gpt-4o-mini-search-preview gpt-5-search-api].each do |model|
         expect(described_class.normalize(0.7, model)).to be_nil
       end
     end


### PR DESCRIPTION
## Summary
- make OpenAI search models drop temperature before the broader gpt-5 normalization branch runs
- add regression coverage for `gpt-5-search-api` alongside the existing search model expectations

## Testing
- `bundle exec rspec spec/ruby_llm/providers/open_ai/temperature_spec.rb -e \"returns nil for search models\"`
- `bundle exec rspec spec/ruby_llm/providers/open_ai/temperature_spec.rb`
- `bundle exec rubocop lib/ruby_llm/providers/openai/temperature.rb spec/ruby_llm/providers/open_ai/temperature_spec.rb`