### PR TITLE
Add `with:` parameter to Image.paint for provider-specific params (closes #623)

### DIFF
--- a/lib/ruby_llm/image.rb
+++ b/lib/ruby_llm/image.rb
@@ -31,19 +31,33 @@ module RubyLLM
       path
     end
 
+    # Generate an image from a text prompt.
+    #
+    # @param prompt [String] the description of the image to generate
+    # @param model [String, nil] the image model to use (defaults to config.default_image_model)
+    # @param provider [Symbol, nil] force a specific provider
+    # @param assume_model_exists [Boolean] skip the model registry check
+    # @param size [String] image dimensions (provider-dependent; ignored by providers that do not support it)
+    # @param context [RubyLLM::Context, nil] per-call configuration override
+    # @param with [Hash] provider-specific parameters merged into the API payload as-is
+    #   (e.g. quality: "medium", output_format: "jpeg" for OpenAI gpt-image-1,
+    #   or personGeneration: "ALLOW_ADULT" for Gemini imagen). Not validated
+    #   client-side; the provider API will either use or reject unknown keys.
+    # @return [RubyLLM::Image]
     def self.paint(prompt, # rubocop:disable Metrics/ParameterLists
                    model: nil,
                    provider: nil,
                    assume_model_exists: false,
                    size: '1024x1024',
-                   context: nil)
+                   context: nil,
+                   with: {})
       config = context&.config || RubyLLM.config
       model ||= config.default_image_model
       model, provider_instance = Models.resolve(model, provider: provider, assume_exists: assume_model_exists,
                                                        config: config)
       model_id = model.id
 
-      provider_instance.paint(prompt, model: model_id, size:)
+      provider_instance.paint(prompt, model: model_id, size:, params: with)
     end
   end
 end

--- a/lib/ruby_llm/provider.rb
+++ b/lib/ruby_llm/provider.rb
@@ -81,8 +81,8 @@ module RubyLLM
       parse_moderation_response(response, model:)
     end
 
-    def paint(prompt, model:, size:)
-      payload = render_image_payload(prompt, model:, size:)
+    def paint(prompt, model:, size:, params: {})
+      payload = render_image_payload(prompt, model:, size:, params: params)
       response = @connection.post images_url, payload
       parse_image_response(response, model:)
     end

--- a/lib/ruby_llm/providers/gemini/images.rb
+++ b/lib/ruby_llm/providers/gemini/images.rb
@@ -9,10 +9,10 @@ module RubyLLM
           "models/#{@model}:predict"
         end
 
-        def render_image_payload(prompt, model:, size:)
+        def render_image_payload(prompt, model:, size:, params: {})
           RubyLLM.logger.debug { "Ignoring size #{size}. Gemini does not support image size customization." }
           @model = model
-          {
+          payload = {
             instances: [
               {
                 prompt: prompt
@@ -22,6 +22,8 @@ module RubyLLM
               sampleCount: 1
             }
           }
+          payload[:parameters].merge!(params) unless params.empty?
+          payload
         end
 
         def parse_image_response(response, model:)

--- a/lib/ruby_llm/providers/openai/images.rb
+++ b/lib/ruby_llm/providers/openai/images.rb
@@ -11,13 +11,13 @@ module RubyLLM
           'images/generations'
         end
 
-        def render_image_payload(prompt, model:, size:)
+        def render_image_payload(prompt, model:, size:, params: {})
           {
             model: model,
             prompt: prompt,
             n: 1,
             size: size
-          }
+          }.merge(params)
         end
 
         def parse_image_response(response, model:)

--- a/lib/ruby_llm/providers/openrouter/images.rb
+++ b/lib/ruby_llm/providers/openrouter/images.rb
@@ -13,7 +13,7 @@ module RubyLLM
           'chat/completions'
         end
 
-        def render_image_payload(prompt, model:, size:)
+        def render_image_payload(prompt, model:, size:, params: {})
           RubyLLM.logger.debug { "Ignoring size #{size}. OpenRouter image generation does not support size parameter." }
           {
             model: model,
@@ -24,7 +24,7 @@ module RubyLLM
               }
             ],
             modalities: %w[image text]
-          }
+          }.merge(params)
         end
 
         def parse_image_response(response, model:)

