### PR TITLE
Fix Bedrock streaming dropping all chunks when Faraday env is nil

### DIFF
--- a/lib/ruby_llm/protocols/converse/streaming.rb
+++ b/lib/ruby_llm/protocols/converse/streaming.rb
@@ -33,10 +33,15 @@ module RubyLLM
               end
             else
               req.options.on_data = proc do |chunk, _bytes, env|
-                if env&.status == 200
-                  parse_stream_chunk(decoder, chunk, accumulator, &block)
-                else
+                # A nil env means the status is not yet known (Faraday 2 with the
+                # net_http adapter passes nil during streaming) — process the chunk
+                # normally. Only a present env reporting a non-200 status is a real
+                # failure. Gating on `env&.status == 200` would discard every chunk
+                # whenever env is nil, yielding an empty streamed response.
+                if env && env.status != 200
                   handle_failed_stream(chunk, env)
+                else
+                  parse_stream_chunk(decoder, chunk, accumulator, &block)
                 end
               end
             end

--- a/lib/ruby_llm/protocols/converse/streaming.rb
+++ b/lib/ruby_llm/protocols/converse/streaming.rb
@@ -22,28 +22,22 @@ module RubyLLM
           decoder = event_stream_decoder
           body = JSON.generate(payload)
 
+          faraday_v1 = Faraday::VERSION.start_with?('1')
+          on_data = RubyLLM::Streaming::FaradayHandlers.build(
+            faraday_v1: faraday_v1,
+            on_chunk: ->(chunk, _env) { parse_stream_chunk(decoder, chunk, accumulator, &block) },
+            on_failed_response: ->(chunk, env) { handle_failed_stream(chunk, env) }
+          )
+
           response = @connection.post(stream_url, payload) do |req|
             req.headers.merge!(@provider.sign_headers('POST', stream_url, body))
             req.headers.merge!(additional_headers) unless additional_headers.empty?
             req.headers['Accept'] = 'application/vnd.amazon.eventstream'
 
-            if Faraday::VERSION.start_with?('1')
-              req.options[:on_data] = proc do |chunk, _size|
-                parse_stream_chunk(decoder, chunk, accumulator, &block)
-              end
+            if faraday_v1
+              req.options[:on_data] = on_data
             else
-              req.options.on_data = proc do |chunk, _bytes, env|
-                # A nil env means the status is not yet known (Faraday 2 with the
-                # net_http adapter passes nil during streaming) — process the chunk
-                # normally. Only a present env reporting a non-200 status is a real
-                # failure. Gating on `env&.status == 200` would discard every chunk
-                # whenever env is nil, yielding an empty streamed response.
-                if env && env.status != 200
-                  handle_failed_stream(chunk, env)
-                else
-                  parse_stream_chunk(decoder, chunk, accumulator, &block)
-                end
-              end
+              req.options.on_data = on_data
             end
           end
 

--- a/lib/ruby_llm/streaming.rb
+++ b/lib/ruby_llm/streaming.rb
@@ -171,10 +171,16 @@ module RubyLLM
 
       def v2_on_data(on_chunk, on_failed_response)
         proc do |chunk, _bytes, env|
-          if env&.status == 200
-            on_chunk.call(chunk, env)
-          else
+          # A nil env means the status is not yet known (Faraday 2 with the
+          # net_http adapter passes nil during streaming) — treat the chunk as a
+          # normal response chunk. Only a present env reporting a non-200 status
+          # is a real failure. Gating on `env&.status == 200` would route every
+          # chunk to the failure handler whenever env is nil, discarding the
+          # entire streamed response.
+          if env && env.status != 200
             on_failed_response.call(chunk, env)
+          else
+            on_chunk.call(chunk, env)
           end
         end
       end

--- a/lib/ruby_llm/streaming.rb
+++ b/lib/ruby_llm/streaming.rb
@@ -171,13 +171,10 @@ module RubyLLM
 
       def v2_on_data(on_chunk, on_failed_response)
         proc do |chunk, _bytes, env|
-          # A nil env means the status is not yet known (Faraday 2 with the
-          # net_http adapter passes nil during streaming) — treat the chunk as a
-          # normal response chunk. Only a present env reporting a non-200 status
-          # is a real failure. Gating on `env&.status == 200` would route every
-          # chunk to the failure handler whenever env is nil, discarding the
-          # entire streamed response.
-          if env && env.status != 200
+          # Some adapters do not expose response status during on_data.
+          status = env&.status
+
+          if status && status != 200
             on_failed_response.call(chunk, env)
           else
             on_chunk.call(chunk, env)

--- a/spec/ruby_llm/protocols/converse/streaming_spec.rb
+++ b/spec/ruby_llm/protocols/converse/streaming_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RubyLLM::Protocols::Converse::Streaming do
     Object.new.tap do |object|
       object.extend(described_class)
       object.instance_variable_set(:@model, instance_double(RubyLLM::Model, id: 'bedrock-test-model'))
+      object.define_singleton_method(:escape_model_id) { |id| id.to_s.gsub('/', '%2F') }
     end
   end
 

