### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+ASTRAFLOW_API_KEY=$(op read "op://RubyLLM/Astraflow/credential")
+ASTRAFLOW_CN_API_KEY=$(op read "op://RubyLLM/AstraflowCN/credential")
 ANTHROPIC_API_KEY=$(op read "op://RubyLLM/Anthropic/credential")
 AWS_ACCESS_KEY_ID=$(op read "op://RubyLLM/AWS/key id")
 AWS_REGION=$(op read "op://RubyLLM/AWS/region")

--- a/lib/ruby_llm.rb
+++ b/lib/ruby_llm.rb
@@ -29,7 +29,8 @@ loader.inflector.inflect(
   'perplexity' => 'Perplexity',
   'ruby_llm' => 'RubyLLM',
   'vertexai' => 'VertexAI',
-  'xai' => 'XAI'
+  'astraflow' => 'Astraflow',
+    'xai' => 'XAI'
 )
 loader.ignore("#{__dir__}/tasks")
 loader.ignore("#{__dir__}/generators")
@@ -95,6 +96,7 @@ module RubyLLM
 end
 
 RubyLLM::Provider.register :anthropic, RubyLLM::Providers::Anthropic
+RubyLLM::Provider.register :astraflow, RubyLLM::Providers::Astraflow
 RubyLLM::Provider.register :azure, RubyLLM::Providers::Azure
 RubyLLM::Provider.register :bedrock, RubyLLM::Providers::Bedrock
 RubyLLM::Provider.register :deepseek, RubyLLM::Providers::DeepSeek

--- a/lib/ruby_llm/providers/astraflow.rb
+++ b/lib/ruby_llm/providers/astraflow.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    # Astraflow API integration.
+    # Astraflow (by UCloud) is an OpenAI-compatible platform supporting 200+ models.
+    # Global endpoint: https://api-us-ca.umodelverse.ai/v1  (env var: ASTRAFLOW_API_KEY)
+    # China endpoint:  https://api.modelverse.cn/v1         (env var: ASTRAFLOW_CN_API_KEY)
+    class Astraflow < OpenAI
+      include Astraflow::Chat
+      include Astraflow::Models
+
+      def api_base
+        if @config.astraflow_cn_api_key && !@config.astraflow_cn_api_key.to_s.empty?
+          @config.astraflow_api_base || 'https://api.modelverse.cn/v1'
+        else
+          @config.astraflow_api_base || 'https://api-us-ca.umodelverse.ai/v1'
+        end
+      end
+
+      def headers
+        api_key = if @config.astraflow_cn_api_key && !@config.astraflow_cn_api_key.to_s.empty?
+                    @config.astraflow_cn_api_key
+                  else
+                    @config.astraflow_api_key
+                  end
+        {
+          'Authorization' => "Bearer #{api_key}",
+          'Content-Type' => 'application/json'
+        }
+      end
+
+      class << self
+        def configuration_options
+          %i[astraflow_api_key astraflow_cn_api_key astraflow_api_base]
+        end
+
+        def configuration_requirements
+          # At least one key must be set; validated at connection time via headers.
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/astraflow/chat.rb
+++ b/lib/ruby_llm/providers/astraflow/chat.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class Astraflow
+      # Chat implementation for Astraflow.
+      # Astraflow is fully OpenAI-compatible, so we delegate to OpenAI::Media.
+      module Chat
+        def format_role(role)
+          role.to_s
+        end
+
+        def format_content(content)
+          OpenAI::Media.format_content(
+            content,
+            document_attachments: :none,
+            image_attachments: true,
+            audio_attachments: false
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/astraflow/models.rb
+++ b/lib/ruby_llm/providers/astraflow/models.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class Astraflow
+      # Models metadata for Astraflow.
+      # Astraflow aggregates 200+ models; we parse the provider's /v1/models response
+      # dynamically rather than maintaining a hard-coded list.
+      module Models
+        module_function
+
+        def parse_list_models_response(response, slug, _capabilities)
+          Array(response.body['data']).map do |model_data|
+            model_id = model_data['id']
+
+            Model::Info.new(
+              id: model_id,
+              name: format_display_name(model_id),
+              provider: slug,
+              family: infer_family(model_id),
+              created_at: model_data['created'] ? Time.at(model_data['created']) : nil,
+              context_window: nil,
+              max_output_tokens: nil,
+              modalities: { input: ['text'], output: ['text'] },
+              capabilities: %w[streaming function_calling],
+              pricing: {},
+              metadata: {
+                object: model_data['object'],
+                owned_by: model_data['owned_by']
+              }.compact
+            )
+          end
+        end
+
+        def format_display_name(model_id)
+          model_id.tr('-', ' ').split.map(&:capitalize).join(' ')
+        end
+
+        def infer_family(model_id)
+          case model_id
+          when /\Agpt/i      then 'gpt'
+          when /\Aclaude/i   then 'claude'
+          when /\Agemini/i   then 'gemini'
+          when /\Amistral/i  then 'mistral'
+          when /\Adeepseek/i then 'deepseek'
+          when /\Allama/i    then 'llama'
+          when /\Aqwen/i     then 'qwen'
+          else 'unknown'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this does

Adds [Astraflow](https://astraflow.ucloud-global.com) as a supported provider.

Astraflow (by UCloud / 优刻得) is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because it is fully OpenAI-compatible, the integration is minimal: it reuses the existing `OpenAI` base class with a custom `api_base` and `headers`.

### What's included

| File | Change |
|------|--------|
| `lib/ruby_llm.rb` | Add Zeitwerk inflector entry + `Provider.register` call |
| `lib/ruby_llm/providers/astraflow.rb` | New provider class (inherits `OpenAI`) |
| `lib/ruby_llm/providers/astraflow/chat.rb` | Minimal `Chat` module (delegates to `OpenAI::Media`) |
| `lib/ruby_llm/providers/astraflow/models.rb` | `Models` module that parses the `/v1/models` response |
| `.env.example` | Add `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY` entries |

### Usage

```ruby
# Global endpoint (default)
RubyLLM.configure do |config|
  config.astraflow_api_key = ENV["ASTRAFLOW_API_KEY"]
end

# China endpoint
RubyLLM.configure do |config|
  config.astraflow_cn_api_key = ENV["ASTRAFLOW_CN_API_KEY"]
end
```

### Provider details

| | Global | China |
|-|--------|-------|
| **Endpoint** | `https://api-us-ca.umodelverse.ai/v1` | `https://api.modelverse.cn/v1` |
| **Env var** | `ASTRAFLOW_API_KEY` | `ASTRAFLOW_CN_API_KEY` |
| **Sign-up** | https://astraflow.ucloud-global.com | https://astraflow.ucloud.cn |

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [ ] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

<!-- Skip this section for bug fixes and documentation -->

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: #___

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [ ] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [ ] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [ ] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [ ] I used AI tools to help write this code
- [ ] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [x] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes