### PR TITLE
Fixes issue #744: nil response bodies in openrouter responses

### DIFF
--- a/lib/ruby_llm/providers/openrouter/chat.rb
+++ b/lib/ruby_llm/providers/openrouter/chat.rb
@@ -52,7 +52,7 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
-          return if data.empty?
+          return if data.blank?
 
           raise Error.new(response, data.dig('error', 'message')) if data.dig('error', 'message')
 

--- a/lib/ruby_llm/providers/openrouter/chat.rb
+++ b/lib/ruby_llm/providers/openrouter/chat.rb
@@ -52,7 +52,7 @@ module RubyLLM
 
         def parse_completion_response(response)
           data = response.body
-          return if data.blank?
+          return if data.nil? || data.blank?
 
           raise Error.new(response, data.dig('error', 'message')) if data.dig('error', 'message')
 

--- a/spec/ruby_llm/providers/open_router/chat_spec.rb
+++ b/spec/ruby_llm/providers/open_router/chat_spec.rb
@@ -3,8 +3,9 @@
 require 'spec_helper'
 
 RSpec.describe RubyLLM::Providers::OpenRouter::Chat do
+  let(:model) { instance_double(RubyLLM::Model::Info, id: 'anthropic/claude-haiku-4.5') }
+
   describe '.render_payload' do
-    let(:model) { instance_double(RubyLLM::Model::Info, id: 'anthropic/claude-haiku-4.5') }
     let(:messages) { [RubyLLM::Message.new(role: :user, content: 'Hello')] }
 
     before do
@@ -61,6 +62,14 @@ RSpec.describe RubyLLM::Providers::OpenRouter::Chat do
       expect(payload[:response_format][:json_schema][:name]).to eq('PersonSchema')
       expect(payload[:response_format][:json_schema][:schema]).to eq(schema[:schema])
       expect(payload[:response_format][:json_schema][:strict]).to be(false)
+    end
+  end
+
+  describe '.parse_completion_response' do
+    let(:response) { instance_double(Faraday::Response, body: nil) }
+
+    it "doesn't throw an error when response is nil" do
+      expect { described_class.parse_completion_response(response) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## What this does

Fixes issue [744](https://github.com/crmne/ruby_llm/issues/744) where openrouter sends empty an response body for streaming responses and `.empty?` raises an error.  Switching it to `.blank?` works and all the other openrouter provider tests pass.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [X] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [X] This aligns with RubyLLM's focus on **LLM communication**
- [X] This isn't application-specific logic that belongs in user code
- [X] This benefits most users, not just my specific use case

## Required for new features

<!-- Skip this section for bug fixes and documentation -->

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: #___

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [X] I ran `overcommit --install` and all hooks pass
- [X] I tested my changes thoroughly (I monkey-patched RubyLLM locally with the fix to confirm it worked w/ openrouter in our app)
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [X] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [X] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [ ] I used AI tools to help write this code
- [ ] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [X] No API changes
