### PR TITLE
Fix generator spec for use_new_acts_as default

### DIFF
--- a/spec/ruby_llm/generators/install_generator_spec.rb
+++ b/spec/ruby_llm/generators/install_generator_spec.rb
@@ -75,7 +75,8 @@ RSpec.describe RubyLLM::Generators::InstallGenerator, :generator, type: :generat
         expect(File.exist?('config/initializers/ruby_llm.rb')).to be true
         initializer = File.read('config/initializers/ruby_llm.rb')
         expect(initializer).to include('RubyLLM.configure')
-        expect(initializer).to include('config.use_new_acts_as = true')
+        # use_new_acts_as defaults to true, so the generator no longer emits it
+        expect(initializer).not_to include('config.use_new_acts_as')
         # Default Model class doesn't need explicit config
         expect(initializer).not_to include('config.model_registry_class')
       end


### PR DESCRIPTION
## What this does

`c7e93e26` ("use_new_acts_as defaults to true") flipped the `use_new_acts_as` config default to `true` and removed the now-redundant `config.use_new_acts_as = true` line from the install generator template. It updated `configuration_spec.rb` and the dummy initializer to match, but missed `spec/ruby_llm/generators/install_generator_spec.rb`, which still asserts the removed line is present.

As a result CI has been red since `c7e93e26` — the failure is only visible on commits that touch `lib/`/`spec/`, so subsequent docs-only commits left `main`'s status green while the suite was actually broken.

This updates the assertion to expect the line is **absent**, matching the template and the new default (mirroring the existing `config.model_registry_class` assertion just below it). The upgrade-to-v1.7 generator still emits the line, so `upgrade_generators_spec.rb` is left unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

N/A — bug fix.

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]` *(N/A — spec-only change, no provider/HTTP code touched)*
  - [x] All tests pass: `bundle exec rspec spec/ruby_llm/generators/install_generator_spec.rb -e "creates initializer file"` *(the generator suite's live-API examples require provider keys and are unrelated to this change)*
- [x] I updated documentation if needed *(none needed)*
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
