### PR TITLE
Add Requesty provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ MISTRAL_API_KEY=$(op read "op://RubyLLM/Mistral/credential")
 OLLAMA_API_BASE=http://localhost:11434/v1
 OPENAI_API_KEY=$(op read "op://RubyLLM/OpenAI/credential")
 OPENROUTER_API_KEY=$(op read "op://RubyLLM/OpenRouter/credential")
+REQUESTY_API_KEY=$(op read "op://RubyLLM/Requesty/credential")
 PERPLEXITY_API_KEY=$(op read "op://RubyLLM/Perplexity/credential")
 RUBYLLM_DEBUG=true
 RUBYLLM_STREAM_DEBUG=true

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ response = chat.with_schema(ProductSchema).ask "Analyze this product", with: "pr
 * **Extended thinking:** Control, view, and persist model deliberation
 * **Citations:** Normalized source citations from documents, search, and grounding
 * **Batches:** Provider-side batch processing at half price with `RubyLLM.batch`
-* **Providers:** OpenAI, xAI, Anthropic, Gemini, VertexAI, Bedrock, DeepSeek, Mistral, Ollama, OpenRouter, Perplexity, GPUStack, and any OpenAI-compatible API
+* **Providers:** OpenAI, xAI, Anthropic, Gemini, VertexAI, Bedrock, DeepSeek, Mistral, Ollama, OpenRouter, Requesty, Perplexity, GPUStack, and any OpenAI-compatible API
 
 ## Installation
 

--- a/docs/_getting_started/configuration.md
+++ b/docs/_getting_started/configuration.md
@@ -93,6 +93,10 @@ RubyLLM.configure do |config|
   config.openrouter_api_key = ENV['OPENROUTER_API_KEY']
   config.openrouter_api_base = ENV['OPENROUTER_API_BASE'] # Available in v1.13.0+ (optional custom OpenRouter endpoint)
 
+  # Requesty (https://requesty.ai) - OpenAI-compatible router
+  config.requesty_api_key = ENV['REQUESTY_API_KEY']
+  config.requesty_api_base = ENV['REQUESTY_API_BASE'] # Optional custom Requesty endpoint (defaults to https://router.requesty.ai/v1)
+
   # Perplexity
   config.perplexity_api_key = ENV['PERPLEXITY_API_KEY']
   config.perplexity_api_base = ENV['PERPLEXITY_API_BASE'] # v1.16+ (optional custom Perplexity endpoint)
@@ -483,6 +487,10 @@ RubyLLM.configure do |config|
   # OpenRouter
   config.openrouter_api_key = String
   config.openrouter_api_base = String  # v1.13.0+
+
+  # Requesty
+  config.requesty_api_key = String
+  config.requesty_api_base = String  # optional, defaults to https://router.requesty.ai/v1
 
   # Perplexity
   config.perplexity_api_key = String

--- a/docs/about.md
+++ b/docs/about.md
@@ -21,7 +21,7 @@ topics:
 
 # About RubyLLM
 
-RubyLLM is an open source Ruby gem that gives developers one consistent framework for building AI applications across OpenAI, Anthropic, Gemini, Bedrock, DeepSeek, Mistral, Ollama, OpenRouter, Perplexity, GPUStack, xAI, and OpenAI-compatible providers.
+RubyLLM is an open source Ruby gem that gives developers one consistent framework for building AI applications across OpenAI, Anthropic, Gemini, Bedrock, DeepSeek, Mistral, Ollama, OpenRouter, Requesty, Perplexity, GPUStack, xAI, and OpenAI-compatible providers.
 
 It supports chat, multi-modal inputs, image generation, embeddings, audio transcription, moderation, tools, agents, structured output, streaming, Rails integration, async workloads, and model registry access.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -217,7 +217,7 @@ response = chat.with_schema(ProductSchema).ask "Analyze this product", with: "pr
 * **Extended thinking:** Control, view, and persist model deliberation
 * **Citations:** Normalized source citations from documents, search, and grounding
 * **Batches:** Provider-side batch processing at half price with `RubyLLM.batch`
-* **Providers:** OpenAI, xAI, Anthropic, Gemini, VertexAI, Bedrock, DeepSeek, Mistral, Ollama, OpenRouter, Perplexity, GPUStack, and any OpenAI-compatible API
+* **Providers:** OpenAI, xAI, Anthropic, Gemini, VertexAI, Bedrock, DeepSeek, Mistral, Ollama, OpenRouter, Requesty, Perplexity, GPUStack, and any OpenAI-compatible API
 
 ## Installation
 

--- a/lib/ruby_llm.rb
+++ b/lib/ruby_llm.rb
@@ -119,6 +119,7 @@ RubyLLM::Provider.register :mistral, RubyLLM::Providers::Mistral
 RubyLLM::Provider.register :ollama, RubyLLM::Providers::Ollama
 RubyLLM::Provider.register :openai, RubyLLM::Providers::OpenAI
 RubyLLM::Provider.register :openrouter, RubyLLM::Providers::OpenRouter
+RubyLLM::Provider.register :requesty, RubyLLM::Providers::Requesty
 RubyLLM::Provider.register :perplexity, RubyLLM::Providers::Perplexity
 RubyLLM::Provider.register :vertexai, RubyLLM::Providers::VertexAI
 RubyLLM::Provider.register :xai, RubyLLM::Providers::XAI

--- a/lib/ruby_llm/providers/requesty.rb
+++ b/lib/ruby_llm/providers/requesty.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    # Requesty API integration. Requesty is an OpenAI-compatible router
+    # (https://router.requesty.ai/v1) that exposes many models behind a single
+    # endpoint, using provider/model identifiers (e.g. openai/gpt-4o-mini).
+    class Requesty < Provider
+      # Requesty's dialect of the Chat Completions API.
+      class ChatCompletions < Protocols::ChatCompletions
+        include Requesty::Chat
+        include Requesty::Images
+        include Requesty::Models
+        include Requesty::Streaming
+      end
+
+      protocol :chat_completions, ChatCompletions
+
+      def api_base
+        @config.requesty_api_base || 'https://router.requesty.ai/v1'
+      end
+
+      def headers
+        {
+          'Authorization' => "Bearer #{@config.requesty_api_key}"
+        }
+      end
+
+      def parse_error(response)
+        return if response.body.empty?
+
+        body = try_parse_json(response.body)
+        case body
+        when Hash
+          parse_error_part_message body
+        when Array
+          body.map do |part|
+            parse_error_part_message part
+          end.join('. ')
+        else
+          body
+        end
+      end
+
+      class << self
+        def configuration_options
+          %i[requesty_api_key requesty_api_base]
+        end
+
+        def configuration_requirements
+          %i[requesty_api_key]
+        end
+      end
+
+      private
+
+      def parse_error_part_message(part)
+        message = part.dig('error', 'message')
+        raw = try_parse_json(part.dig('error', 'metadata', 'raw'))
+        return message unless raw.is_a?(Hash)
+
+        raw_message = raw.dig('error', 'message')
+        return [message, raw_message].compact.join(' - ') if raw_message
+
+        message
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/requesty/chat.rb
+++ b/lib/ruby_llm/providers/requesty/chat.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class Requesty
+      # Chat methods of the Requesty API integration
+      module Chat
+        module_function
+
+        # rubocop:disable Metrics/ParameterLists
+        def render_payload(messages, tools:, temperature:, model:, stream: false, schema: nil,
+                           thinking: nil, citations: false, tool_prefs: nil)
+          payload = super
+          payload.delete(:reasoning_effort)
+          strip_schema_strict(payload)
+
+          reasoning = build_reasoning(thinking)
+          payload[:reasoning] = reasoning if reasoning
+          payload
+        end
+        # rubocop:enable Metrics/ParameterLists
+
+        def strip_schema_strict(payload)
+          schema_def = payload.dig(:response_format, :json_schema, :schema)
+          return unless schema_def.is_a?(Hash)
+
+          schema_def = RubyLLM::Utils.deep_dup(schema_def)
+          schema_def.delete(:strict)
+          schema_def.delete('strict')
+          payload[:response_format][:json_schema][:schema] = schema_def
+        end
+
+        def build_reasoning(thinking)
+          return nil unless thinking&.enabled?
+
+          reasoning = {}
+          reasoning[:effort] = thinking.effort if thinking.respond_to?(:effort) && thinking.effort
+          reasoning[:max_tokens] = thinking.budget if thinking.respond_to?(:budget) && thinking.budget
+          reasoning[:enabled] = true if reasoning.empty?
+          reasoning
+        end
+
+        def format_thinking(msg)
+          thinking = msg.thinking
+          return {} unless thinking && msg.role == :assistant
+
+          details = []
+          if thinking.text
+            details << {
+              type: 'reasoning.text',
+              text: thinking.text,
+              signature: thinking.signature
+            }.compact
+          elsif thinking.signature
+            details << {
+              type: 'reasoning.encrypted',
+              data: thinking.signature
+            }
+          end
+
+          details.empty? ? {} : { reasoning_details: details }
+        end
+
+        def extract_thinking_text(message_data)
+          candidate = message_data['reasoning']
+          return candidate if candidate.is_a?(String)
+
+          details = message_data['reasoning_details']
+          return nil unless details.is_a?(Array)
+
+          text = details.filter_map do |detail|
+            case detail['type']
+            when 'reasoning.text'
+              detail['text']
+            when 'reasoning.summary'
+              detail['summary']
+            end
+          end.join
+
+          text.empty? ? nil : text
+        end
+
+        def extract_thinking_signature(message_data)
+          details = message_data['reasoning_details']
+          return nil unless details.is_a?(Array)
+
+          signature = details.filter_map do |detail|
+            detail['signature'] if detail['signature'].is_a?(String)
+          end.first
+          return signature if signature
+
+          encrypted = details.find { |detail| detail['type'] == 'reasoning.encrypted' && detail['data'].is_a?(String) }
+          encrypted&.dig('data')
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/requesty/images.rb
+++ b/lib/ruby_llm/providers/requesty/images.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class Requesty
+      # Image generation methods for the Requesty API integration.
+      # Like OpenRouter, Requesty routes image generation through the chat
+      # completions endpoint instead of a dedicated images endpoint.
+      module Images
+        module_function
+
+        def images_url(with: nil, mask: nil) # rubocop:disable Lint/UnusedMethodArgument
+          'chat/completions'
+        end
+
+        def render_image_payload(prompt, model:, size:, with: nil, mask: nil, params: {}) # rubocop:disable Lint/UnusedMethodArgument,Metrics/ParameterLists
+          RubyLLM.logger.debug { "Ignoring size #{size}. Requesty image generation does not support size parameter." }
+          {
+            model: model,
+            messages: [
+              {
+                role: 'user',
+                content: prompt
+              }
+            ],
+            modalities: %w[image text]
+          }
+        end
+
+        def parse_image_response(response, model:)
+          data = response.body
+          message = data.dig('choices', 0, 'message')
+
+          unless message&.key?('images') && message['images']&.any?
+            raise Error.new(nil, 'Unexpected response format from Requesty image generation API')
+          end
+
+          image_data = message['images'].first
+          image_url = image_data.dig('image_url', 'url') || image_data['url']
+
+          raise Error.new(nil, 'No image URL found in Requesty response') unless image_url
+
+          build_image_from_url(image_url, model)
+        end
+
+        def build_image_from_url(image_url, model)
+          if image_url.start_with?('data:')
+            # Parse data URL format: data:image/png;base64,<data>
+            match = image_url.match(/^data:([^;]+);base64,(.+)$/)
+            raise Error.new(nil, 'Invalid data URL format from Requesty') unless match
+
+            Image.new(
+              data: match[2],
+              mime_type: match[1],
+              model_id: model
+            )
+          else
+            # Regular URL
+            Image.new(
+              url: image_url,
+              mime_type: 'image/png',
+              model_id: model
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/requesty/models.rb
+++ b/lib/ruby_llm/providers/requesty/models.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class Requesty
+      # Models methods of the Requesty API integration
+      module Models
+        module_function
+
+        def models_url
+          'models'
+        end
+
+        def parse_list_models_response(response, slug, _capabilities)
+          Array(response.body['data']).map do |model_data| # rubocop:disable Metrics/BlockLength
+            modalities = {
+              input: Array(model_data.dig('architecture', 'input_modalities')),
+              output: Array(model_data.dig('architecture', 'output_modalities'))
+            }
+
+            pricing = { text_tokens: { standard: {} } }
+
+            pricing_types = {
+              prompt: :input_per_million,
+              completion: :output_per_million,
+              input_cache_read: :cache_read_input_per_million,
+              internal_reasoning: :reasoning_output_per_million
+            }
+
+            pricing_types.each do |source_key, target_key|
+              value = model_data.dig('pricing', source_key.to_s).to_f
+              pricing[:text_tokens][:standard][target_key] = value * 1_000_000 if value.positive?
+            end
+
+            capabilities = supported_parameters_to_capabilities(model_data['supported_parameters'])
+
+            Model::Info.new(
+              id: model_data['id'],
+              name: model_data['name'],
+              provider: slug,
+              family: model_data['id'].split('/').first,
+              created_at: model_data['created'] ? Time.at(model_data['created']) : nil,
+              context_window: model_data['context_length'],
+              max_output_tokens: model_data.dig('top_provider', 'max_completion_tokens'),
+              modalities: modalities,
+              capabilities: capabilities,
+              pricing: pricing,
+              metadata: {
+                description: model_data['description'],
+                architecture: model_data['architecture'],
+                top_provider: model_data['top_provider'],
+                per_request_limits: model_data['per_request_limits'],
+                supported_parameters: model_data['supported_parameters']
+              }
+            )
+          end
+        end
+
+        def supported_parameters_to_capabilities(params)
+          return [] unless params
+
+          capabilities = []
+          capabilities << 'streaming'
+          capabilities << 'function_calling' if params.include?('tools') || params.include?('tool_choice')
+          capabilities << 'structured_output' if params.include?('response_format')
+          capabilities << 'batch' if params.include?('batch')
+          capabilities << 'predicted_outputs' if params.include?('logit_bias') && params.include?('top_k')
+          capabilities
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/requesty/streaming.rb
+++ b/lib/ruby_llm/providers/requesty/streaming.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class Requesty
+      # Streaming methods of the Requesty API integration
+      module Streaming
+        module_function
+
+        def build_chunk(data)
+          usage = data['usage'] || {}
+          delta = data.dig('choices', 0, 'delta') || {}
+
+          Chunk.new(
+            role: :assistant,
+            model_id: data['model'],
+            content: delta['content'],
+            thinking: Thinking.build(
+              text: extract_thinking_text(delta),
+              signature: extract_thinking_signature(delta)
+            ),
+            tool_calls: parse_tool_calls(delta['tool_calls'], parse_arguments: false),
+            input_tokens: input_tokens(usage),
+            output_tokens: output_tokens(usage),
+            cached_tokens: cache_read_tokens(usage),
+            cache_creation_tokens: cache_write_tokens(usage),
+            thinking_tokens: thinking_tokens(usage)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/models.rake
+++ b/lib/tasks/models.rake
@@ -42,6 +42,7 @@ def configure_from_env
     config.mistral_api_key = ENV.fetch('MISTRAL_API_KEY', nil)
     config.openai_api_key = ENV.fetch('OPENAI_API_KEY', nil)
     config.openrouter_api_key = ENV.fetch('OPENROUTER_API_KEY', nil)
+    config.requesty_api_key = ENV.fetch('REQUESTY_API_KEY', nil)
     config.perplexity_api_key = ENV.fetch('PERPLEXITY_API_KEY', nil)
     config.vertexai_location = ENV.fetch('GOOGLE_CLOUD_LOCATION', nil)
     config.vertexai_project_id = ENV.fetch('GOOGLE_CLOUD_PROJECT', nil)

--- a/spec/ruby_llm/provider_spec.rb
+++ b/spec/ruby_llm/provider_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe RubyLLM::Provider do
         custom: 'https://openrouter-proxy.example.com/api/v1',
         default: 'https://openrouter.ai/api/v1'
       },
+      requesty: {
+        provider: RubyLLM::Providers::Requesty,
+        key: :requesty_api_base,
+        custom: 'https://requesty-proxy.example.com/v1',
+        default: 'https://router.requesty.ai/v1'
+      },
       perplexity: {
         provider: RubyLLM::Providers::Perplexity,
         key: :perplexity_api_base,
@@ -108,6 +114,8 @@ RSpec.describe RubyLLM::Provider do
         config.openai_api_key = 'openai-key'
       when :openrouter
         config.openrouter_api_key = 'openrouter-key'
+      when :requesty
+        config.requesty_api_key = 'requesty-key'
       when :perplexity
         config.perplexity_api_key = 'perplexity-key'
       when :vertexai


### PR DESCRIPTION
## Add Requesty provider

This adds [Requesty](https://requesty.ai) as a provider, alongside the existing OpenRouter / OpenAI / Anthropic / etc.

Requesty is an OpenAI-compatible model router that uses the same `provider/model` identifier format as OpenRouter, so it is implemented by mirroring the existing OpenRouter provider 1:1 (the provider class + chat/images/models/streaming mixins), differing only in base URL and config keys.

### Changes
- `lib/ruby_llm/providers/requesty.rb` + `lib/ruby_llm/providers/requesty/{chat,images,models,streaming}.rb` (new) — mirror of the OpenRouter provider. `api_base` defaults to `https://router.requesty.ai/v1`; config keys `requesty_api_key` / `requesty_api_base`.
- `lib/ruby_llm.rb` — `RubyLLM::Provider.register :requesty, RubyLLM::Providers::Requesty`.
- `lib/tasks/models.rake`, `.env.example` — `REQUESTY_API_KEY` wiring.
- `README.md`, `docs/index.md`, `docs/about.md`, `docs/_getting_started/configuration.md` — list Requesty in the providers list and config reference.

(I did not add a provider logo SVG under `docs/assets/images/external/providers/` — happy to add the official asset if you'd like it in the homepage logo strip.)

### Testing
- `ruby -c` passes on all new/changed Ruby files.
- Eager-load smoke test (Ruby 3.4): `RubyLLM::Provider.providers` includes `:requesty`, the class and `Requesty::Models` mixin resolve via Zeitwerk.
- Live endpoint: `POST https://router.requesty.ai/v1/chat/completions` with `openai/gpt-4o-mini` -> real completion; `GET /v1/models` -> 200 (554 models).

### Disclosure
I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust naming/placement or close it if it's not a fit.
