### PR TITLE
Handle nil response bodies consistently across providers

### DIFF
--- a/lib/ruby_llm/provider.rb
+++ b/lib/ruby_llm/provider.rb
@@ -112,7 +112,7 @@ module RubyLLM
     end
 
     def parse_error(response)
-      return if response.body.empty?
+      return if response.body.nil? || response.body.empty?
 
       body = try_parse_json(response.body)
       case body
@@ -266,7 +266,13 @@ module RubyLLM
       response = connection.post completion_url, payload do |req|
         req.headers = additional_headers.merge(req.headers) unless additional_headers.empty?
       end
+      ensure_response_body!(response)
+
       parse_completion_response response
+    end
+
+    def ensure_response_body!(response)
+      raise Error.new(response, 'Provider returned an empty response body') if response.body.nil?
     end
   end
 end

--- a/lib/ruby_llm/provider.rb
+++ b/lib/ruby_llm/provider.rb
@@ -272,7 +272,10 @@ module RubyLLM
     end
 
     def ensure_response_body!(response)
-      raise Error.new(response, 'Provider returned an empty response body') if response.body.nil?
+      body = response.body
+      return unless body.nil? || (body.respond_to?(:empty?) && body.empty?)
+
+      raise Error.new(response, 'Provider returned an empty response body')
     end
   end
 end

--- a/lib/ruby_llm/providers/anthropic/chat.rb
+++ b/lib/ruby_llm/providers/anthropic/chat.rb
@@ -84,6 +84,8 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
+          raise Error.new(response, 'Provider returned an empty response body') if data.nil?
+
           content_blocks = data['content'] || []
 
           text_content = extract_text_content(content_blocks)

--- a/lib/ruby_llm/providers/anthropic/chat.rb
+++ b/lib/ruby_llm/providers/anthropic/chat.rb
@@ -84,7 +84,7 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
-          raise Error.new(response, 'Provider returned an empty response body') if data.nil?
+          raise Error.new(response, 'Provider returned an empty response body') if data.nil? || data.empty?
 
           content_blocks = data['content'] || []
 

--- a/lib/ruby_llm/providers/bedrock/auth.rb
+++ b/lib/ruby_llm/providers/bedrock/auth.rb
@@ -21,6 +21,7 @@ module RubyLLM
             yield req if block_given?
           end
 
+          ensure_response_body!(response)
           parse_completion_response(response)
         end
 

--- a/lib/ruby_llm/providers/bedrock/chat.rb
+++ b/lib/ruby_llm/providers/bedrock/chat.rb
@@ -45,7 +45,8 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
-          return if data.nil? || data.empty?
+          raise Error.new(response, 'Provider returned an empty response body') if data.nil?
+          return if data.empty?
 
           content_blocks = data.dig('output', 'message', 'content') || []
           usage = data['usage'] || {}

--- a/lib/ruby_llm/providers/bedrock/chat.rb
+++ b/lib/ruby_llm/providers/bedrock/chat.rb
@@ -45,8 +45,7 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
-          raise Error.new(response, 'Provider returned an empty response body') if data.nil?
-          return if data.empty?
+          raise Error.new(response, 'Provider returned an empty response body') if data.nil? || data.empty?
 
           content_blocks = data.dig('output', 'message', 'content') || []
           usage = data['usage'] || {}

--- a/lib/ruby_llm/providers/gemini/chat.rb
+++ b/lib/ruby_llm/providers/gemini/chat.rb
@@ -107,6 +107,8 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
+          raise Error.new(response, 'Provider returned an empty response body') if data.nil?
+
           parts = data.dig('candidates', 0, 'content', 'parts') || []
           tool_calls = extract_tool_calls(data)
 

--- a/lib/ruby_llm/providers/gemini/chat.rb
+++ b/lib/ruby_llm/providers/gemini/chat.rb
@@ -107,7 +107,7 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
-          raise Error.new(response, 'Provider returned an empty response body') if data.nil?
+          raise Error.new(response, 'Provider returned an empty response body') if data.nil? || data.empty?
 
           parts = data.dig('candidates', 0, 'content', 'parts') || []
           tool_calls = extract_tool_calls(data)

