### PR TITLE
Eager-load message associations in to_llm to prevent N+1 queries

### DIFF
--- a/lib/ruby_llm/active_record/chat_methods.rb
+++ b/lib/ruby_llm/active_record/chat_methods.rb
@@ -84,7 +84,7 @@ module RubyLLM
         )
         @chat.reset_messages!
 
-        ordered_messages = order_messages_for_llm(messages_association.to_a)
+        ordered_messages = order_messages_for_llm(eager_load_messages)
         ordered_messages.each do |msg|
           @chat.add_message(msg.to_llm)
         end
@@ -236,7 +236,7 @@ module RubyLLM
 
       def cleanup_orphaned_tool_results # rubocop:disable Metrics/PerceivedComplexity
         messages_association.reload
-        last = messages_association.order(:id).last
+        last = eager_load_messages.max_by(&:id)
 
         return unless last&.tool_call? || last&.tool_result?
 
@@ -253,6 +253,16 @@ module RubyLLM
             tool_call_message.destroy
           end
         end
+      end
+
+      def eager_load_messages
+        assoc = messages_association
+        return assoc.to_a unless assoc.respond_to?(:includes)
+
+        msg_class = assoc.klass
+        tool_calls_name = msg_class.tool_calls_association_name
+        model_name = msg_class.model_association_name
+        assoc.includes(tool_calls_name, :parent_tool_call, model_name).to_a
       end
 
       def setup_persistence_callbacks

--- a/lib/ruby_llm/active_record/chat_methods.rb
+++ b/lib/ruby_llm/active_record/chat_methods.rb
@@ -61,7 +61,7 @@ module RubyLLM
           provider: model_record.provider.to_sym,
           assume_model_exists: assume_model_exists || false
         )
-        @chat.messages = messages_association.to_a
+        @chat.messages = eager_load_messages
         reapply_runtime_instructions(@chat)
 
         setup_persistence_callbacks
@@ -282,7 +282,7 @@ module RubyLLM
 
       def cleanup_orphaned_tool_results # rubocop:disable Metrics/PerceivedComplexity
         messages_association.reload
-        last = messages_association.order(:id).last
+        last = eager_load_messages.max_by(&:id)
 
         return unless last&.tool_call? || last&.tool_result?
 
@@ -299,6 +299,22 @@ module RubyLLM
             tool_call_message.destroy
           end
         end
+      end
+
+      def eager_load_messages
+        assoc = messages_association
+        messages = assoc.to_a
+        return messages unless assoc.respond_to?(:klass)
+
+        msg_class = assoc.klass
+        associations = [
+          msg_class.tool_calls_association_name,
+          :parent_tool_call,
+          msg_class.model_association_name
+        ].compact
+
+        ::ActiveRecord::Associations::Preloader.new(records: messages, associations: associations).call
+        messages
       end
 
       def find_or_create_model_record(model_info)

--- a/spec/ruby_llm/active_record/acts_as_spec.rb
+++ b/spec/ruby_llm/active_record/acts_as_spec.rb
@@ -960,6 +960,43 @@ RSpec.describe RubyLLM::ActiveRecord::ActsAs do
     end
   end
 
