### PR TITLE
Add Respan to ecosystem docs

### DIFF
--- a/docs/_reference/ecosystem.md
+++ b/docs/_reference/ecosystem.md
@@ -251,7 +251,7 @@ For detailed documentation, setup instructions, and examples, visit the [OpenTel
 
 **AI Gateway, Tracing, and Prompt Management**
 
-[Respan](https://respan.ai) is an LLM platform that provides an AI gateway, tracing, evaluation, and prompt management. Since Respan's gateway is OpenAI-compatible, you can route all RubyLLM traffic through it by changing the base URL — no additional gems required.
+[Respan](https://respan.ai) is an LLM platform that provides an AI gateway, tracing, evaluation, and prompt management. Since Respan's gateway is OpenAI-compatible, you can route RubyLLM requests through it by setting the OpenAI base URL and using `provider: :openai` — no additional gems required.
 
 ### Why Use Respan?
 


### PR DESCRIPTION
## What this does

Adds [Respan](https://respan.ai) to the RubyLLM Ecosystem docs page. Respan is an LLM observability platform with a dedicated [RubyLLM integration](https://respan.ai/docs/integrations/ruby_llm) that works via its OpenAI-compatible gateway — no additional gems required.

Changes:
- New Respan section with gateway setup, key features, and code examples
- Added Respan to the OpenTelemetry section's list of compatible backends (it supports OTLP ingestion)
- Added Respan bullet to the "After reading this guide" list

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

_N/A — documentation-only change._

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [ ] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes