### PR TITLE
Expose persisted assistant message during streaming

### DIFF
--- a/docs/_advanced/rails-streaming.md
+++ b/docs/_advanced/rails-streaming.md
@@ -88,11 +88,8 @@ class ChatStreamJob < ApplicationJob
     chat = Chat.find(chat_id)
 
     chat.complete do |chunk|
-      # Get the assistant message record (created before streaming starts)
-      assistant_message = chat.messages.last
-      if chunk.content && assistant_message
-        assistant_message.broadcast_append_chunk(chunk.content)
-      end
+      # chat.message is the assistant record created before streaming starts
+      chat.message.broadcast_append_chunk(chunk.content) if chunk.content.present?
     end
   end
 end

--- a/lib/generators/ruby_llm/chat_ui/templates/jobs/chat_response_job.rb.tt
+++ b/lib/generators/ruby_llm/chat_ui/templates/jobs/chat_response_job.rb.tt
@@ -4,8 +4,7 @@ class <%= chat_job_class_name %> < ApplicationJob
 
     <%= chat_variable_name %>.ask(content) do |chunk|
       if chunk.content && !chunk.content.empty?
-        <%= message_variable_name %> = <%= chat_variable_name %>.<%= message_table_name %>.last
-        <%= message_variable_name %>.broadcast_append_chunk(chunk.content)
+        <%= chat_variable_name %>.message.broadcast_append_chunk(chunk.content)
       end
     end
   end

--- a/lib/ruby_llm/active_record/chat_methods.rb
+++ b/lib/ruby_llm/active_record/chat_methods.rb
@@ -16,6 +16,11 @@ module RubyLLM
 
       attr_accessor :assume_model_exists, :context
 
+      # The assistant message record currently being persisted during a complete/ask call.
+      # Set by persist_new_message before streaming starts; reassigned on each tool-flow turn.
+      # Useful for broadcasting streamed chunks without relying on messages.last.
+      attr_reader :message
+
       def messages_association
         send(messages_association_name)
       end

--- a/spec/ruby_llm/active_record/acts_as_spec.rb
+++ b/spec/ruby_llm/active_record/acts_as_spec.rb
@@ -768,6 +768,77 @@ RSpec.describe RubyLLM::ActiveRecord::ActsAs do
     end
   end
 
+  describe 'persisted assistant message reader' do
+    it 'is nil before a completion and points at the assistant record afterwards' do
+      chat = Chat.create!(model: model)
+      provider = chat.to_llm.instance_variable_get(:@provider)
+      allow(provider).to receive(:complete).and_return(RubyLLM::Message.new(role: :assistant, content: 'Hello back'))
+
+      expect(chat.message).to be_nil
+
+      chat.ask('Hello')
+
+      expect(chat.message).to be_a(Message)
+      expect(chat.message.role).to eq('assistant')
+      expect(chat.message.content).to eq('Hello back')
+      expect(chat.message).to eq(chat.messages.order(:id).last)
+    end
+
+    it 'is available inside the streaming block as the in-progress assistant record' do
+      chat = Chat.create!(model: model)
+      llm_chat = chat.to_llm
+      provider = llm_chat.instance_variable_get(:@provider)
+
+      allow(provider).to receive(:complete) do |*, &block|
+        block&.call(RubyLLM::Chunk.new(role: :assistant, content: 'Hel'))
+        block&.call(RubyLLM::Chunk.new(role: :assistant, content: 'lo'))
+        RubyLLM::Message.new(role: :assistant, content: 'Hello')
+      end
+
+      messages_seen = []
+      chat.ask('Hi') do |_chunk|
+        messages_seen << chat.message
+      end
+
+      expect(messages_seen.size).to eq(2)
+      expect(messages_seen).to all(be_a(Message))
+      expect(messages_seen.map(&:id).uniq).to eq([chat.message.id])
+      expect(chat.message.role).to eq('assistant')
+      expect(chat.message.content).to eq('Hello')
+    end
+
+    it 'reassigns message on each tool-flow assistant turn' do
+      chat = Chat.create!(model: model).with_tool(Calculator)
+      llm_chat = chat.to_llm
+      provider = llm_chat.instance_variable_get(:@provider)
+
+      tool_call = RubyLLM::ToolCall.new(id: 'call_1', name: 'calculator', arguments: { expression: '2 + 2' })
+      call_count = 0
+      assistant_ids_during_stream = []
+
+      allow(provider).to receive(:complete) do |*, &block|
+        call_count += 1
+        if call_count == 1
+          block&.call(RubyLLM::Chunk.new(role: :assistant, content: nil, tool_calls: { 'call_1' => tool_call }))
+          RubyLLM::Message.new(role: :assistant, content: nil, tool_calls: { 'call_1' => tool_call })
+        else
+          block&.call(RubyLLM::Chunk.new(role: :assistant, content: '4'))
+          RubyLLM::Message.new(role: :assistant, content: '4')
+        end
+      end
+
+      chat.ask('What is 2 + 2?') do |_chunk|
+        assistant_ids_during_stream << chat.message.id if chat.message
+      end
+
+      assistant_messages = chat.messages.where(role: :assistant).order(:id)
+      expect(assistant_messages.count).to be >= 2
+      expect(assistant_ids_during_stream).not_to be_empty
+      expect(chat.message).to eq(assistant_messages.last)
+      expect(chat.message.content).to eq('4')
+    end
+  end
+
   describe 'event callbacks' do
     it 'runs additive callbacks while preserving persistence callbacks' do
       first_callback_called = false

--- a/spec/ruby_llm/generators/chat_ui_generator_spec.rb
+++ b/spec/ruby_llm/generators/chat_ui_generator_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe RubyLLM::Generators::ChatUIGenerator, :generator, type: :generato
         class_name: 'class ChatResponseJob',
         lookup_line: 'chat = Chat.find(chat_id)',
         ask_line: 'chat.ask(content)',
-        last_message_line: 'message = chat.messages.last'
+        last_message_line: 'chat.message.broadcast_append_chunk(chunk.content)'
       },
       functionality_example: 'chat functionality works correctly',
       functionality_script: <<~RUBY
@@ -271,7 +271,7 @@ RSpec.describe RubyLLM::Generators::ChatUIGenerator, :generator, type: :generato
         class_name: 'class LlmChatResponseJob',
         lookup_line: 'llm_chat = Llm::Chat.find(llm_chat_id)',
         ask_line: 'llm_chat.ask(content)',
-        last_message_line: 'llm_message = llm_chat.llm_messages.last'
+        last_message_line: 'llm_chat.message.broadcast_append_chunk(chunk.content)'
       },
       extra_view_example: 'views use correct partial paths',
       extra_view_assertions: lambda do


### PR DESCRIPTION
## Summary

- Add a public `attr_reader :message` on `acts_as_chat` models that exposes the assistant record currently being persisted during `complete`/`ask` (including across tool-flow turns).
- Lets streaming blocks broadcast against the stable in-memory record without relying on `messages.last`, `before_message` capture, or private ivar access.
- Update the chat UI generator job template and streaming docs to use the new reader.

Closes #814

## Usage

```ruby
chat.complete do |chunk|
  chat.message.broadcast_append_chunk(chunk.content) if chunk.content.present?
end
```

## Test plan

- [x] Specs for `chat.message` nil before completion and set afterwards
- [x] Specs for `chat.message` available inside the streaming block
- [x] Specs for reassignment on tool-flow assistant turns
- [x] Generator job expectations updated and passing
- [ ] CI green on this PR