+  describe 'strict_loading compatibility' do
+    # Verify that to_llm and cleanup_orphaned_tool_results eager-load message
+    # associations, preventing N+1 queries with strict_loading enabled.
+
+    let(:chat_with_tool_calls) do
+      chat = Chat.create!(model: model)
+      chat.messages.create!(role: 'user', content: "What's 2 + 2?")
+      assistant_msg = chat.messages.create!(role: 'assistant', content: nil)
+      tool_call = assistant_msg.tool_calls.create!(
+        tool_call_id: 'call_strict_1',
+        name: 'calculator',
+        arguments: { expression: '2 + 2' }.to_json
+      )
+      chat.messages.create!(role: 'tool', content: '4', parent_tool_call: tool_call)
+      chat.messages.create!(role: 'assistant', content: 'The answer is 4.')
+      chat
+    end
+
+    around do |example|
+      chat_with_tool_calls # create data before enabling strict_loading
+      ApplicationRecord.strict_loading_by_default = true
+      ApplicationRecord.strict_loading_mode = :n_plus_one_only
+      example.run
+    ensure
+      ApplicationRecord.strict_loading_by_default = false
+      ApplicationRecord.strict_loading_mode = :all
+    end
+
+    it 'to_llm does not raise StrictLoadingViolationError' do
+      expect { chat_with_tool_calls.reload.to_llm }.not_to raise_error
+    end
+
+    it 'cleanup_orphaned_tool_results does not raise StrictLoadingViolationError' do
+      expect { chat_with_tool_calls.reload.send(:cleanup_orphaned_tool_results) }.not_to raise_error
+    end
+  end
+
   describe 'extended thinking persistence' do
     def thinking_config_for(provider)
       case provider

--- a/spec/ruby_llm/active_record/acts_as_spec.rb
+++ b/spec/ruby_llm/active_record/acts_as_spec.rb
@@ -1136,6 +1136,48 @@ RSpec.describe RubyLLM::ActiveRecord::ActsAs do
     end
   end
 
+  describe 'strict_loading compatibility' do
+    # Verify that to_llm and cleanup_orphaned_tool_results eager-load message
+    # associations, preventing N+1 queries with strict_loading enabled.
+
+    let(:strict_loading_state) { {} }
+
+    let!(:chat_with_tool_calls) do
+      chat = Chat.create!(model: model)
+      chat.messages.create!(role: 'user', content: "What's 2 + 2?")
+      assistant_msg = chat.messages.create!(role: 'assistant', content: nil)
+      tool_call = assistant_msg.tool_calls.create!(
+        tool_call_id: 'call_strict_1',
+        name: 'calculator',
+        arguments: { expression: '2 + 2' }.to_json
+      )
+      chat.messages.create!(role: 'tool', content: '4', parent_tool_call: tool_call)
+      chat.messages.create!(role: 'assistant', content: 'The answer is 4.')
+      chat
+    end
+
+    before do
+      strict_loading_state[:by_default] = ApplicationRecord.strict_loading_by_default
+      strict_loading_state[:mode] = ApplicationRecord.strict_loading_mode
+
+      ApplicationRecord.strict_loading_by_default = true
+      ApplicationRecord.strict_loading_mode = :n_plus_one_only
+    end
+
+    after do
+      ApplicationRecord.strict_loading_by_default = strict_loading_state[:by_default]
+      ApplicationRecord.strict_loading_mode = strict_loading_state[:mode]
+    end
+
+    it 'to_llm does not raise StrictLoadingViolationError' do
+      expect { chat_with_tool_calls.reload.to_llm }.not_to raise_error
+    end
+
+    it 'cleanup_orphaned_tool_results does not raise StrictLoadingViolationError' do
+      expect { chat_with_tool_calls.reload.send(:cleanup_orphaned_tool_results) }.not_to raise_error
+    end
+  end
+
   describe 'extended thinking persistence' do
     def thinking_config_for(provider)
       case provider


### PR DESCRIPTION
## What this does

`ChatMethods#to_llm` loads all messages via `messages_association.to_a`, then iterates calling `msg.to_llm` on each. `Message#to_llm` accesses `tool_calls`, `parent_tool_call`, and `model` associations per message — an N+1 query pattern.

This is invisible without `strict_loading`, but with Rails' `strict_loading_by_default = true` and `:n_plus_one_only` mode, every call to `conversation.ask` raises `ActiveRecord::StrictLoadingViolationError`.

The same issue exists in `cleanup_orphaned_tool_results`, which reloads messages and accesses `tool_call?` / `tool_result?` on the last message without eager-loading.

Fix: add an `eager_load_messages` helper that preloads `tool_calls`, `parent_tool_call`, and `model` in a single query. Falls back to plain `.to_a` when `messages_association` is not an ActiveRecord relation (e.g. in test stubs).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
- [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
- [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes