### PR TITLE
Add claude-opus-4-7 model

### DIFF
--- a/lib/ruby_llm/models.json
+++ b/lib/ruby_llm/models.json
@@ -894,6 +894,59 @@
     }
   },
   {
+    "id": "claude-opus-4-7",
+    "name": "Claude Opus 4.7",
+    "provider": "anthropic",
+    "family": "claude-opus",
+    "created_at": "2026-04-22 00:00:00 UTC",
+    "context_window": 1000000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-04-22",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 128000
+      },
+      "knowledge": "2025-08"
+    }
+  },
+  {
     "id": "claude-sonnet-4-0",
     "name": "Claude Sonnet 4 (latest)",
     "provider": "anthropic",
@@ -4374,6 +4427,33 @@
   {
     "id": "claude-opus-4-6",
     "name": "claude-opus-4-6",
+    "provider": "azure",
+    "family": null,
+    "created_at": null,
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [],
+      "output": []
+    },
+    "capabilities": [],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": null
+    }
+  },
+  {
+    "id": "claude-opus-4-7",
+    "name": "claude-opus-4-7",
     "provider": "azure",
     "family": null,
     "created_at": null,

--- a/lib/ruby_llm/models.json
+++ b/lib/ruby_llm/models.json
@@ -898,10 +898,10 @@
     "name": "Claude Opus 4.7",
     "provider": "anthropic",
     "family": "claude-opus",
-    "created_at": "2026-04-22 00:00:00 UTC",
+    "created_at": "2026-04-16 00:00:00 UTC",
     "context_window": 1000000,
     "max_output_tokens": 128000,
-    "knowledge_cutoff": null,
+    "knowledge_cutoff": "2026-01-01",
     "modalities": {
       "input": [
         "text",
@@ -927,12 +927,12 @@
       }
     },
     "metadata": {
-      "source": "models.dev",
+      "source": "anthropic",
       "provider_id": "anthropic",
       "open_weights": false,
       "attachment": true,
       "temperature": true,
-      "last_updated": "2026-04-22",
+      "last_updated": "2026-04-16",
       "cost": {
         "input": 5,
         "output": 25,
@@ -943,7 +943,7 @@
         "context": 1000000,
         "output": 128000
       },
-      "knowledge": "2025-08"
+      "knowledge": "2026-01"
     }
   },
   {


### PR DESCRIPTION
## Summary

- Adds `claude-opus-4-7` (Anthropic provider) to `models.json`
- Adds `claude-opus-4-7` (Azure provider) to `models.json`
- Modeled after the existing `claude-opus-4-6` entry with updated dates and knowledge cutoff

## Test plan

- [x] Verify `RubyLLM.models.find('claude-opus-4-7')` returns the model
- [x] Verify chat with `model: 'claude-opus-4-7'` routes correctly to Anthropic

🤖 Generated with [Claude Code](https://claude.com/claude-code)