### PR TITLE
Add bedrock model ID fallback

### DIFF
--- a/lib/ruby_llm/protocols/converse/chat.rb
+++ b/lib/ruby_llm/protocols/converse/chat.rb
@@ -81,7 +81,7 @@ module RubyLLM
             cache_write_tokens: usage['cacheWriteInputTokens'],
             thinking_tokens: reasoning_tokens(usage),
             finish_reason: data['stopReason'],
-            model: data['modelId'],
+            model: data['modelId'] || @model&.id,
             raw: raw
           )
         end

--- a/spec/ruby_llm/protocols/converse/chat_spec.rb
+++ b/spec/ruby_llm/protocols/converse/chat_spec.rb
@@ -73,6 +73,25 @@ RSpec.describe RubyLLM::Protocols::Converse::Chat do
       expect(message.finish_reason).to eq('guardrail_intervened')
     end
 
+    it 'falls back to the request model when Bedrock omits modelId' do
+      response_body = {
+        'output' => {
+          'message' => {
+            'content' => [{ 'text' => 'Hi!' }]
+          }
+        },
+        'usage' => {}
+      }
+
+      provider = double(config: RubyLLM.config, connection: nil)
+      model = instance_double(RubyLLM::Model, id: 'openai.gpt-oss-120b-1:0')
+      protocol = RubyLLM::Protocols::Converse.new(provider, model)
+      response = instance_double(Faraday::Response, body: response_body)
+      message = protocol.send(:parse_completion_body, response_body, raw: response)
+
+      expect(message.model).to eq('openai.gpt-oss-120b-1:0')
+    end
+
     it 'extracts thinking tokens from top-level reasoningTokens' do
       response_body = {
         'output' => {


### PR DESCRIPTION
## What this does

Fix Bedrock Converse non-streaming responses so `Message#model_id` falls back to the request model when Bedrock omits `modelId`.

### Why

Bedrock Converse responses do not include `modelId`, so non-streaming messages currently get `model_id: nil`. That prevents `Message#cost` from resolving pricing, even though the request model is known. Streaming already falls back to `@model.id`; this makes non-streaming match that behavior.

### Reproduction

```ruby
require 'ruby_llm'

RubyLLM.configure do |config|
  config.bedrock_api_key = ENV.fetch('AWS_ACCESS_KEY_ID')
  config.bedrock_secret_key = ENV.fetch('AWS_SECRET_ACCESS_KEY')
  config.bedrock_session_token = ENV['AWS_SESSION_TOKEN']
  config.bedrock_region = ENV.fetch('AWS_REGION')
end

message = RubyLLM.chat(model: 'openai.gpt-oss-120b-1:0', provider: :bedrock).ask('Say hi in one sentence.')

puts "model_id: #{message.model_id.inspect}"
puts "input_tokens: #{message.input_tokens.inspect}"
puts "output_tokens: #{message.output_tokens.inspect}"
puts "cost_total: #{message.cost.total.inspect}"
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [x] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
