### PR TITLE
Remove spurious 'single system message' warning from Anthropic provider

### DIFF
--- a/lib/ruby_llm/providers/anthropic/chat.rb
+++ b/lib/ruby_llm/providers/anthropic/chat.rb
@@ -31,13 +31,9 @@ module RubyLLM
         def build_system_content(system_messages)
           return [] if system_messages.empty?
 
-          if system_messages.length > 1
-            RubyLLM.logger.warn(
-              "Anthropic's Claude implementation only supports a single system message. " \
-              'Multiple system messages will be combined into one.'
-            )
-          end
-
+          # Anthropic's `system` parameter accepts an array of text content blocks
+          # (each optionally with cache_control); each :system message becomes its
+          # own block in the resulting array.
           system_messages.flat_map do |msg|
             content = msg.content
 

--- a/spec/ruby_llm/providers/anthropic/chat_spec.rb
+++ b/spec/ruby_llm/providers/anthropic/chat_spec.rb
@@ -3,6 +3,80 @@
 require 'spec_helper'
 
 RSpec.describe RubyLLM::Providers::Anthropic::Chat do
+  describe '.build_system_content' do
+    let(:logger) { instance_double(Logger, info: nil, debug: nil, error: nil, warn: nil) }
+
+    before { allow(RubyLLM).to receive(:logger).and_return(logger) }
+
+    it 'returns an empty array when no :system messages are present' do
+      expect(described_class.build_system_content([])).to eq([])
+    end
+
+    it 'returns a single text block for one :system message' do
+      msg = RubyLLM::Message.new(role: :system, content: 'Solo system prompt.')
+
+      blocks = described_class.build_system_content([msg])
+
+      expect(blocks).to eq([{ type: 'text', text: 'Solo system prompt.' }])
+    end
+
+    it 'returns both text blocks when multiple :system messages are passed' do
+      first = RubyLLM::Message.new(role: :system, content: 'Static prompt.')
+      second = RubyLLM::Message.new(role: :system, content: 'Per-session context.')
+
+      blocks = described_class.build_system_content([first, second])
+
+      expect(blocks).to eq(
+        [
+          { type: 'text', text: 'Static prompt.' },
+          { type: 'text', text: 'Per-session context.' }
+        ]
+      )
+    end
+
+    it 'does not log a warning when multiple :system messages are passed' do
+      first = RubyLLM::Message.new(role: :system, content: 'A')
+      second = RubyLLM::Message.new(role: :system, content: 'B')
+
+      described_class.build_system_content([first, second])
+
+      expect(logger).not_to have_received(:warn)
+    end
+
+    it 'preserves per-block cache_control on Raw content alongside plain text' do
+      cached_raw = RubyLLM::Providers::Anthropic::Content.new(
+        'Cached prefix.',
+        cache_control: { type: 'ephemeral' }
+      )
+      cached_msg = RubyLLM::Message.new(role: :system, content: cached_raw)
+      plain_msg = RubyLLM::Message.new(role: :system, content: 'Dynamic suffix.')
+
+      blocks = described_class.build_system_content([cached_msg, plain_msg])
+
+      expect(blocks).to eq(
+        [
+          { type: 'text', text: 'Cached prefix.', cache_control: { type: 'ephemeral' } },
+          { type: 'text', text: 'Dynamic suffix.' }
+        ]
+      )
+    end
+
+    it 'flattens mixed Raw-wrapped and plain string content into a single array' do
+      raw = RubyLLM::Content::Raw.new([{ type: 'text', text: 'Raw block.' }])
+      raw_msg = RubyLLM::Message.new(role: :system, content: raw)
+      plain_msg = RubyLLM::Message.new(role: :system, content: 'Plain block.')
+
+      blocks = described_class.build_system_content([raw_msg, plain_msg])
+
+      expect(blocks).to eq(
+        [
+          { type: 'text', text: 'Raw block.' },
+          { type: 'text', text: 'Plain block.' }
+        ]
+      )
+    end
+  end
+
   describe '.render_payload' do
     let(:model) { instance_double(RubyLLM::Model::Info, id: 'claude-sonnet-4-5', max_tokens: nil) }
 


### PR DESCRIPTION
## What this does

Removes a stale `RubyLLM.logger.warn(...)` call in `Anthropic::Chat#build_system_content` that fires on every request whenever a chat carries more than one `:system`-role message. The warning claims Anthropic only supports a single system message and that the gem will merge them -- neither is still true. Anthropic's `system` parameter has accepted an array of text content blocks (with per-block `cache_control`) since the prompt-caching launch in August 2024 (GA December 2024), and the gem already serializes correctly via `flat_map` over `Media.format_content`. Only the warning is stale.

At high request volume the warning floods logs for applications that intentionally split system content into a cached prefix + a per-conversation envelope. The Bedrock provider (`lib/ruby_llm/providers/bedrock/chat.rb`) handles the same case without warning, so this also aligns the two providers.

Adds direct unit coverage for `build_system_content`:
- returns `[]` for zero messages
- returns one block for one message
- returns two blocks (in order) for two messages
- does **not** log a warning when multiple `:system` messages are passed
- preserves `cache_control` on a `Content::Raw` block when paired with a plain-text block
- flattens mixed `Content::Raw` + plain-string content correctly

Fixes #767.

References:
- Anthropic Messages API: https://docs.anthropic.com/en/api/messages -- `system: string | array of text content blocks`
- Prompt caching with `cache_control` on system blocks: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
- `anthropic-sdk-python` ships `system: Union[str, Iterable[TextBlockParam]]`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

<!-- N/A: bug fix -->

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]` (N/A -- this change is wire-format-neutral; no provider request/response shape changed, so existing cassettes still match)
  - [x] All tests pass: `bundle exec rspec spec/ruby_llm/providers/anthropic/chat_spec.rb` (13 examples, 0 failures -- 6 new + 7 existing) and `bundle exec rspec spec/ruby_llm/providers/anthropic_spec.rb` (2 examples, 0 failures)
- [x] I updated documentation if needed (no user-facing docs reference this warning)
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
