### PR TITLE
Support VertexAI embedding task_type and title

### DIFF
--- a/lib/ruby_llm/embedding.rb
+++ b/lib/ruby_llm/embedding.rb
@@ -16,7 +16,8 @@ module RubyLLM
                    provider: nil,
                    assume_model_exists: false,
                    context: nil,
-                   dimensions: nil)
+                   dimensions: nil,
+                   **provider_params)
       config = context&.config || RubyLLM.config
       model ||= config.default_embedding_model
       model, provider_instance = Models.resolve(model, provider: provider, assume_exists: assume_model_exists,
@@ -33,7 +34,7 @@ module RubyLLM
       }
 
       RubyLLM.instrument('embedding.ruby_llm', payload, config: config) do |event|
-        result = provider_instance.embed(text, model: model_id, dimensions:)
+        result = provider_instance.embed(text, model: model_id, dimensions:, **provider_params)
         event[:result] = result
         event[:response_model] = result.model
         event[:input_tokens] = result.input_tokens

--- a/lib/ruby_llm/protocol.rb
+++ b/lib/ruby_llm/protocol.rb
@@ -56,8 +56,8 @@ module RubyLLM
       parse_list_models_response response, @provider.slug, @provider.capabilities
     end
 
-    def embed(text, model:, dimensions:)
-      payload = render_embedding_payload(text, model:, dimensions:)
+    def embed(text, model:, dimensions:, **provider_params)
+      payload = render_embedding_payload(text, model:, dimensions:, **provider_params)
       response = @connection.post(embedding_url(model:), payload)
       parse_embedding_response(response, model:, text:)
     end

--- a/lib/ruby_llm/protocols/chat_completions/embeddings.rb
+++ b/lib/ruby_llm/protocols/chat_completions/embeddings.rb
@@ -11,7 +11,7 @@ module RubyLLM
           'embeddings'
         end
 
-        def render_embedding_payload(text, model:, dimensions:)
+        def render_embedding_payload(text, model:, dimensions:, **)
           {
             model: model,
             input: text,

--- a/lib/ruby_llm/protocols/gemini/embeddings.rb
+++ b/lib/ruby_llm/protocols/gemini/embeddings.rb
@@ -11,7 +11,7 @@ module RubyLLM
           "models/#{model}:batchEmbedContents"
         end
 
-        def render_embedding_payload(text, model:, dimensions:)
+        def render_embedding_payload(text, model:, dimensions:, **)
           { requests: [text].flatten.map { |t| single_embedding_payload(t, model:, dimensions:) } }
         end
 

--- a/lib/ruby_llm/provider.rb
+++ b/lib/ruby_llm/provider.rb
@@ -134,8 +134,8 @@ module RubyLLM
       default_protocol.new(self).list_models
     end
 
-    def embed(text, model:, dimensions:)
-      default_protocol.new(self).embed(text, model:, dimensions:)
+    def embed(text, model:, dimensions:, **provider_params)
+      default_protocol.new(self).embed(text, model:, dimensions:, **provider_params)
     end
 
     def moderate(input, model:)

--- a/lib/ruby_llm/providers/azure/embeddings.rb
+++ b/lib/ruby_llm/providers/azure/embeddings.rb
@@ -11,7 +11,7 @@ module RubyLLM
           azure_endpoint(:embeddings)
         end
 
-        def render_embedding_payload(text, model:, dimensions:)
+        def render_embedding_payload(text, model:, dimensions:, **)
           {
             model: model,
             input: [text].flatten,

--- a/lib/ruby_llm/providers/mistral/embeddings.rb
+++ b/lib/ruby_llm/providers/mistral/embeddings.rb
@@ -11,7 +11,7 @@ module RubyLLM
           'embeddings'
         end
 
-        def render_embedding_payload(text, model:, dimensions:) # rubocop:disable Lint/UnusedMethodArgument
+        def render_embedding_payload(text, model:, dimensions:, **) # rubocop:disable Lint/UnusedMethodArgument
           {
             model: model,
             input: text

--- a/lib/ruby_llm/providers/vertexai/embeddings.rb
+++ b/lib/ruby_llm/providers/vertexai/embeddings.rb
@@ -11,10 +11,15 @@ module RubyLLM
           "#{@provider.model_path(model)}:predict"
         end
 
-        def render_embedding_payload(text, model:, dimensions:) # rubocop:disable Lint/UnusedMethodArgument
-          {
-            instances: [text].flatten.map { |t| { content: t.to_s } }
-          }.tap do |payload|
+        def render_embedding_payload(text, model:, dimensions:, task_type: nil, title: nil, **) # rubocop:disable Lint/UnusedMethodArgument
+          instances = [text].flatten.map do |t|
+            instance = { content: t.to_s }
+            instance[:task_type] = task_type if task_type
+            instance[:title] = title if title
+            instance
+          end
+
+          { instances: instances }.tap do |payload|
             payload[:parameters] = { outputDimensionality: dimensions } if dimensions
           end
         end

--- a/spec/ruby_llm/embedding_provider_params_spec.rb
+++ b/spec/ruby_llm/embedding_provider_params_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'embedding provider params' do
+  let(:config) { RubyLLM.config }
+  let(:provider) { instance_double(RubyLLM::Providers::VertexAI, slug: 'vertexai') }
+  let(:model) { instance_double(RubyLLM::Model::Info, id: 'gemini-embedding-001') }
+
+  before do
+    allow(RubyLLM::Models).to receive(:resolve).and_return([model, provider])
+    allow(RubyLLM).to receive(:instrument).and_yield({})
+  end
+
+  it 'forwards task_type to the provider embed call' do
+    result = instance_double(RubyLLM::Embedding, model: 'gemini-embedding-001', input_tokens: 0, vectors: [0.1, 0.2])
+    allow(provider).to receive(:embed).and_return(result)
+    allow(provider).to receive(:class).and_return(RubyLLM::Providers::VertexAI)
+
+    RubyLLM.embed(
+      'hello',
+      model: 'gemini-embedding-001',
+      provider: :vertexai,
+      dimensions: 1536,
+      task_type: 'SEMANTIC_SIMILARITY'
+    )
+
+    expect(provider).to have_received(:embed).with(
+      'hello',
+      model: 'gemini-embedding-001',
+      dimensions: 1536,
+      task_type: 'SEMANTIC_SIMILARITY'
+    )
+  end
+
+  it 'forwards title alongside task_type' do
+    result = instance_double(RubyLLM::Embedding, model: 'gemini-embedding-001', input_tokens: 0, vectors: [0.1, 0.2])
+    allow(provider).to receive(:embed).and_return(result)
+    allow(provider).to receive(:class).and_return(RubyLLM::Providers::VertexAI)
+
+    RubyLLM.embed(
+      'hello',
+      model: 'gemini-embedding-001',
+      provider: :vertexai,
+      task_type: 'RETRIEVAL_DOCUMENT',
+      title: 'My Document'
+    )
+
+    expect(provider).to have_received(:embed).with(
+      'hello',
+      model: 'gemini-embedding-001',
+      dimensions: nil,
+      task_type: 'RETRIEVAL_DOCUMENT',
+      title: 'My Document'
+    )
+  end
+end

--- a/spec/ruby_llm/providers/vertex_ai/embeddings_spec.rb
+++ b/spec/ruby_llm/providers/vertex_ai/embeddings_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::VertexAI::Embeddings do
+  let(:config) do
+    instance_double(
+      RubyLLM::Configuration,
+      request_timeout: 300,
+      max_retries: 3,
+      retry_interval: 0.1,
+      retry_interval_randomness: 0.5,
+      retry_backoff_factor: 2,
+      http_proxy: nil,
+      faraday_adapter: :net_http,
+      vertexai_location: 'us-central1',
+      vertexai_project_id: 'test-project',
+      vertexai_api_base: nil,
+      vertexai_protocol: nil
+    )
+  end
+  let(:provider) { RubyLLM::Providers::VertexAI.new(config) }
+  let(:protocol) { RubyLLM::Providers::VertexAI::Gemini.new(provider) }
+
+  describe '#render_embedding_payload' do
+    it 'includes content for each instance' do
+      payload = protocol.send(:render_embedding_payload, 'hello', model: 'gemini-embedding-001', dimensions: nil)
+
+      expect(payload).to eq(instances: [{ content: 'hello' }])
+    end
+
+    it 'includes outputDimensionality when dimensions are provided' do
+      payload = protocol.send(
+        :render_embedding_payload,
+        'hello',
+        model: 'gemini-embedding-001',
+        dimensions: 1536
+      )
+
+      expect(payload).to eq(
+        instances: [{ content: 'hello' }],
+        parameters: { outputDimensionality: 1536 }
+      )
+    end
+
+    it 'includes task_type when provided' do
+      payload = protocol.send(
+        :render_embedding_payload,
+        'hello',
+        model: 'gemini-embedding-001',
+        dimensions: 1536,
+        task_type: 'SEMANTIC_SIMILARITY'
+      )
+
+      expect(payload).to eq(
+        instances: [{ content: 'hello', task_type: 'SEMANTIC_SIMILARITY' }],
+        parameters: { outputDimensionality: 1536 }
+      )
+    end
+
+    it 'includes title when provided' do
+      payload = protocol.send(
+        :render_embedding_payload,
+        'hello',
+        model: 'gemini-embedding-001',
+        dimensions: nil,
+        task_type: 'RETRIEVAL_DOCUMENT',
+        title: 'Doc title'
+      )
+
+      expect(payload).to eq(
+        instances: [{ content: 'hello', task_type: 'RETRIEVAL_DOCUMENT', title: 'Doc title' }]
+      )
+    end
+
+    it 'applies task_type to every instance in a batch' do
+      payload = protocol.send(
+        :render_embedding_payload,
+        %w[one two],
+        model: 'gemini-embedding-001',
+        dimensions: nil,
+        task_type: 'RETRIEVAL_QUERY'
+      )
+
+      expect(payload[:instances]).to eq(
+        [
+          { content: 'one', task_type: 'RETRIEVAL_QUERY' },
+          { content: 'two', task_type: 'RETRIEVAL_QUERY' }
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Plumbs provider-specific kwargs (`**provider_params`) through `RubyLLM.embed` → `Provider#embed` → `Protocol#embed` → `render_embedding_payload`
- VertexAI embedding payloads can now include `task_type` (e.g. `SEMANTIC_SIMILARITY`, `RETRIEVAL_QUERY`, `RETRIEVAL_DOCUMENT`) and optional `title` on each instance
- Other embedding providers ignore unknown kwargs via `**` splat so extra options don't raise

Fixes #810

## Usage

```ruby
RubyLLM.embed(
  "hello",
  model: "gemini-embedding-001",
  provider: :vertexai,
  dimensions: 1536,
  task_type: "SEMANTIC_SIMILARITY"
)
```

Produces a VertexAI payload shaped like:

```json
{
  "instances": [
    {
      "content": "hello",
      "task_type": "SEMANTIC_SIMILARITY"
    }
  ],
  "parameters": {
    "outputDimensionality": 1536
  }
}
```

For document embeddings:

```ruby
RubyLLM.embed(
  "document body",
  model: "gemini-embedding-001",
  provider: :vertexai,
  task_type: "RETRIEVAL_DOCUMENT",
  title: "My Document"
)
```

## Test plan

- [x] Added unit specs for `VertexAI::Embeddings#render_embedding_payload` covering `task_type`, `title`, batch instances, and dimensions
- [x] Added specs proving `RubyLLM.embed` forwards `task_type`/`title` to the provider (reproduced `ArgumentError: unknown keyword: :task_type` before the fix)
- [x] All new specs pass locally