### PR TITLE
Fix Vertex AI tool response roles

### DIFF
--- a/lib/ruby_llm/providers/vertexai/chat.rb
+++ b/lib/ruby_llm/providers/vertexai/chat.rb
@@ -8,6 +8,14 @@ module RubyLLM
         def completion_url
           "projects/#{@config.vertexai_project_id}/locations/#{@config.vertexai_location}/publishers/google/models/#{@model}:generateContent" # rubocop:disable Layout/LineLength
         end
+
+        def render_payload(messages, **kwargs)
+          payload = super
+          payload[:contents] = payload[:contents].map do |content|
+            content[:role] == 'function' ? content.merge(role: 'user') : content
+          end
+          payload
+        end
       end
     end
   end

--- a/spec/ruby_llm/providers/vertex_ai_spec.rb
+++ b/spec/ruby_llm/providers/vertex_ai_spec.rb
@@ -36,4 +36,49 @@ RSpec.describe RubyLLM::Providers::VertexAI do
       end
     end
   end
+
+  describe '#render_payload' do
+    let(:location) { 'us-central1' }
+    let(:model) do
+      instance_double(RubyLLM::Model::Info, id: 'gemini-2.5-pro', max_tokens: nil, metadata: {})
+    end
+
+    it 'normalizes tool response content roles to user' do
+      tool_message = instance_double(
+        RubyLLM::Message,
+        role: :tool,
+        tool_call_id: 'call_1',
+        content: 'tool output'
+      )
+      user_message = instance_double(
+        RubyLLM::Message,
+        role: :user,
+        tool_call?: false,
+        tool_result?: false,
+        content: 'prompt'
+      )
+
+      payload = provider.send(:render_payload, [tool_message, user_message], tools: {}, temperature: nil, model: model)
+
+      expect(payload[:contents]).to eq(
+        [
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  name: 'call_1',
+                  response: {
+                    name: 'call_1',
+                    content: [{ text: 'tool output' }]
+                  }
+                }
+              }
+            ]
+          },
+          { role: 'user', parts: [{ text: 'prompt' }] }
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- override Vertex AI chat payload rendering so tool response batches use `role: 'user'` instead of inheriting Gemini's `role: 'function'`
- add focused provider coverage that exercises the rendered payload directly

## Testing
- `bundle exec rspec spec/ruby_llm/providers/vertex_ai_spec.rb`
- `bundle exec rubocop lib/ruby_llm/providers/vertexai/chat.rb spec/ruby_llm/providers/vertex_ai_spec.rb`