### PR TITLE
feat(config): Add RUBYLLM_LOG_FILE default logger path

### DIFF
--- a/lib/ruby_llm/configuration.rb
+++ b/lib/ruby_llm/configuration.rb
@@ -51,7 +51,7 @@ module RubyLLM
     option :http_proxy, nil
 
     option :logger, nil
-    option :log_file, -> { $stdout }
+    option :log_file, -> { ENV['RUBYLLM_LOG_FILE'] || $stdout }
     option :log_level, -> { ENV['RUBYLLM_DEBUG'] ? Logger::DEBUG : Logger::INFO }
     option :log_stream_debug, -> { ENV['RUBYLLM_STREAM_DEBUG'] == 'true' }
     option :log_regexp_timeout, -> { Regexp.respond_to?(:timeout) ? (Regexp.timeout || 1.0) : nil }

--- a/spec/ruby_llm_spec.rb
+++ b/spec/ruby_llm_spec.rb
@@ -46,5 +46,23 @@ RSpec.describe RubyLLM do
         expect(described_class.logger).to eq(logger)
       end
     end
+
+    context 'with RUBYLLM_LOG_FILE set' do
+      around do |example|
+        original_log_file = ENV.fetch('RUBYLLM_LOG_FILE', nil)
+        ENV['RUBYLLM_LOG_FILE'] = '/tmp/ruby_llm.log'
+        example.run
+      ensure
+        ENV['RUBYLLM_LOG_FILE'] = original_log_file
+      end
+
+      it 'uses the env var as the default log file' do
+        allow(Logger).to receive(:new)
+          .with('/tmp/ruby_llm.log', progname: 'RubyLLM', level: Logger::INFO)
+          .and_return(logger)
+
+        expect(described_class.logger).to eq(logger)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- refresh the old `RUBYLLM_LOG_FILE` support patch onto current `main`
- let `RubyLLM::Configuration.log_file` default to `ENV['RUBYLLM_LOG_FILE']` before falling back to `$stdout`
- keep logger behavior unchanged when a custom logger or explicit `config.log_file` is provided

## Validation

- `bundle exec rspec spec/ruby_llm_spec.rb`
- `bundle exec rubocop lib/ruby_llm/configuration.rb spec/ruby_llm_spec.rb`