### PR TITLE
Forward choice: and calls: from Agent tools macro to with_tools

### DIFF
--- a/docs/_core_features/agents.md
+++ b/docs/_core_features/agents.md
@@ -116,6 +116,19 @@ class CriticAgent < RubyLLM::Agent
 end
 ```
 
+`tools` accepts the same `choice:` and `calls:` options as `with_tools`, forwarding them to the underlying chat:
+
+```ruby
+class WeatherAgent < RubyLLM::Agent
+  tools Weather, Calculator, choice: :required
+end
+
+# Block form works too:
+class WeatherAgent < RubyLLM::Agent
+  tools(choice: :required) { [Weather.new, Calculator.new] }
+end
+```
+
 ## Runtime Context and Inputs
 
 Agents support runtime-evaluated values using blocks and lambdas.

--- a/lib/ruby_llm/agent.rb
+++ b/lib/ruby_llm/agent.rb
@@ -16,6 +16,7 @@ module RubyLLM
         super
         subclass.instance_variable_set(:@chat_kwargs, (@chat_kwargs || {}).dup)
         subclass.instance_variable_set(:@tools, (@tools || []).dup)
+        subclass.instance_variable_set(:@tool_options, (@tool_options || {}).dup)
         subclass.instance_variable_set(:@instructions, @instructions)
         subclass.instance_variable_set(:@temperature, @temperature)
         subclass.instance_variable_set(:@thinking, @thinking)
@@ -32,10 +33,15 @@ module RubyLLM
         @chat_kwargs = options
       end
 
-      def tools(*tools, &block)
-        return @tools || [] if tools.empty? && !block_given?
+      def tools(*tools, choice: nil, calls: nil, &block)
+        return @tools || [] if tools.empty? && !block_given? && choice.nil? && calls.nil?
 
         @tools = block_given? ? block : tools.flatten
+        @tool_options = { choice:, calls: }.compact
+      end
+
+      def tool_options
+        @tool_options || {}
       end
 
       def instructions(text = nil, **prompt_locals, &block)
@@ -208,7 +214,9 @@ module RubyLLM
 
       def apply_tools(llm_chat, runtime)
         tools_to_apply = Array(evaluate(tools, runtime))
-        llm_chat.with_tools(*tools_to_apply) unless tools_to_apply.empty?
+        return if tools_to_apply.empty?
+
+        llm_chat.with_tools(*tools_to_apply, **tool_options)
       end
 
       def apply_temperature(llm_chat)

--- a/spec/ruby_llm/agent_spec.rb
+++ b/spec/ruby_llm/agent_spec.rb
@@ -36,6 +36,83 @@ RSpec.describe RubyLLM::Agent do
     expect(chat.messages.first.content).to eq('RubyLLM::Chat')
   end
 
+  it 'forwards choice: from the tools macro positional form to with_tools' do
+    tool_class = Class.new(RubyLLM::Tool) do
+      def name = 'echo_tool'
+    end
+
+    agent_class = Class.new(RubyLLM::Agent) do
+      model 'gpt-4.1-nano'
+      tools tool_class, choice: :required
+    end
+
+    chat = agent_class.chat
+
+    expect(chat.tools.keys).to include(:echo_tool)
+    expect(chat.tool_prefs[:choice]).to eq(:required)
+  end
+
+  it 'forwards choice: from the tools macro block form to with_tools' do
+    tool_class = Class.new(RubyLLM::Tool) do
+      def name = 'echo_tool'
+    end
+
+    agent_class = Class.new(RubyLLM::Agent) do
+      model 'gpt-4.1-nano'
+      tools(choice: :required) { [tool_class.new] }
+    end
+
+    chat = agent_class.chat
+
+    expect(chat.tools.keys).to include(:echo_tool)
+    expect(chat.tool_prefs[:choice]).to eq(:required)
+  end
+
+  it 'forwards calls: from the tools macro to with_tools' do
+    tool_class = Class.new(RubyLLM::Tool) do
+      def name = 'echo_tool'
+    end
+
+    agent_class = Class.new(RubyLLM::Agent) do
+      model 'gpt-4.1-nano'
+      tools tool_class, calls: :one
+    end
+
+    chat = agent_class.chat
+
+    expect(chat.tool_prefs[:calls]).to eq(:one)
+  end
+
+  it 'keeps the zero-arg tools reader returning the configured tool list' do
+    tool_class = Class.new(RubyLLM::Tool) do
+      def name = 'echo_tool'
+    end
+
+    agent_class = Class.new(RubyLLM::Agent) do
+      model 'gpt-4.1-nano'
+      tools tool_class, choice: :required
+    end
+
+    expect(agent_class.tools).to eq([tool_class])
+  end
+
+  it 'leaves tool prefs unset when no options are given' do
+    tool_class = Class.new(RubyLLM::Tool) do
+      def name = 'echo_tool'
+    end
+
+    agent_class = Class.new(RubyLLM::Agent) do
+      model 'gpt-4.1-nano'
+      tools tool_class
+    end
+
+    chat = agent_class.chat
+
+    expect(chat.tools.keys).to include(:echo_tool)
+    expect(chat.tool_prefs[:choice]).to be_nil
+    expect(chat.tool_prefs[:calls]).to be_nil
+  end
+
   it 'raises when instructions default prompt is missing' do
     agent_class = Class.new(RubyLLM::Agent) do
       model 'gpt-4.1-nano'


### PR DESCRIPTION
## What this does

The `RubyLLM::Agent` `tools` class macro accepted only positional tools and ignored the tool-call controls (`choice:`, `calls:`) that `Chat#with_tools` has supported since 1.13.0. The docs state "tools maps to with_tools", but passing the options either crashed or was silently dropped:

```ruby
class MacroKwargAgent < RubyLLM::Agent
  tools DummyTool, choice: :required
end
MacroKwargAgent.new
# => NoMethodError: undefined method 'name' for an instance of Hash
#    (the choice: hash was swallowed into *tools and treated as a tool)

class MacroBlockAgent < RubyLLM::Agent
  tools(choice: :required) { [DummyTool.new] }
end
MacroBlockAgent.new.chat.tool_prefs[:choice]
# => nil   (silently dropped)
```

This PR makes `tools` accept `choice:` and `calls:`, store them, and forward them in `apply_tools`, so both the positional and block forms set the tool preferences on the underlying chat, equivalent to `with_tools(*tools, choice:, calls:)`.

- Reader path preserved: `tools` with no args/options still returns the configured tool list.
- Options propagated to subclasses via `inherited`.
- Forwarding `**{}` is safe since `with_tools`/`update_tool_options` already skip `nil` options.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: #___

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [x] Changed method signatures
- [ ] No API changes