--- a/spec/ruby_llm/image_paint_with_params_spec.rb
+++ b/spec/ruby_llm/image_paint_with_params_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Image, '.paint' do
+  describe 'OpenAI render_image_payload with params' do
+    it 'merges custom params like quality, output_format, n' do
+      payload = RubyLLM::Providers::OpenAI::Images.render_image_payload(
+        'a cat',
+        model: 'gpt-image-1',
+        size: '1024x1024',
+        params: { quality: 'medium', output_format: 'jpeg', output_compression: 80 }
+      )
+      expect(payload[:model]).to eq('gpt-image-1')
+      expect(payload[:prompt]).to eq('a cat')
+      expect(payload[:size]).to eq('1024x1024')
+      expect(payload[:quality]).to eq('medium')
+      expect(payload[:output_format]).to eq('jpeg')
+      expect(payload[:output_compression]).to eq(80)
+    end
+
+    it 'default (no params) is unchanged' do
+      payload = RubyLLM::Providers::OpenAI::Images.render_image_payload(
+        'a cat',
+        model: 'dall-e-3',
+        size: '1024x1024'
+      )
+      expect(payload).to eq({ model: 'dall-e-3', prompt: 'a cat', n: 1, size: '1024x1024' })
+    end
+
+    it 'params override defaults when keys collide (e.g. n)' do
+      payload = RubyLLM::Providers::OpenAI::Images.render_image_payload(
+        'a cat',
+        model: 'dall-e-3',
+        size: '1024x1024',
+        params: { n: 3 }
+      )
+      expect(payload[:n]).to eq(3)
+    end
+  end
+
+  describe 'Gemini render_image_payload with params' do
+    let(:provider) do
+      Class.new do
+        include RubyLLM::Providers::Gemini::Images
+      end.new
+    end
+
+    it 'merges params into parameters hash (not top level)' do
+      payload = provider.render_image_payload(
+        'a cat',
+        model: 'imagen-3',
+        size: '1024x1024',
+        params: { personGeneration: 'ALLOW_ADULT', aspectRatio: '16:9' }
+      )
+      expect(payload[:parameters][:personGeneration]).to eq('ALLOW_ADULT')
+      expect(payload[:parameters][:aspectRatio]).to eq('16:9')
+      expect(payload[:parameters][:sampleCount]).to eq(1)
+    end
+  end
+
+  describe 'OpenRouter render_image_payload with params' do
+    it 'merges params at top level of chat-completions-shaped payload' do
+      payload = RubyLLM::Providers::OpenRouter::Images.render_image_payload(
+        'a cat',
+        model: 'anthropic/claude-3-opus',
+        size: '1024x1024',
+        params: { temperature: 0.5 }
+      )
+      expect(payload[:temperature]).to eq(0.5)
+    end
+  end
+end


### PR DESCRIPTION
## Closes #623

## Summary

Chat already supports arbitrary provider-specific parameters via `with_params` ([docs](https://rubyllm.com/chat/#provider-specific-parameters)). Image generation did not — `Image.paint` only forwarded `size`. OpenAI's `gpt-image-1` exposes `quality`, `output_format`, `output_compression`, `background`; Gemini imagen exposes `personGeneration`, `aspectRatio`; DALL-E 3 has `response_format`. Application code had no way to reach them without dropping down to raw `Faraday` / `ruby-openai`.

This patch mirrors the Chat pattern on the image side:

```ruby
RubyLLM.paint('a cat', model: 'gpt-image-1', with: {
  quality: 'medium',           # $0.063/image vs default ~$0.25
  output_format: 'jpeg',
  output_compression: 80
})
```

## Design

- `Image.paint` accepts `with: {}` (default empty — backward compatible).
- `Provider#paint` forwards a `params:` kwarg to `render_image_payload`.
- `OpenAI` / `Gemini` / `OpenRouter` `render_image_payload` merge params into their provider-specific payload shape:
  - OpenAI / OpenRouter: merged at top level
  - Gemini: merged into the nested `:parameters` hash (imagen instances-based API)

## Philosophy

Consistent with Chat's existing `with_params`: the gem does **not** validate provider-specific keys. Users know their provider's API surface; unknown keys are either used or rejected by the provider. This avoids the maintenance burden of tracking every parameter OpenAI / Google / Anthropic add each quarter.

Documented in the YARD comment on `Image.paint`.

## Tests

`spec/ruby_llm/image_paint_with_params_spec.rb` — pure-unit tests on the payload builders:

- OpenAI: quality / output_format / output_compression merged in
- OpenAI: default (no `with:`) produces identical payload as before
- OpenAI: params override default keys on collision (e.g. `n: 3`)
- Gemini: params merge into `:parameters` (not top level)
- OpenRouter: params merge into chat-completions-shaped payload

All 5 pass. Rubocop clean.

## Backward compatibility

Every existing caller keeps working (new kwarg defaults to `{}`). No breaking change.

## Real-world motivation

Working on a Rails app generating ~30 blog hero images/month. Current path uses `ruby-openai` just for that one feature, keeping two HTTP stacks in production. Moving to `RubyLLM.paint` with `quality: 'medium'` cuts cost 4× vs default and lets the app drop `ruby-openai` entirely. #623 is the blocker — this PR unblocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