--- a/lib/ruby_llm/providers/openai/chat.rb
+++ b/lib/ruby_llm/providers/openai/chat.rb
@@ -53,6 +53,8 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
+          raise Error.new(response, 'Provider returned an empty response body') if data.nil?
+
           return if data.empty?
 
           raise Error.new(response, data.dig('error', 'message')) if data.dig('error', 'message')

--- a/lib/ruby_llm/providers/openai/chat.rb
+++ b/lib/ruby_llm/providers/openai/chat.rb
@@ -53,9 +53,7 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
-          raise Error.new(response, 'Provider returned an empty response body') if data.nil?
-
-          return if data.empty?
+          raise Error.new(response, 'Provider returned an empty response body') if data.nil? || data.empty?
 
           raise Error.new(response, data.dig('error', 'message')) if data.dig('error', 'message')
 

--- a/lib/ruby_llm/providers/openrouter.rb
+++ b/lib/ruby_llm/providers/openrouter.rb
@@ -20,7 +20,7 @@ module RubyLLM
       end
 
       def parse_error(response)
-        return if response.body.empty?
+        return if response.body.nil? || response.body.empty?
 
         body = try_parse_json(response.body)
         case body

--- a/lib/ruby_llm/providers/openrouter/chat.rb
+++ b/lib/ruby_llm/providers/openrouter/chat.rb
@@ -52,6 +52,8 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
+          raise Error.new(response, 'Provider returned an empty response body') if data.nil?
+
           return if data.empty?
 
           raise Error.new(response, data.dig('error', 'message')) if data.dig('error', 'message')

--- a/lib/ruby_llm/providers/openrouter/chat.rb
+++ b/lib/ruby_llm/providers/openrouter/chat.rb
@@ -52,9 +52,7 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
-          raise Error.new(response, 'Provider returned an empty response body') if data.nil?
-
-          return if data.empty?
+          raise Error.new(response, 'Provider returned an empty response body') if data.nil? || data.empty?
 
           raise Error.new(response, data.dig('error', 'message')) if data.dig('error', 'message')
 

--- a/lib/ruby_llm/providers/perplexity.rb
+++ b/lib/ruby_llm/providers/perplexity.rb
@@ -34,7 +34,7 @@ module RubyLLM
 
       def parse_error(response)
         body = response.body
-        return if body.empty?
+        return if body.nil? || body.empty?
 
         # If response is HTML (Perplexity returns HTML for auth errors)
         if body.include?('<html>') && body.include?('<title>')

--- a/spec/ruby_llm/provider_spec.rb
+++ b/spec/ruby_llm/provider_spec.rb
@@ -3,6 +3,57 @@
 require 'spec_helper'
 
 RSpec.describe RubyLLM::Provider do
+  describe '#sync_response' do
+    let(:provider_class) do
+      Class.new(described_class) do
+        def api_base
+          'https://example.com'
+        end
+
+        def completion_url
+          'chat/completions'
+        end
+
+        def parse_completion_response(_response)
+          :parsed
+        end
+      end
+    end
+    let(:provider) { provider_class.new(RubyLLM::Configuration.new) }
+
+    it 'raises RubyLLM::Error for nil completion bodies' do
+      request = instance_double(Faraday::Request, headers: {})
+      response = instance_double(Faraday::Response, body: nil)
+      connection = instance_double(RubyLLM::Connection)
+
+      allow(connection).to receive(:post)
+        .with('chat/completions', { prompt: 'hello' })
+        .and_yield(request)
+        .and_return(response)
+
+      expect do
+        provider.send(:sync_response, connection, { prompt: 'hello' })
+      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+    end
+  end
+
+  describe '#parse_error' do
+    let(:provider_class) do
+      Class.new(described_class) do
+        def api_base
+          'https://example.com'
+        end
+      end
+    end
+    let(:provider) { provider_class.new(RubyLLM::Configuration.new) }
+
+    it 'returns nil when the response body is nil' do
+      response = Struct.new(:body).new(nil)
+
+      expect(provider.parse_error(response)).to be_nil
+    end
+  end
+
   describe '.register' do
     it 'registers provider configuration options on Configuration' do
       provider_key = :test_provider_spec

