### PR TITLE
Support Bedrock application inference profile ARNs as model ids

### DIFF
--- a/lib/ruby_llm/protocols/converse/chat.rb
+++ b/lib/ruby_llm/protocols/converse/chat.rb
@@ -13,7 +13,13 @@ module RubyLLM
         module_function
 
         def completion_url
-          "/model/#{@model.id}/converse"
+          "/model/#{escape_model_id(@model.id)}/converse"
+        end
+
+        # Application inference profile ARNs contain '/', but Bedrock expects the model id
+        # to remain one path segment.
+        def escape_model_id(model_id)
+          model_id.to_s.gsub('/', '%2F')
         end
 
         # rubocop:disable Metrics/ParameterLists,Lint/UnusedMethodArgument

--- a/lib/ruby_llm/protocols/converse/streaming.rb
+++ b/lib/ruby_llm/protocols/converse/streaming.rb
@@ -14,7 +14,7 @@ module RubyLLM
         private
 
         def stream_url
-          "/model/#{@model.id}/converse-stream"
+          "/model/#{escape_model_id(@model.id)}/converse-stream"
         end
 
         def stream_response(payload, additional_headers = {}, &block)

--- a/spec/ruby_llm/providers/bedrock_spec.rb
+++ b/spec/ruby_llm/providers/bedrock_spec.rb
@@ -160,4 +160,42 @@ RSpec.describe RubyLLM::Providers::Bedrock do
       expect(provider.protocol_for(model)).to eq(RubyLLM::Protocols::Converse)
     end
   end
+
+  describe 'model id path encoding' do
+    let(:converse) { RubyLLM::Protocols::Converse.allocate }
+    let(:arn) { 'arn:aws:bedrock:us-west-2:123:application-inference-profile/p' }
+
+    def with_model(id)
+      converse.instance_variable_set(:@model, instance_double(RubyLLM::Model, id: id))
+    end
+
+    it 'keeps an application inference profile ARN as a single path segment in the converse URL' do
+      with_model(arn)
+      expect(converse.send(:completion_url)).to eq(
+        '/model/arn:aws:bedrock:us-west-2:123:application-inference-profile%2Fp/converse'
+      )
+    end
+
+    it 'encodes the ARN for the converse-stream URL too' do
+      with_model(arn)
+      expect(converse.send(:stream_url)).to eq(
+        '/model/arn:aws:bedrock:us-west-2:123:application-inference-profile%2Fp/converse-stream'
+      )
+    end
+
+    it 'leaves ordinary model ids (including a ":" version suffix) unchanged' do
+      with_model('us.anthropic.claude-sonnet-4-5-20250929-v1:0')
+      expect(converse.send(:completion_url)).to eq(
+        '/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/converse'
+      )
+    end
+
+    it 'signs the ARN as one segment (SigV4 canonical path double-encodes "/", not truncates)' do
+      with_model(arn)
+      path = URI.parse(converse.send(:completion_url)).path
+      expect(described_class.allocate.send(:canonical_uri, path)).to eq(
+        '/model/arn%3Aaws%3Abedrock%3Aus-west-2%3A123%3Aapplication-inference-profile%252Fp/converse'
+      )
+    end
+  end
 end


### PR DESCRIPTION
## What this does

Fixes Bedrock so an **application inference profile ARN** can be passed as the model id.

Application inference profiles (used for cost-allocation tagging) are invoked by passing their ARN as the `modelId`. An ARN contains a `/`:

```
arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/<profile-id>
```

The Converse protocol builds the request path with the id raw — `"/model/#{@model.id}/converse"` — and the SigV4 signer (`Bedrock::Auth#canonical_uri`) splits the path on `/` to build the canonical URI. So the ARN's internal `/` is treated as a **path separator** in both the request URL and the signed canonical path, truncating the `modelId` to `.../application-inference-profile`. Bedrock then rejects the call:

> The provided model identifier is invalid

The fix percent-encodes the model id's `/` (`%2F`) so the ARN stays a **single path segment**. `canonical_uri` then re-encodes each segment, double-encoding it to `%252F` — which is exactly what SigV4 requires for non-S3 services — so the signed path and the sent path stay consistent.

This is a **no-op for ordinary model ids**, which contain no `/`. A `:` version suffix (e.g. `...-v1:0`) is a valid path-segment character and is unaffected.

Files (rebased onto current `main` after the Converse refactor, so the escaping now lives in the shared `Protocols::Converse` rather than the old `Bedrock::Chat`/`Streaming`):
- `lib/ruby_llm/protocols/converse/chat.rb` — `completion_url` now escapes the id via a new `escape_model_id` helper.
- `lib/ruby_llm/protocols/converse/streaming.rb` — `stream_url` escapes the id too (converse-stream).
- `spec/ruby_llm/providers/bedrock_spec.rb` — new unit spec covering the converse URL, the converse-stream URL, an unchanged ordinary id, and the SigV4 canonical-path encoding.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

N/A — bug fix in an existing provider, no new public API.

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]` — *N/A: this change only affects URL/path string construction; it touches no HTTP request body or response handling, and the new spec is a pure unit test (no cassette), consistent with the other top-level provider specs (`vertex_ai_auth_spec.rb`, `ollama_spec.rb`, etc.).*
  - [x] All tests pass: `bundle exec rspec spec/ruby_llm/providers/bedrock_spec.rb` (14 examples, 0 failures — the 4 new path-encoding examples alongside the existing Bedrock specs); `bundle exec rubocop` on the changed files reports no offenses.
- [x] I updated documentation if needed — *none needed.*
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