--- a/spec/ruby_llm/protocols/converse/streaming_spec.rb
+++ b/spec/ruby_llm/protocols/converse/streaming_spec.rb
@@ -98,4 +98,63 @@ RSpec.describe RubyLLM::Protocols::Converse::Streaming do
     expect(message.thinking.text).to eq('thinking text')
     expect(message.thinking.signature).to eq('thinking-signature')
   end
+
+  describe 'on_data routing in stream_response' do
+    # Captures the on_data proc that stream_response installs on the Faraday
+    # request, by faking @connection/@provider/req just enough to run the block.
+    let(:captured_on_data) do
+      captured = nil
+      request_options = Object.new
+      request_options.define_singleton_method(:on_data=) { |proc| captured = proc }
+      req = Object.new
+      req.define_singleton_method(:headers) { {} }
+      req.define_singleton_method(:options) { request_options }
+
+      connection = instance_double(RubyLLM::Connection)
+      allow(connection).to receive(:post) do |_url, _payload, &block|
+        block.call(req)
+        nil
+      end
+
+      provider = double('provider', sign_headers: {}) # rubocop:disable RSpec/VerifiedDoubles
+
+      streaming.instance_variable_set(:@connection, connection)
+      streaming.instance_variable_set(:@provider, provider)
+      allow(streaming).to receive_messages(event_stream_decoder: :decoder, parse_stream_chunk: nil,
+                                           handle_failed_stream: nil)
+      allow(RubyLLM::StreamAccumulator).to receive(:new).and_return(
+        instance_double(RubyLLM::StreamAccumulator, to_message: RubyLLM::Message.new(role: :assistant, content: ''))
+      )
+
+      streaming.send(:stream_response, {})
+      captured
+    end
+
+    before { stub_const('Faraday::VERSION', '2.0.0') }
+
+    # Faraday 2 with the net_http adapter passes a nil env during streaming
+    # (status unknown). Chunks must still be parsed, not dropped as failures.
+    it 'parses the chunk when env is nil (status not yet known)' do
+      captured_on_data.call('event-frame', 11, nil)
+
+      expect(streaming).to have_received(:parse_stream_chunk).with(:decoder, 'event-frame', anything)
+      expect(streaming).not_to have_received(:handle_failed_stream)
+    end
+
+    it 'parses the chunk when env reports a 200 status' do
+      env = Struct.new(:status).new(200)
+      captured_on_data.call('event-frame', 11, env)
+
+      expect(streaming).to have_received(:parse_stream_chunk).with(:decoder, 'event-frame', anything)
+      expect(streaming).not_to have_received(:handle_failed_stream)
+    end
+
+    it 'routes the chunk to failure handling when env reports a non-200 status' do
+      env = Struct.new(:status).new(403)
+      captured_on_data.call('error-frame', 11, env)
+
+      expect(streaming).to have_received(:handle_failed_stream).with('error-frame', env)
+      expect(streaming).not_to have_received(:parse_stream_chunk)
+    end
+  end
 end

--- a/spec/ruby_llm/streaming_spec.rb
+++ b/spec/ruby_llm/streaming_spec.rb
@@ -63,4 +63,52 @@ RSpec.describe RubyLLM::Streaming do
     expect(response.status).to eq(429)
     expect(response.body).to eq(parsed_error)
   end
+
+  # Faraday 2 with the net_http adapter invokes on_data with a nil env (the
+  # status is not yet known mid-stream). The handler must process such chunks
+  # normally rather than treating them as a failed response and discarding them.
+  it 'processes chunks when env is nil (status not yet known)' do
+    yielded_chunks = []
+    handler = test_obj.send(:handle_stream) { |chunk| yielded_chunks << chunk }
+
+    handler.call("data: {\"x\":\"ok\"}\n\n", 0, nil)
+
+    expect(yielded_chunks).to eq(['chunk:ok'])
+  end
+
+  describe RubyLLM::Streaming::FaradayHandlers do
+    describe '.v2_on_data' do
+      let(:on_chunk_calls) { [] }
+      let(:on_failed_calls) { [] }
+      let(:handler) do
+        described_class.v2_on_data(
+          ->(chunk, env) { on_chunk_calls << [chunk, env] },
+          ->(chunk, env) { on_failed_calls << [chunk, env] }
+        )
+      end
+
+      it 'routes the chunk to on_chunk when env is nil (status unknown)' do
+        handler.call('frame', 5, nil)
+
+        expect(on_chunk_calls).to eq([['frame', nil]])
+        expect(on_failed_calls).to be_empty
+      end
+
+      it 'routes the chunk to on_chunk when env reports a 200 status' do
+        env = Struct.new(:status).new(200)
+        handler.call('frame', 5, env)
+
+        expect(on_chunk_calls).to eq([['frame', env]])
+        expect(on_failed_calls).to be_empty
+      end
+
+      it 'routes the chunk to on_failed_response when env reports a non-200 status' do
+        env = Struct.new(:status).new(403)
+        handler.call('error-frame', 11, env)
+
+        expect(on_failed_calls).to eq([['error-frame', env]])
+        expect(on_chunk_calls).to be_empty
+      end
+    end
+  end
 end

