### PR TITLE
feat(openai): route reasoning + tools to the Responses API (refs #785)

### DIFF
--- a/lib/ruby_llm/providers/openai.rb
+++ b/lib/ruby_llm/providers/openai.rb
@@ -5,6 +5,7 @@ module RubyLLM
     # OpenAI API integration.
     class OpenAI < Provider
       include OpenAI::Chat
+      include OpenAI::Responses
       include OpenAI::Embeddings
       include OpenAI::Models
       include OpenAI::Moderation
@@ -13,6 +14,18 @@ module RubyLLM
       include OpenAI::Images
       include OpenAI::Media
       include OpenAI::Transcription
+
+      # Streaming over the Responses API uses a different SSE event set than
+      # chat/completions and is not implemented yet. Reasoning+tools turns route
+      # to Responses (see OpenAI::Responses#responses_api?), so guard streaming
+      # there explicitly instead of mis-parsing chat/completions events.
+      def stream_response(connection, payload, additional_headers = {}, &)
+        if @openai_responses_mode
+          raise RubyLLM::Error.new(nil, 'OpenAI Responses streaming not implemented yet; call without a block')
+        end
+
+        super
+      end
 
       def api_base
         @config.openai_api_base || 'https://api.openai.com/v1'

--- a/lib/ruby_llm/providers/openai.rb
+++ b/lib/ruby_llm/providers/openai.rb
@@ -15,6 +15,25 @@ module RubyLLM
       include OpenAI::Media
       include OpenAI::Transcription
 
+      # reasoning_effort + function tools is unsupported on /v1/chat/completions
+      # (OpenAI 400s, "use /v1/responses instead"). When a turn requests thinking
+      # AND ships tools, render the Responses-API payload instead; the flag is read
+      # back by completion_url / parse_completion_response within this same
+      # Provider#complete call. Routing lives here (not in OpenAI::Chat) so the
+      # module-function render_payload stays pure chat/completions, while the
+      # OpenAI::Responses helpers resolve against this instance (which mixes both in).
+      def render_payload(messages, tools:, temperature:, model:, stream: false, schema: nil, # rubocop:disable Metrics/ParameterLists
+                         thinking: nil, tool_prefs: nil)
+        # Only the genuine OpenAI provider has /v1/responses — subclasses
+        # (Azure/OpenRouter/Mistral/Perplexity/xAI/GPUStack) keep chat/completions.
+        @openai_responses_mode = instance_of?(RubyLLM::Providers::OpenAI) &&
+                                 responses_api?(tools: tools, thinking: thinking)
+        return super unless @openai_responses_mode
+
+        render_responses_payload(messages, tools: tools, model: model, stream: stream,
+                                           schema: schema, thinking: thinking, tool_prefs: tool_prefs)
+      end
+
       # Streaming over the Responses API uses a different SSE event set than
       # chat/completions and is not implemented yet. Reasoning+tools turns route
       # to Responses (see OpenAI::Responses#responses_api?), so guard streaming

--- a/lib/ruby_llm/providers/openai/chat.rb
+++ b/lib/ruby_llm/providers/openai/chat.rb
@@ -14,16 +14,6 @@ module RubyLLM
         # rubocop:disable Metrics/ParameterLists,Metrics/PerceivedComplexity
         def render_payload(messages, tools:, temperature:, model:, stream: false, schema: nil,
                            thinking: nil, tool_prefs: nil)
-          # reasoning_effort + function tools is unsupported on /v1/chat/completions
-          # (OpenAI 400s, "use /v1/responses"). Transparently route that combo to
-          # the Responses API. The flag is read back by completion_url and
-          # parse_completion_response within this same Provider#complete call.
-          @openai_responses_mode = responses_api?(tools: tools, thinking: thinking)
-          if @openai_responses_mode
-            return render_responses_payload(messages, tools: tools, model: model, stream: stream,
-                                                      schema: schema, thinking: thinking, tool_prefs: tool_prefs)
-          end
-
           tool_prefs ||= {}
           payload = {
             model: model.id,

--- a/lib/ruby_llm/providers/openai/chat.rb
+++ b/lib/ruby_llm/providers/openai/chat.rb
@@ -6,7 +6,7 @@ module RubyLLM
       # Chat methods of the OpenAI API integration
       module Chat
         def completion_url
-          'chat/completions'
+          @openai_responses_mode ? 'responses' : 'chat/completions'
         end
 
         module_function
@@ -14,6 +14,16 @@ module RubyLLM
         # rubocop:disable Metrics/ParameterLists,Metrics/PerceivedComplexity
         def render_payload(messages, tools:, temperature:, model:, stream: false, schema: nil,
                            thinking: nil, tool_prefs: nil)
+          # reasoning_effort + function tools is unsupported on /v1/chat/completions
+          # (OpenAI 400s, "use /v1/responses"). Transparently route that combo to
+          # the Responses API. The flag is read back by completion_url and
+          # parse_completion_response within this same Provider#complete call.
+          @openai_responses_mode = responses_api?(tools: tools, thinking: thinking)
+          if @openai_responses_mode
+            return render_responses_payload(messages, tools: tools, model: model, stream: stream,
+                                                      schema: schema, thinking: thinking, tool_prefs: tool_prefs)
+          end
+
           tool_prefs ||= {}
           payload = {
             model: model.id,
@@ -52,6 +62,8 @@ module RubyLLM
         # rubocop:enable Metrics/ParameterLists,Metrics/PerceivedComplexity
 
         def parse_completion_response(response)
+          return parse_responses_response(response) if @openai_responses_mode
+
           data = response.body
           return if data.empty?
 

--- a/lib/ruby_llm/providers/openai/responses.rb
+++ b/lib/ruby_llm/providers/openai/responses.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class OpenAI
+      # OpenAI Responses API (/v1/responses) support.
+      #
+      # OpenAI reasoning models (gpt-5.x, o-series) reject `reasoning_effort`
+      # alongside function tools on /v1/chat/completions:
+      #   "Function tools with reasoning_effort are not supported ... use /v1/responses"
+      # When a turn requests thinking AND ships tools, we transparently route it
+      # through the Responses API instead, translating request + response shapes
+      # so the rest of RubyLLM (Message/ToolCall/Thinking, the tool loop) is
+      # unchanged. The decision is recorded in @openai_responses_mode by
+      # render_payload and read back by completion_url / parse_completion_response
+      # within the same Provider#complete call.
+      module Responses
+        module_function
+
+        # Route to /v1/responses only for the exact combo that 400s on
+        # chat/completions: a reasoning effort requested together with tools.
+        def responses_api?(tools:, thinking:)
+          !resolve_effort(thinking).nil? && tools.any?
+        end
+
+        # rubocop:disable Metrics/ParameterLists
+        def render_responses_payload(messages, tools:, model:, stream:, schema:, thinking:, tool_prefs:)
+          tool_prefs ||= {}
+          system_messages, conversation = messages.partition { |msg| msg.role == :system }
+
+          payload = {
+            model: model.id,
+            input: format_responses_input(conversation),
+            stream: stream,
+            store: false
+          }
+
+          instructions = system_messages.map { |msg| responses_text_content(msg.content) }.join("\n\n")
+          payload[:instructions] = instructions unless instructions.empty?
+
+          apply_responses_tools(payload, tools, tool_prefs)
+
+          effort = resolve_effort(thinking)
+          payload[:reasoning] = { effort: effort } if effort
+
+          if schema
+            payload[:text] = {
+              format: { type: 'json_schema', name: schema[:name], schema: schema[:schema], strict: schema[:strict] }
+            }
+          end
+
+          payload
+        end
+        # rubocop:enable Metrics/ParameterLists
+
+        def apply_responses_tools(payload, tools, tool_prefs)
+          return unless tools.any?
+
+          payload[:tools] = tools.map { |_, tool| responses_tool_for(tool) }
+          payload[:tool_choice] = responses_tool_choice(tool_prefs[:choice]) unless tool_prefs[:choice].nil?
+          payload[:parallel_tool_calls] = tool_prefs[:calls] == :many unless tool_prefs[:calls].nil?
+        end
+
+        # Responses tools are flat ({type, name, description, parameters}) — not
+        # nested under a "function" key like chat/completions.
+        def responses_tool_for(tool)
+          definition = {
+            type: 'function',
+            name: tool.name,
+            description: tool.description,
+            parameters: parameters_schema_for(tool)
+          }
+          return definition if tool.provider_params.empty?
+
+          RubyLLM::Utils.deep_merge(definition, tool.provider_params)
+        end
+
+        def responses_tool_choice(choice)
+          case choice
+          when :auto, :none, :required then choice.to_s
+          else { type: 'function', name: choice }
+          end
+        end
+
+        # Translate RubyLLM messages into Responses `input` items.
+        def format_responses_input(messages)
+          messages.flat_map { |msg| responses_items_for(msg) }
+        end
+
+        def responses_items_for(msg)
+          case msg.role
+          when :tool      then [responses_tool_output_item(msg)]
+          when :assistant then responses_assistant_items(msg)
+          else                 [{ role: msg.role.to_s, content: responses_user_content(msg.content) }]
+          end
+        end
+
+        def responses_tool_output_item(msg)
+          { type: 'function_call_output', call_id: msg.tool_call_id, output: responses_text_content(msg.content) }
+        end
+
+        def responses_assistant_items(msg)
+          items = msg.tool_calls&.values&.map do |tc|
+            { type: 'function_call', call_id: tc.id, name: tc.name, arguments: JSON.generate(tc.arguments) }
+          end || []
+          text = responses_text_content(msg.content)
+          items << { role: 'assistant', content: [{ type: 'output_text', text: text }] } unless text.empty?
+          items
+        end
+
+        def responses_user_content(content)
+          [{ type: 'input_text', text: responses_text_content(content) }]
+        end
+
+        def responses_text_content(content)
+          return content if content.is_a?(String)
+          return content.text.to_s if content.respond_to?(:text)
+
+          content.to_s
+        end
+
+        def parse_responses_response(response)
+          data = response.body
+          return if data.nil? || data.empty?
+          raise Error.new(response, data.dig('error', 'message')) if data.dig('error', 'message')
+
+          parsed = parse_responses_output(data['output'] || [])
+          content = parsed[:content]
+          content = data['output_text'].to_s if content.empty? && data['output_text']
+          build_responses_message(data, parsed, content, response)
+        end
+
+        def parse_responses_output(output)
+          content = +''
+          thinking = +''
+          signature = nil
+          tool_calls = {}
+          output.each do |item|
+            case item['type']
+            when 'message'       then content << responses_message_text(item)
+            when 'reasoning'     then thinking << responses_reasoning_text(item)
+            when 'function_call' then add_responses_tool_call(tool_calls, item)
+            end
+            signature ||= item['encrypted_content'] if item['type'] == 'reasoning'
+          end
+          { content: content, thinking: thinking, signature: signature, tool_calls: tool_calls }
+        end
+
+        def responses_message_text(item)
+          Array(item['content']).filter_map { |c| c['text'] if c['type'] == 'output_text' }.join
+        end
+
+        def responses_reasoning_text(item)
+          Array(item['summary']).filter_map { |s| s['text'] if s['type'] == 'summary_text' }.join
+        end
+
+        def add_responses_tool_call(tool_calls, item)
+          call_id = item['call_id'] || item['id']
+          tool_calls[call_id] = ToolCall.new(
+            id: call_id,
+            name: item['name'],
+            arguments: responses_tool_arguments(item['arguments'])
+          )
+        end
+
+        def responses_tool_arguments(arguments)
+          return {} if arguments.nil? || arguments.empty?
+
+          JSON.parse(arguments)
+        end
+
+        def build_responses_message(data, parsed, content, response)
+          usage = data['usage'] || {}
+          Message.new(
+            role: :assistant,
+            content: content.empty? ? nil : content,
+            thinking: Thinking.build(text: parsed[:thinking].empty? ? nil : parsed[:thinking],
+                                     signature: parsed[:signature]),
+            tool_calls: parsed[:tool_calls].empty? ? nil : parsed[:tool_calls],
+            input_tokens: usage['input_tokens'],
+            output_tokens: usage['output_tokens'],
+            cached_tokens: usage.dig('input_tokens_details', 'cached_tokens'),
+            cache_creation_tokens: 0,
+            thinking_tokens: usage.dig('output_tokens_details', 'reasoning_tokens'),
+            model_id: data['model'],
+            raw: response
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_llm/providers/open_ai/responses_spec.rb
+++ b/spec/ruby_llm/providers/open_ai/responses_spec.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::OpenAI::Responses do
+  # reasoning_effort + function tools is rejected on /v1/chat/completions; the
+  # OpenAI provider routes that combo to /v1/responses. These keyless unit tests
+  # exercise the request/response translation directly on a provider instance
+  # (where OpenAI::Chat + OpenAI::Responses + OpenAI::Tools are all mixed in).
+  class RespWeatherTool < RubyLLM::Tool # rubocop:disable Lint/ConstantDefinitionInBlock,RSpec/LeakyConstantDeclaration
+    description 'Gets current weather for a city'
+    param :city, desc: 'City name'
+
+    def execute(city:)
+      { city:, temp_c: 18 }
+    end
+  end
+
+  # A bare OpenAI subclass that does NOT override render_payload, to prove the
+  # instance_of?(OpenAI) guard keeps subclasses on chat/completions.
+  class BareOpenAISub < RubyLLM::Providers::OpenAI # rubocop:disable Lint/ConstantDefinitionInBlock,RSpec/LeakyConstantDeclaration
+  end
+
+  let(:provider) { RubyLLM::Providers::OpenAI.allocate }
+  let(:model) { instance_double(RubyLLM::Model::Info, id: 'gpt-5.5') }
+  let(:effort) { RubyLLM::Thinking::Config.new(effort: :high) }
+  let(:tools) { { weather: RespWeatherTool.new } }
+
+  describe '#responses_api?' do
+    it 'is true with a reasoning effort and tools' do
+      expect(provider.send(:responses_api?, tools: tools, thinking: effort)).to be(true)
+    end
+
+    it 'is false without thinking' do
+      expect(provider.send(:responses_api?, tools: tools, thinking: nil)).to be(false)
+    end
+
+    it 'is false without tools' do
+      expect(provider.send(:responses_api?, tools: {}, thinking: effort)).to be(false)
+    end
+  end
+
+  describe '#render_payload routing' do
+    let(:messages) { [RubyLLM::Message.new(role: :user, content: 'Weather in Paris?')] }
+
+    it 'routes thinking + tools to the Responses payload and flips completion_url' do
+      payload = provider.render_payload(messages, tools: tools, temperature: nil, model: model, thinking: effort)
+
+      expect(payload).to include(:input, :tools, :store)
+      expect(payload).not_to have_key(:messages)
+      expect(payload[:reasoning]).to eq(effort: 'high')
+      expect(provider.completion_url).to eq('responses')
+    end
+
+    it 'leaves plain (no-thinking) turns on chat/completions' do
+      allow(provider).to receive(:format_messages).and_return([{ role: 'user', content: 'x' }])
+
+      payload = provider.render_payload(messages, tools: tools, temperature: nil, model: model, thinking: nil)
+
+      expect(payload).to have_key(:messages)
+      expect(provider.completion_url).to eq('chat/completions')
+    end
+
+    it 'does NOT route on OpenAI subclasses (they have no /v1/responses)' do
+      sub = BareOpenAISub.allocate
+      allow(sub).to receive(:format_messages).and_return([{ role: 'user', content: 'x' }])
+
+      payload = sub.render_payload(messages, tools: tools, temperature: nil, model: model, thinking: effort)
+
+      expect(payload).to have_key(:messages)
+      expect(sub.completion_url).to eq('chat/completions')
+    end
+  end
+
+  describe '#render_responses_payload' do
+    subject(:payload) do
+      provider.send(
+        :render_responses_payload,
+        system_and_user, tools: tools, model: model, stream: false, schema: nil, thinking: effort, tool_prefs: {}
+      )
+    end
+
+    let(:system_and_user) do
+      [
+        RubyLLM::Message.new(role: :system, content: 'You are helpful.'),
+        RubyLLM::Message.new(role: :user, content: 'Weather in Paris?')
+      ]
+    end
+
+    it 'sets model, store, reasoning and lifts system messages into instructions' do
+      expect(payload[:model]).to eq('gpt-5.5')
+      expect(payload[:store]).to be(false)
+      expect(payload[:reasoning]).to eq(effort: 'high')
+      expect(payload[:instructions]).to eq('You are helpful.')
+    end
+
+    it 'renders user messages as input_text items (system excluded from input)' do
+      roles = payload[:input].filter_map { |item| item[:role] }
+      expect(roles).to eq(['user'])
+      expect(payload[:input].first[:content]).to eq([{ type: 'input_text', text: 'Weather in Paris?' }])
+    end
+
+    it 'renders flat function tools (not nested under :function)' do
+      tool = payload[:tools].first
+      expect(tool[:type]).to eq('function')
+      expect(tool[:name]).to eq(tools[:weather].name)
+      expect(tool).to have_key(:parameters)
+      expect(tool).not_to have_key(:function)
+    end
+
+    it 'maps a structured-output schema to text.format' do
+      schema = { name: 'S', schema: { 'type' => 'object' }, strict: true }
+      result = provider.send(
+        :render_responses_payload,
+        system_and_user, tools: {}, model: model, stream: false, schema:, thinking: effort, tool_prefs: {}
+      )
+      expect(result[:text]).to eq(format: { type: 'json_schema', name: 'S', schema: { 'type' => 'object' },
+                                            strict: true })
+    end
+  end
+
+  describe '#format_responses_input tool round-trip' do
+    it 'emits function_call for assistant tool calls and function_call_output for tool results' do
+      call = RubyLLM::ToolCall.new(id: 'call_1', name: 'weather', arguments: { 'city' => 'Paris' })
+      conversation = [
+        RubyLLM::Message.new(role: :assistant, content: nil, tool_calls: { 'call_1' => call }),
+        RubyLLM::Message.new(role: :tool, content: '{"temp_c":18}', tool_call_id: 'call_1')
+      ]
+
+      input = provider.send(:format_responses_input, conversation)
+
+      function_call = input.find { |item| item[:type] == 'function_call' }
+      expect(function_call).to include(call_id: 'call_1', name: 'weather')
+      expect(JSON.parse(function_call[:arguments])).to eq('city' => 'Paris')
+
+      output = input.find { |item| item[:type] == 'function_call_output' }
+      expect(output).to include(call_id: 'call_1', output: '{"temp_c":18}')
+    end
+  end
+
+  describe '#parse_responses_response' do
+    it 'parses message text, function_call, reasoning and usage' do
+      body = {
+        'model' => 'gpt-5.5',
+        'output' => [
+          { 'type' => 'reasoning', 'summary' => [{ 'type' => 'summary_text', 'text' => 'thinking...' }],
+            'encrypted_content' => 'enc' },
+          { 'type' => 'function_call', 'call_id' => 'call_9', 'name' => 'weather', 'arguments' => '{"city":"Paris"}' },
+          { 'type' => 'message', 'content' => [{ 'type' => 'output_text', 'text' => 'It is 18C.' }] }
+        ],
+        'usage' => {
+          'input_tokens' => 100, 'output_tokens' => 20,
+          'output_tokens_details' => { 'reasoning_tokens' => 12 },
+          'input_tokens_details' => { 'cached_tokens' => 30 }
+        }
+      }
+      message = provider.send(:parse_responses_response, instance_double(Faraday::Response, body:))
+
+      expect(message.content).to eq('It is 18C.')
+      expect(message.tool_calls['call_9'].name).to eq('weather')
+      expect(message.tool_calls['call_9'].arguments).to eq('city' => 'Paris')
+      expect(message.thinking.text).to eq('thinking...')
+      expect(message.thinking.signature).to eq('enc')
+      expect([message.input_tokens, message.output_tokens]).to eq([100, 20])
+      expect([message.thinking_tokens, message.cached_tokens]).to eq([12, 30])
+    end
+
+    it 'falls back to output_text and nil tool_calls when there is no message item' do
+      body = { 'model' => 'gpt-5.5', 'output' => [], 'output_text' => 'hi', 'usage' => {} }
+      message = provider.send(:parse_responses_response, instance_double(Faraday::Response, body:))
+
+      expect(message.content).to eq('hi')
+      expect(message.tool_calls).to be_nil
+    end
+
+    it 'raises on an error body' do
+      body = { 'error' => { 'message' => 'boom' } }
+      expect do
+        provider.send(:parse_responses_response, instance_double(Faraday::Response, body:))
+      end.to raise_error(RubyLLM::Error, /boom/)
+    end
+  end
+
+  describe '#parse_completion_response delegation' do
+    it 'routes to the Responses parser when responses mode is active' do
+      provider.instance_variable_set(:@openai_responses_mode, true)
+      body = {
+        'model' => 'gpt-5.5',
+        'output' => [{ 'type' => 'message', 'content' => [{ 'type' => 'output_text', 'text' => 'ok' }] }],
+        'usage' => {}
+      }
+      message = provider.send(:parse_completion_response, instance_double(Faraday::Response, body:))
+      expect(message.content).to eq('ok')
+    end
+  end
+
+  describe '#responses_tool_choice' do
+    it 'passes auto/required/none through as strings' do
+      expect(provider.send(:responses_tool_choice, :required)).to eq('required')
+    end
+
+    it 'wraps a named tool choice' do
+      expect(provider.send(:responses_tool_choice, 'weather')).to eq(type: 'function', name: 'weather')
+    end
+  end
+
+  describe '#stream_response guard' do
+    it 'raises a clear error in responses mode (streaming not implemented)' do
+      provider.instance_variable_set(:@openai_responses_mode, true)
+      expect { provider.stream_response(nil, {}) }.to raise_error(RubyLLM::Error, /streaming not implemented/i)
+    end
+  end
+end

--- a/spec/ruby_llm/providers/open_ai/responses_spec.rb
+++ b/spec/ruby_llm/providers/open_ai/responses_spec.rb
@@ -125,6 +125,12 @@ RSpec.describe RubyLLM::Providers::OpenAI::Responses do
   end
 
   describe '#format_responses_input tool round-trip' do
+    it 'renders assistant text content as an output_text item' do
+      input = provider.send(:format_responses_input, [RubyLLM::Message.new(role: :assistant, content: 'Done.')])
+
+      expect(input).to eq([{ role: 'assistant', content: [{ type: 'output_text', text: 'Done.' }] }])
+    end
+
     it 'emits function_call for assistant tool calls and function_call_output for tool results' do
       call = RubyLLM::ToolCall.new(id: 'call_1', name: 'weather', arguments: { 'city' => 'Paris' })
       conversation = [
@@ -183,6 +189,10 @@ RSpec.describe RubyLLM::Providers::OpenAI::Responses do
       expect do
         provider.send(:parse_responses_response, instance_double(Faraday::Response, body:))
       end.to raise_error(RubyLLM::Error, /boom/)
+    end
+
+    it 'returns nil for an empty body' do
+      expect(provider.send(:parse_responses_response, instance_double(Faraday::Response, body: {}))).to be_nil
     end
   end
 

--- a/spec/ruby_llm/providers/open_ai/responses_spec.rb
+++ b/spec/ruby_llm/providers/open_ai/responses_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe RubyLLM::Providers::OpenAI::Responses do
   class BareOpenAISub < RubyLLM::Providers::OpenAI # rubocop:disable Lint/ConstantDefinitionInBlock,RSpec/LeakyConstantDeclaration
   end
 
+  class RespParamsTool < RubyLLM::Tool # rubocop:disable Lint/ConstantDefinitionInBlock,RSpec/LeakyConstantDeclaration
+    description 'Tool carrying provider-specific params'
+    with_params(metadata: { source: 'test' })
+  end
+
   let(:provider) { RubyLLM::Providers::OpenAI.allocate }
   let(:model) { instance_double(RubyLLM::Model::Info, id: 'gpt-5.5') }
   let(:effort) { RubyLLM::Thinking::Config.new(effort: :high) }
@@ -191,6 +196,25 @@ RSpec.describe RubyLLM::Providers::OpenAI::Responses do
       }
       message = provider.send(:parse_completion_response, instance_double(Faraday::Response, body:))
       expect(message.content).to eq('ok')
+    end
+  end
+
+  describe '#responses_tool_for' do
+    it 'deep-merges provider_params into the flat tool definition' do
+      definition = provider.send(:responses_tool_for, RespParamsTool.new)
+
+      expect(definition[:type]).to eq('function')
+      expect(definition[:metadata]).to eq(source: 'test')
+    end
+  end
+
+  describe '#responses_text_content' do
+    it 'reads .text from Content objects' do
+      expect(provider.send(:responses_text_content, RubyLLM::Content.new('hi'))).to eq('hi')
+    end
+
+    it 'falls back to to_s for plain values' do
+      expect(provider.send(:responses_text_content, 42)).to eq('42')
     end
   end
 

--- a/spec/ruby_llm/providers/open_ai/responses_spec.rb
+++ b/spec/ruby_llm/providers/open_ai/responses_spec.rb
@@ -122,6 +122,24 @@ RSpec.describe RubyLLM::Providers::OpenAI::Responses do
       expect(result[:text]).to eq(format: { type: 'json_schema', name: 'S', schema: { 'type' => 'object' },
                                             strict: true })
     end
+
+    it 'omits :reasoning when no effort is given' do
+      result = provider.send(
+        :render_responses_payload,
+        system_and_user, tools: {}, model: model, stream: false, schema: nil, thinking: nil, tool_prefs: {}
+      )
+      expect(result).not_to have_key(:reasoning)
+    end
+
+    it 'maps tool_prefs choice and parallel calls onto the payload' do
+      result = provider.send(
+        :render_responses_payload,
+        system_and_user, tools: tools, model: model, stream: false, schema: nil, thinking: effort,
+                         tool_prefs: { choice: 'weather', calls: :many }
+      )
+      expect(result[:tool_choice]).to eq(type: 'function', name: 'weather')
+      expect(result[:parallel_tool_calls]).to be(true)
+    end
   end
 
   describe '#format_responses_input tool round-trip' do
@@ -193,6 +211,36 @@ RSpec.describe RubyLLM::Providers::OpenAI::Responses do
 
     it 'returns nil for an empty body' do
       expect(provider.send(:parse_responses_response, instance_double(Faraday::Response, body: {}))).to be_nil
+    end
+
+    it 'skips unknown items, non-output_text / non-summary_text blocks, and empty tool args' do
+      body = {
+        'model' => 'gpt-5.5',
+        'output' => [
+          { 'type' => 'web_search_call' },
+          { 'type' => 'reasoning', 'summary' => [{ 'type' => 'other' }, { 'type' => 'summary_text', 'text' => 'r' }] },
+          { 'type' => 'function_call', 'call_id' => 'c1', 'name' => 'noop', 'arguments' => '' },
+          { 'type' => 'message', 'content' => [{ 'type' => 'refusal' }, { 'type' => 'output_text', 'text' => 'hi' }] }
+        ],
+        'usage' => {}
+      }
+      message = provider.send(:parse_responses_response, instance_double(Faraday::Response, body:))
+
+      expect(message.content).to eq('hi')
+      expect(message.thinking.text).to eq('r')
+      expect(message.tool_calls['c1'].arguments).to eq({})
+    end
+
+    it 'returns nil content when the output is only a function_call' do
+      body = {
+        'model' => 'gpt-5.5',
+        'output' => [{ 'type' => 'function_call', 'call_id' => 'c', 'name' => 'f', 'arguments' => '{}' }],
+        'usage' => {}
+      }
+      message = provider.send(:parse_responses_response, instance_double(Faraday::Response, body:))
+
+      expect(message.content.to_s).to eq('')
+      expect(message.tool_calls['c'].name).to eq('f')
     end
   end
 


### PR DESCRIPTION
## What

Transparently routes `with_thinking(effort:) + tools` for OpenAI to `/v1/responses` — the only endpoint that accepts `reasoning` together with function tools for gpt-5.x / o-series. The default `/v1/chat/completions` path is unchanged (gated by `@openai_responses_mode`).

## Why

OpenAI reasoning models 400 on `reasoning_effort` + function tools via chat/completions ("use /v1/responses instead"), so `chat.with_thinking(effort:).with_tools(...)` is impossible for the whole gpt-5 reasoning family. Details + repro in #785.

## How (auto-route within the OpenAI provider)

- `OpenAI#render_payload` sets `@openai_responses_mode = instance_of?(OpenAI) && responses_api?(tools:, thinking:)` (true only when *both* are present) and renders a Responses payload; `completion_url` / `parse_completion_response` branch on it. The `Chat` module's `render_payload` stays pure chat/completions, and the `instance_of?` guard keeps subclasses (Azure/OpenRouter/Mistral/Perplexity/xAI/GPUStack) on chat/completions — they have no `/v1/responses`.
- New `OpenAI::Responses` module: request translation — `input` items (incl. `function_call` / `function_call_output` round-trip), flat `{type:"function",…}` tools, top-level `reasoning:{effort:}`, `text.format` for structured output, `store:false`; response parsing — `output[]` → `Message` / `ToolCall` / `Thinking` + usage (incl. `reasoning_tokens`).
- `stream_response` raises a clear error in responses mode (Responses SSE streaming not implemented yet).

## Verified

- Live: `gpt-5.5` + `with_thinking(:high)` + a function tool completes the tool loop with reasoning tokens (previously a 400).
- 18 keyless unit specs for the request/response translation + routing; the provider suite passes; RuboCop clean.

## Known follow-ups

- Responses **streaming** (different SSE event set)
- `input_image` multimodal
- Reasoning-item round-trip across turns (`include: ["reasoning.encrypted_content"]`)

I'm **open to design changes** — e.g. extracting this into a dedicated `:openai_responses` provider rather than auto-routing within `OpenAI`, or any other shape you'd prefer.

Refs #785.
