### PR TITLE
Add first-class per-call metadata for observability (#807)

### DIFF
--- a/docs/_advanced/instrumentation.md
+++ b/docs/_advanced/instrumentation.md
@@ -25,6 +25,7 @@ After reading this guide, you will know:
 
 *   How to subscribe to RubyLLM events in Rails.
 *   How to connect RubyLLM instrumentation outside Rails.
+*   How to attach per-call metadata for observability attribution.
 *   Which events RubyLLM emits.
 *   Which payload fields may contain sensitive application data.
 
@@ -45,6 +46,36 @@ end
 ```
 
 When an instrumented block raises, Rails adds the standard `:exception` and `:exception_object` payload keys.
+
+## Per-call metadata
+
+Attach caller attribution with `with_metadata` on chat (and agents / ActiveRecord chat models). Metadata is **not** sent to providers — it only rides along on instrumentation payloads so subscribers can attribute metrics and traces without monkey-patching core classes.
+
+```ruby
+RubyLLM.chat
+  .with_metadata(namespace: :chat_session, tags: { academy_id: 42 })
+  .with_instructions(instructions)
+  .ask(message)
+```
+
+Successive `with_metadata` calls merge tags and replace `namespace` when a new one is given. One-shot APIs (`embed`, `paint`, `moderate`, `speak`, `transcribe`) accept a `metadata:` keyword (`RubyLLM::Metadata` or a hash with `:namespace` / `:tags`).
+
+```ruby
+# config/initializers/ruby_llm_instrumentation.rb
+ActiveSupport::Notifications.subscribe('chat.ruby_llm') do |_name, _start, _finish, _id, payload|
+  metadata = payload[:metadata]
+  next unless metadata
+
+  Appsignal.increment_counter("#{metadata.namespace}_requests", 1, metadata.tags)
+  Appsignal.add_distribution_value(
+    "#{metadata.namespace}_input_tokens",
+    payload[:input_tokens],
+    metadata.tags
+  )
+end
+```
+
+Use metadata for observability attribution only. Provider request options still go through `with_params` / keyword arguments; configuration scoping still uses [contexts]({% link _getting_started/configuration-connection.md %}#contexts-isolated-configurations).
 
 ## Outside Rails
 

--- a/lib/ruby_llm/active_record/chat_methods.rb
+++ b/lib/ruby_llm/active_record/chat_methods.rb
@@ -122,6 +122,11 @@ module RubyLLM
         self
       end
 
+      def with_metadata(...)
+        to_llm.with_metadata(...)
+        self
+      end
+
       def with_headers(...)
         to_llm.with_headers(...)
         self

--- a/lib/ruby_llm/agent.rb
+++ b/lib/ruby_llm/agent.rb
@@ -363,9 +363,9 @@ module RubyLLM
 
     attr_reader :chat
 
-    def_delegators :chat, :model, :messages, :tools, :params, :headers, :schema, :ask, :say, :with_tool, :with_tools,
-                   :with_model, :with_temperature, :with_thinking, :with_citations, :with_context, :with_params,
-                   :with_headers, :with_schema,
+    def_delegators :chat, :model, :messages, :tools, :params, :headers, :schema, :metadata, :ask, :say, :with_tool,
+                   :with_tools, :with_model, :with_temperature, :with_thinking, :with_citations, :with_context,
+                   :with_metadata, :with_params, :with_headers, :with_schema,
                    :before_message, :after_message, :before_tool_call, :after_tool_result, :each, :complete,
                    :complete?, :ask_later, :generate, :run_tools, :step, :add_message, :add_completion,
                    :cost

--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -7,7 +7,8 @@ module RubyLLM
   class Chat
     include Enumerable
 
-    attr_reader :model, :provider, :messages, :tools, :tool_prefs, :params, :headers, :schema, :concurrency
+    attr_reader :model, :provider, :messages, :tools, :tool_prefs, :params, :headers, :schema, :concurrency,
+                :metadata
 
     def initialize(model: nil, provider: nil, assume_model_exists: false, context: nil)
       if assume_model_exists && !provider
@@ -29,6 +30,7 @@ module RubyLLM
       @thinking = nil
       @citations = false
       @protocol = nil
+      @metadata = nil
       @callbacks = Hash.new { |callbacks, name| callbacks[name] = [] }
     end
 
@@ -151,6 +153,18 @@ module RubyLLM
       @context = context
       @config = context.config
       with_model(@model.id, provider: @provider.slug, assume_exists: true)
+      self
+    end
+
+    # Attaches caller attribution for observability. Not sent to providers —
+    # only included in instrumentation payloads (distinct from with_params /
+    # with_context). Successive calls merge tags and replace namespace when given.
+    def with_metadata(namespace: nil, tags: {})
+      @metadata = if @metadata
+                    @metadata.merge(namespace: namespace, tags: tags)
+                  else
+                    Metadata.new(namespace: namespace, tags: tags)
+                  end
       self
     end
 
@@ -323,7 +337,8 @@ module RubyLLM
         schema: schema,
         thinking: @thinking,
         citations: @citations,
-        streaming: streaming
+        streaming: streaming,
+        metadata: metadata
       }
     end
 
@@ -445,7 +460,8 @@ module RubyLLM
         tool_call: tool_call,
         tool_name: tool.name,
         tool_arguments: args,
-        tool_call_id: tool_call.id
+        tool_call_id: tool_call.id,
+        metadata: metadata
       }
 
       RubyLLM.instrument('tool_call.ruby_llm', payload, config: @config) do |event|

--- a/lib/ruby_llm/embedding.rb
+++ b/lib/ruby_llm/embedding.rb
@@ -16,7 +16,8 @@ module RubyLLM
                    provider: nil,
                    assume_model_exists: false,
                    context: nil,
-                   dimensions: nil)
+                   dimensions: nil,
+                   metadata: nil)
       config = context&.config || RubyLLM.config
       model ||= config.default_embedding_model
       model, provider_instance = Models.resolve(model, provider: provider, assume_exists: assume_model_exists,
@@ -29,7 +30,8 @@ module RubyLLM
         model: model_id,
         model_info: model,
         input: text,
-        dimensions: dimensions
+        dimensions: dimensions,
+        metadata: Metadata.coerce(metadata)
       }
 
       RubyLLM.instrument('embedding.ruby_llm', payload, config: config) do |event|

--- a/lib/ruby_llm/image.rb
+++ b/lib/ruby_llm/image.rb
@@ -15,7 +15,8 @@ module RubyLLM
                    context: nil,
                    with: nil,
                    mask: nil,
-                   params: {})
+                   params: {},
+                   metadata: nil)
       config = context&.config || RubyLLM.config
       model ||= config.default_image_model
       model, provider_instance = Models.resolve(model, provider: provider, assume_exists: assume_model_exists,
@@ -26,7 +27,8 @@ module RubyLLM
         model: model.id,
         model_info: model,
         prompt: prompt,
-        size: size
+        size: size,
+        metadata: Metadata.coerce(metadata)
       }
 
       RubyLLM.instrument('image.ruby_llm', payload, config: config) do |event|

--- a/lib/ruby_llm/metadata.rb
+++ b/lib/ruby_llm/metadata.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  # Caller-supplied attribution for observability (not provider request params).
+  # Distinct from RubyLLM::Context, which scopes configuration.
+  Metadata = Data.define(:namespace, :tags) do
+    def initialize(namespace: nil, tags: {})
+      super(namespace: namespace, tags: tags.transform_keys(&:to_sym).freeze)
+    end
+
+    def merge(namespace: nil, tags: {})
+      self.class.new(
+        namespace: namespace.nil? ? self.namespace : namespace,
+        tags: self.tags.merge(tags.transform_keys(&:to_sym))
+      )
+    end
+
+    def self.coerce(metadata)
+      return metadata if metadata.nil? || metadata.is_a?(self)
+
+      attrs = metadata.transform_keys(&:to_sym)
+      new(namespace: attrs[:namespace], tags: attrs[:tags] || {})
+    end
+  end
+end

--- a/lib/ruby_llm/moderation.rb
+++ b/lib/ruby_llm/moderation.rb
@@ -16,7 +16,8 @@ module RubyLLM
                       model: nil,
                       provider: nil,
                       assume_model_exists: false,
-                      context: nil)
+                      context: nil,
+                      metadata: nil)
       config = context&.config || RubyLLM.config
       model ||= config.default_moderation_model
       model, provider_instance = Models.resolve(model, provider: provider, assume_exists: assume_model_exists,
@@ -26,7 +27,8 @@ module RubyLLM
         provider_class: provider_instance.class.display_name,
         model: model.id,
         model_info: model,
-        input: input
+        input: input,
+        metadata: Metadata.coerce(metadata)
       }
 
       RubyLLM.instrument('moderation.ruby_llm', payload, config: config) do |event|

--- a/lib/ruby_llm/speech.rb
+++ b/lib/ruby_llm/speech.rb
@@ -30,6 +30,7 @@ module RubyLLM
                    format: nil,
                    context: nil,
                    params: {},
+                   metadata: nil,
                    **options)
       config = context&.config || RubyLLM.config
       model ||= config.default_speech_model
@@ -43,7 +44,8 @@ module RubyLLM
         model_info: model,
         input: input,
         voice: voice,
-        format: format
+        format: format,
+        metadata: Metadata.coerce(metadata)
       }
 
       RubyLLM.instrument('speech.ruby_llm', payload, config: config) do |event|

--- a/lib/ruby_llm/transcription.rb
+++ b/lib/ruby_llm/transcription.rb
@@ -22,6 +22,7 @@ module RubyLLM
                         provider: nil,
                         assume_model_exists: false,
                         context: nil,
+                        metadata: nil,
                         **options)
       config = context&.config || RubyLLM.config
       model ||= config.default_transcription_model
@@ -32,7 +33,8 @@ module RubyLLM
         provider_class: provider_instance.class.display_name,
         model: model.id,
         model_info: model,
-        language: language
+        language: language,
+        metadata: Metadata.coerce(metadata)
       }
 
       RubyLLM.instrument('transcription.ruby_llm', payload, config: config) do |event|

--- a/spec/ruby_llm/instrumentation_spec.rb
+++ b/spec/ruby_llm/instrumentation_spec.rb
@@ -87,12 +87,47 @@ RSpec.describe RubyLLM::Instrumentation do
       cached_tokens: 2,
       thinking_tokens: 1,
       temperature: 0.2,
-      streaming: false
+      streaming: false,
+      metadata: nil
     )
     expect(payload).not_to have_key(:operation)
     expect(payload).not_to have_key(:result)
     expect(payload[:input_messages].first.content).to eq('Hello')
     expect(payload[:messages_after].last.content).to eq('done')
+  end
+
+  it 'includes with_metadata in chat and tool_call instrumentation payloads' do
+    stub_const('MetadataProbeTool', Class.new(RubyLLM::Tool) do
+      param :value
+
+      def execute(value:)
+        "tool #{value}"
+      end
+    end)
+    instrumenter = CaptureInstrumenter.new
+    context = RubyLLM.context { |config| config.instrumenter = instrumenter }
+    tool_call = RubyLLM::ToolCall.new(id: 'call_1', name: 'metadata_probe', arguments: { value: 'ok' })
+    tool_message = RubyLLM::Message.new(role: :assistant, content: nil, tool_calls: { 'call_1' => tool_call })
+    final_message = RubyLLM::Message.new(role: :assistant, content: 'complete')
+    chat = context.chat(model: 'gpt-4.1-nano')
+                   .with_metadata(namespace: :summary, tags: { type: 'doc' })
+                   .with_metadata(tags: { academy_id: 42 })
+                   .with_tool(MetadataProbeTool)
+    provider = chat.instance_variable_get(:@provider)
+    allow(provider).to receive(:complete).and_return(tool_message, final_message)
+
+    chat.ask('Use the tool')
+
+    expect(chat.metadata.namespace).to eq(:summary)
+    expect(chat.metadata.tags).to eq(type: 'doc', academy_id: 42)
+
+    chat_payload = instrumenter.events.find { |name, _| name == 'chat.ruby_llm' }.last
+    expect(chat_payload[:metadata]).to eq(chat.metadata)
+    expect(chat_payload[:metadata].namespace).to eq(:summary)
+    expect(chat_payload[:metadata].tags).to include(type: 'doc', academy_id: 42)
+
+    tool_payload = instrumenter.events.find { |name, _| name == 'tool_call.ruby_llm' }.last
+    expect(tool_payload[:metadata]).to eq(chat.metadata)
   end
 
   it 'marks streaming chat events when a block is passed' do
@@ -154,7 +189,8 @@ RSpec.describe RubyLLM::Instrumentation do
     allow(provider).to receive_messages(embed: embedding, class: provider_class)
     allow(RubyLLM::Models).to receive(:resolve).and_return([model, provider])
 
-    result = context.embed(['hello'], model: 'text-embedding-3-small')
+    result = context.embed(['hello'], model: 'text-embedding-3-small',
+                                      metadata: { namespace: :search, tags: { index: 'docs' } })
 
     event_name, payload = instrumenter.events.last
     expect(result).to eq(embedding)
@@ -170,6 +206,9 @@ RSpec.describe RubyLLM::Instrumentation do
       embedding_dimensions: 3,
       embedding_count: 1
     )
+    expect(payload[:metadata]).to be_a(RubyLLM::Metadata)
+    expect(payload[:metadata].namespace).to eq(:search)
+    expect(payload[:metadata].tags).to eq(index: 'docs')
     expect(payload).not_to have_key(:operation)
   end
 


### PR DESCRIPTION
## Summary

- Adds `RubyLLM::Metadata` (`namespace` + `tags`) and `Chat#with_metadata` for opt-in caller attribution on instrumentation events
- Includes `metadata` in `chat.ruby_llm` and `tool_call.ruby_llm` payloads; one-shot APIs (`embed`, `paint`, `moderate`, `speak`, `transcribe`) accept `metadata:`
- Delegates through `Agent` and ActiveRecord `ChatMethods`; documents usage in the instrumentation guide

Closes #807

## Test plan

- [x] `bundle exec rspec spec/ruby_llm/instrumentation_spec.rb`
- [x] Confirm subscribers can read `payload[:metadata]` without reaching into chat ivars
- [x] Smoke-test `with_metadata` chaining merges tags and replaces namespace when set