### PR TITLE
Serialize chat-created model pricing as hashes

### DIFF
--- a/lib/ruby_llm/active_record/chat_methods.rb
+++ b/lib/ruby_llm/active_record/chat_methods.rb
@@ -65,8 +65,8 @@ module RubyLLM
           m.context_window = model_info.context_window
           m.max_output_tokens = model_info.max_output_tokens
           m.capabilities = model_info.capabilities || []
-          m.modalities = model_info.modalities || {}
-          m.pricing = model_info.pricing || {}
+          m.modalities = model_info.modalities.to_h
+          m.pricing = model_info.pricing.to_h
           m.metadata = model_info.metadata || {}
         end
 

--- a/spec/ruby_llm/active_record/acts_as_model_spec.rb
+++ b/spec/ruby_llm/active_record/acts_as_model_spec.rb
@@ -305,6 +305,41 @@ RSpec.describe RubyLLM::ActiveRecord::ActsAs do
         chat.to_llm
       end
 
+      it 'persists created model attributes using JSON-serializable hashes' do
+        model_info = RubyLLM::Model::Info.new(
+          id: 'priced-registry-model',
+          name: 'Priced Registry Model',
+          provider: 'openai',
+          modalities: { input: %w[text image], output: %w[text] },
+          capabilities: ['streaming'],
+          pricing: {
+            text_tokens: {
+              standard: {
+                input_per_million: 1.25,
+                output_per_million: 5.0
+              }
+            }
+          }
+        )
+        allow(RubyLLM::Models).to receive(:resolve).and_return([model_info, nil])
+
+        chat = chat_class.create!(model_id: 'priced-registry-model')
+        created_model = chat.model.reload
+
+        expect(created_model.modalities).to eq(
+          'input' => %w[text image],
+          'output' => %w[text]
+        )
+        expect(created_model.pricing).to eq(
+          'text_tokens' => {
+            'standard' => {
+              'input_per_million' => 1.25,
+              'output_per_million' => 5.0
+            }
+          }
+        )
+      end
+
       it 'fails when model does not exist' do
         expect { chat_class.create!(model_id: 'non-existent') }.to raise_error(RubyLLM::ModelNotFoundError)
       end


### PR DESCRIPTION
## What this does

Fixes #784 by converting `Model::Info` wrapper objects to plain hashes before persisting models created through chat model resolution. This keeps `modalities` and `pricing` JSON columns in the same shape as `acts_as_model` registry sync.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

<!-- Skip this section for bug fixes and documentation -->

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: #___

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [ ] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Tests

- `bundle exec rspec spec/ruby_llm/active_record/acts_as_model_spec.rb`
- `bundle exec rubocop lib/ruby_llm/active_record/chat_methods.rb spec/ruby_llm/active_record/acts_as_model_spec.rb`
- `bundle exec rspec spec/ruby_llm/active_record`
- Pre-commit overcommit hooks (Gitleaks, TrailingWhitespace, RuboCop, AppraisalUpdate, Flay, RSpec)