--- a/spec/ruby_llm/streaming_spec.rb
+++ b/spec/ruby_llm/streaming_spec.rb
@@ -78,16 +78,14 @@ RSpec.describe RubyLLM::Streaming do
 
   describe RubyLLM::Streaming::FaradayHandlers do
     describe '.v2_on_data' do
-      let(:on_chunk_calls) { [] }
-      let(:on_failed_calls) { [] }
-      let(:handler) do
-        described_class.v2_on_data(
-          ->(chunk, env) { on_chunk_calls << [chunk, env] },
-          ->(chunk, env) { on_failed_calls << [chunk, env] }
-        )
-      end
-
       it 'routes the chunk to on_chunk when env is nil (status unknown)' do
+        on_chunk_calls = []
+        on_failed_calls = []
+        handler = described_class.v2_on_data(
+          ->(chunk, faraday_env) { on_chunk_calls << [chunk, faraday_env] },
+          ->(chunk, faraday_env) { on_failed_calls << [chunk, faraday_env] }
+        )
+
         handler.call('frame', 5, nil)
 
         expect(on_chunk_calls).to eq([['frame', nil]])
@@ -95,18 +93,32 @@ RSpec.describe RubyLLM::Streaming do
       end
 
       it 'routes the chunk to on_chunk when env reports a 200 status' do
-        env = Struct.new(:status).new(200)
-        handler.call('frame', 5, env)
+        on_chunk_calls = []
+        on_failed_calls = []
+        ok_env = Struct.new(:status).new(200)
+        handler = described_class.v2_on_data(
+          ->(chunk, faraday_env) { on_chunk_calls << [chunk, faraday_env] },
+          ->(chunk, faraday_env) { on_failed_calls << [chunk, faraday_env] }
+        )
 
-        expect(on_chunk_calls).to eq([['frame', env]])
+        handler.call('frame', 5, ok_env)
+
+        expect(on_chunk_calls).to eq([['frame', ok_env]])
         expect(on_failed_calls).to be_empty
       end
 
       it 'routes the chunk to on_failed_response when env reports a non-200 status' do
-        env = Struct.new(:status).new(403)
-        handler.call('error-frame', 11, env)
+        on_chunk_calls = []
+        on_failed_calls = []
+        err_env = Struct.new(:status).new(403)
+        handler = described_class.v2_on_data(
+          ->(chunk, faraday_env) { on_chunk_calls << [chunk, faraday_env] },
+          ->(chunk, faraday_env) { on_failed_calls << [chunk, faraday_env] }
+        )
 
-        expect(on_failed_calls).to eq([['error-frame', env]])
+        handler.call('error-frame', 11, err_env)
+
+        expect(on_failed_calls).to eq([['error-frame', err_env]])
         expect(on_chunk_calls).to be_empty
       end
     end


### PR DESCRIPTION
## What this does

Fixes a bug where **Bedrock ConverseStream responses come back completely empty** (zero chunks, blank content, nil token counts) even though the HTTP request succeeds with status 200.

The Faraday 2 `on_data` callback gates chunk parsing on `env&.status == 200`. With the `net_http` adapter, `env` is **nil** during streaming (the status is not yet known when chunks arrive), so this condition is false for every chunk. Each valid AWS event-stream frame is then routed to the failed-response handler, which tries to `JSON.parse` binary eventstream bytes, fails, logs a "failed stream error chunk" debug line, and silently drops it. The result is an empty streamed response.

This affects any app on Faraday 2.x + the net_http adapter (Faraday's default) using Bedrock streaming.

**Fix:** invert the guard so a nil env (status unknown) falls through to normal chunk parsing, and only a present env reporting a non-200 status is treated as a failure. Applied in both spots that build the v2 `on_data` proc:

- `RubyLLM::Streaming::FaradayHandlers.v2_on_data` (shared SSE handler)
- `RubyLLM::Protocols::Converse::Streaming#stream_response` (Bedrock ConverseStream)

### Reproduction

```ruby
chat = RubyLLM.chat(model: "us.anthropic.claude-sonnet-4-6", provider: "bedrock", assume_model_exists: true)

# Non-streaming — works:
chat.ask("Say BANANA only.").content          # => "BANANA"

# Streaming — broken before this fix:
chunks = []
resp = chat.ask("Say BANANA only.") { |c| chunks << c }
chunks.size    # => 0   (expected: > 0)
resp.content   # => ""   (expected: "BANANA")
```

With Faraday 2.x + net_http, the debug log shows the data arriving fine (`{"delta":{"text":"BANANA"}}`, usage tokens, status 200) but every frame hitting "Failed Bedrock stream error chunk". After the fix: `chunks.size => 5`, `resp.content => "BANANA"`, tokens populated.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] Added unit tests covering nil-env / 200 / non-200 routing for both code paths (`spec/ruby_llm/streaming_spec.rb`, `spec/ruby_llm/protocols/converse/streaming_spec.rb`)
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