--- a/spec/ruby_llm/provider_spec.rb
+++ b/spec/ruby_llm/provider_spec.rb
@@ -35,6 +35,21 @@ RSpec.describe RubyLLM::Provider do
         provider.send(:sync_response, connection, { prompt: 'hello' })
       end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
     end
+
+    it 'raises RubyLLM::Error for empty completion bodies' do
+      request = instance_double(Faraday::Request, headers: {})
+      response = instance_double(Faraday::Response, body: {})
+      connection = instance_double(RubyLLM::Connection)
+
+      allow(connection).to receive(:post)
+        .with('chat/completions', { prompt: 'hello' })
+        .and_yield(request)
+        .and_return(response)
+
+      expect do
+        provider.send(:sync_response, connection, { prompt: 'hello' })
+      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+    end
   end
 
   describe '#parse_error' do

--- a/spec/ruby_llm/providers/anthropic/chat_spec.rb
+++ b/spec/ruby_llm/providers/anthropic/chat_spec.rb
@@ -134,6 +134,14 @@ RSpec.describe RubyLLM::Providers::Anthropic::Chat do
   end
 
   describe '.parse_completion_response' do
+    it 'raises RubyLLM::Error for nil completion bodies' do
+      response = instance_double(Faraday::Response, body: nil)
+
+      expect do
+        described_class.parse_completion_response(response)
+      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+    end
+
     it 'captures cache usage metrics on the message' do
       response_body = {
         'model' => 'claude-sonnet-4-5-20250929',

--- a/spec/ruby_llm/providers/anthropic/chat_spec.rb
+++ b/spec/ruby_llm/providers/anthropic/chat_spec.rb
@@ -134,12 +134,14 @@ RSpec.describe RubyLLM::Providers::Anthropic::Chat do
   end
 
   describe '.parse_completion_response' do
-    it 'raises RubyLLM::Error for nil completion bodies' do
-      response = instance_double(Faraday::Response, body: nil)
+    it 'raises RubyLLM::Error for nil or empty completion bodies' do
+      [nil, {}].each do |body|
+        response = instance_double(Faraday::Response, body: body)
 
-      expect do
-        described_class.parse_completion_response(response)
-      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+        expect do
+          described_class.parse_completion_response(response)
+        end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+      end
     end
 
     it 'captures cache usage metrics on the message' do

--- a/spec/ruby_llm/providers/bedrock/chat_spec.rb
+++ b/spec/ruby_llm/providers/bedrock/chat_spec.rb
@@ -3,6 +3,16 @@
 require 'spec_helper'
 
 RSpec.describe RubyLLM::Providers::Bedrock::Chat do
+  describe '.parse_completion_response' do
+    it 'raises RubyLLM::Error for nil completion bodies' do
+      response = instance_double(Faraday::Response, body: nil)
+
+      expect do
+        described_class.parse_completion_response(response)
+      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+    end
+  end
+
   describe '.render_tool_result_content' do
     it 'uses a placeholder when the tool returns no content' do
       result = described_class.render_tool_result_content('')

--- a/spec/ruby_llm/providers/bedrock/chat_spec.rb
+++ b/spec/ruby_llm/providers/bedrock/chat_spec.rb
@@ -4,12 +4,14 @@ require 'spec_helper'
 
 RSpec.describe RubyLLM::Providers::Bedrock::Chat do
   describe '.parse_completion_response' do
-    it 'raises RubyLLM::Error for nil completion bodies' do
-      response = instance_double(Faraday::Response, body: nil)
+    it 'raises RubyLLM::Error for nil or empty completion bodies' do
+      [nil, {}].each do |body|
+        response = instance_double(Faraday::Response, body: body)
 
-      expect do
-        described_class.parse_completion_response(response)
-      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+        expect do
+          described_class.parse_completion_response(response)
+        end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+      end
     end
   end
 

--- a/spec/ruby_llm/providers/gemini/chat_spec.rb
+++ b/spec/ruby_llm/providers/gemini/chat_spec.rb
@@ -525,6 +525,19 @@ RSpec.describe RubyLLM::Providers::Gemini::Chat do
   end
 
   describe '#parse_completion_response' do
+    it 'raises RubyLLM::Error for nil completion bodies' do
+      response = Struct.new(:body, :env).new(
+        nil,
+        Struct.new(:url).new(Struct.new(:path).new('/v1/models/gemini-2.5-flash:generateContent'))
+      )
+
+      provider = RubyLLM::Providers::Gemini.new(RubyLLM.config)
+
+      expect do
+        provider.send(:parse_completion_response, response)
+      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+    end
+
     it 'keeps thought-only parts out of assistant content' do
       response = Struct.new(:body, :env).new(
         {

--- a/spec/ruby_llm/providers/gemini/chat_spec.rb
+++ b/spec/ruby_llm/providers/gemini/chat_spec.rb
@@ -525,17 +525,19 @@ RSpec.describe RubyLLM::Providers::Gemini::Chat do
   end
 
   describe '#parse_completion_response' do
-    it 'raises RubyLLM::Error for nil completion bodies' do
-      response = Struct.new(:body, :env).new(
-        nil,
-        Struct.new(:url).new(Struct.new(:path).new('/v1/models/gemini-2.5-flash:generateContent'))
-      )
-
+    it 'raises RubyLLM::Error for nil or empty completion bodies' do
       provider = RubyLLM::Providers::Gemini.new(RubyLLM.config)
 
-      expect do
-        provider.send(:parse_completion_response, response)
-      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+      [nil, {}].each do |body|
+        response = Struct.new(:body, :env).new(
+          body,
+          Struct.new(:url).new(Struct.new(:path).new('/v1/models/gemini-2.5-flash:generateContent'))
+        )
+
+        expect do
+          provider.send(:parse_completion_response, response)
+        end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+      end
     end
 
     it 'keeps thought-only parts out of assistant content' do

--- a/spec/ruby_llm/providers/open_ai/chat_spec.rb
+++ b/spec/ruby_llm/providers/open_ai/chat_spec.rb
@@ -4,6 +4,14 @@ require 'spec_helper'
 
 RSpec.describe RubyLLM::Providers::OpenAI::Chat do
   describe '.parse_completion_response' do
+    it 'raises RubyLLM::Error for nil completion bodies' do
+      response = instance_double(Faraday::Response, body: nil)
+
+      expect do
+        described_class.parse_completion_response(response)
+      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+    end
+
     it 'captures cached token information when present' do
       response_body = {
         'model' => 'gpt-4.1-nano',

--- a/spec/ruby_llm/providers/open_ai/chat_spec.rb
+++ b/spec/ruby_llm/providers/open_ai/chat_spec.rb
@@ -4,12 +4,14 @@ require 'spec_helper'
 
 RSpec.describe RubyLLM::Providers::OpenAI::Chat do
   describe '.parse_completion_response' do
-    it 'raises RubyLLM::Error for nil completion bodies' do
-      response = instance_double(Faraday::Response, body: nil)
+    it 'raises RubyLLM::Error for nil or empty completion bodies' do
+      [nil, {}].each do |body|
+        response = instance_double(Faraday::Response, body: body)
 
-      expect do
-        described_class.parse_completion_response(response)
-      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+        expect do
+          described_class.parse_completion_response(response)
+        end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+      end
     end
 
     it 'captures cached token information when present' do

--- a/spec/ruby_llm/providers/open_router/chat_spec.rb
+++ b/spec/ruby_llm/providers/open_router/chat_spec.rb
@@ -3,6 +3,16 @@
 require 'spec_helper'
 
 RSpec.describe RubyLLM::Providers::OpenRouter::Chat do
+  describe '.parse_completion_response' do
+    it 'raises RubyLLM::Error for nil completion bodies' do
+      response = instance_double(Faraday::Response, body: nil)
+
+      expect do
+        described_class.parse_completion_response(response)
+      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+    end
+  end
+
   describe '.render_payload' do
     let(:model) { instance_double(RubyLLM::Model::Info, id: 'anthropic/claude-haiku-4.5') }
     let(:messages) { [RubyLLM::Message.new(role: :user, content: 'Hello')] }

--- a/spec/ruby_llm/providers/open_router/chat_spec.rb
+++ b/spec/ruby_llm/providers/open_router/chat_spec.rb
@@ -4,12 +4,14 @@ require 'spec_helper'
 
 RSpec.describe RubyLLM::Providers::OpenRouter::Chat do
   describe '.parse_completion_response' do
-    it 'raises RubyLLM::Error for nil completion bodies' do
-      response = instance_double(Faraday::Response, body: nil)
+    it 'raises RubyLLM::Error for nil or empty completion bodies' do
+      [nil, {}].each do |body|
+        response = instance_double(Faraday::Response, body: body)
 
-      expect do
-        described_class.parse_completion_response(response)
-      end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+        expect do
+          described_class.parse_completion_response(response)
+        end.to raise_error(RubyLLM::Error, 'Provider returned an empty response body')
+      end
     end
   end
 

--- a/spec/ruby_llm/providers/open_router/parse_error_spec.rb
+++ b/spec/ruby_llm/providers/open_router/parse_error_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe RubyLLM::Providers::OpenRouter do # rubocop:disable RSpec/SpecFil
   end
 
   describe '#parse_error' do
+    it 'returns nil when the response body is nil' do
+      response = instance_double(Faraday::Response, body: nil)
+
+      expect(provider.parse_error(response)).to be_nil
+    end
+
     it 'appends nested provider message from metadata.raw when present' do
       response = instance_double(
         Faraday::Response,

--- a/spec/ruby_llm/providers/perplexity_spec.rb
+++ b/spec/ruby_llm/providers/perplexity_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::Perplexity do
+  let(:provider) do
+    config = RubyLLM::Configuration.new
+    config.perplexity_api_key = 'test'
+    described_class.new(config)
+  end
+
+  describe '#parse_error' do
+    it 'returns nil when the response body is nil' do
+      response = instance_double(Faraday::Response, body: nil)
+
+      expect(provider.parse_error(response)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Faraday JSON middleware can normalize empty HTTP bodies to nil, but ruby_llm still assumed response.body was always non-nil in several sync completion and error parsing paths. That leaked as NoMethodError from provider parsers instead of raising a RubyLLM::Error with a useful message.

Centralize the sync completion invariant in Provider by adding ensure_response_body! and calling it from Provider#sync_response. Apply the same guard to Bedrock's custom signed sync path so override implementations follow the same contract.

Harden provider-specific parsers that were still nil-fragile:
- OpenAI::Chat#parse_completion_response
- OpenRouter::Chat#parse_completion_response
- Anthropic::Chat#parse_completion_response
- Gemini::Chat#parse_completion_response
- Bedrock::Chat#parse_completion_response
- Provider#parse_error
- OpenRouter#parse_error
- Perplexity#parse_error

Standardize nil sync completion bodies to raise:
  RubyLLM::Error, "Provider returned an empty response body"

Add regression coverage for:
- Provider#sync_response nil-body handling
- Provider/OpenRouter/Perplexity parse_error nil-body handling
- OpenAI/OpenRouter/Anthropic/Gemini/Bedrock chat parser nil-body handling

This keeps empty-body failures inside the gem's error model and makes nil-body behavior consistent across the provider stack.

## What this does

<!-- Clear description of what this PR does and why -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

<!-- Skip this section for bug fixes and documentation -->

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: #___

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [ ] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes
