### PR TITLE
Add RUBYLLM_LOG_FILE env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,6 @@ OPENAI_API_KEY=$(op read "op://RubyLLM/OpenAI/credential")
 OPENROUTER_API_KEY=$(op read "op://RubyLLM/OpenRouter/credential")
 PERPLEXITY_API_KEY=$(op read "op://RubyLLM/Perplexity/credential")
 RUBYLLM_DEBUG=true
+RUBYLLM_LOG_FILE=/tmp/ruby_llm.log
 RUBYLLM_STREAM_DEBUG=true
 XAI_API_KEY=$(op read "op://RubyLLM/xAI/credential")

--- a/docs/_getting_started/configuration-connection.md
+++ b/docs/_getting_started/configuration-connection.md
@@ -102,7 +102,7 @@ end
 
 ```ruby
 RubyLLM.configure do |config|
-  config.log_file = '/var/log/ruby_llm.log'
+  config.log_file = '/var/log/ruby_llm.log'  # Or set RUBYLLM_LOG_FILE
   config.log_level = :info  # :debug, :info, :warn
 
   # Or use Rails logger
@@ -114,6 +114,10 @@ Log levels:
 - `:debug` - Detailed request/response information
 - `:info` - General operational information
 - `:warn` - Non-critical issues
+
+`log_file` notes:
+- Defaults to `$stdout`
+- Can also be set with `RUBYLLM_LOG_FILE=/path/to/file.log`
 
 You can also enable debug logging conditionally from an environment variable:
 

--- a/lib/ruby_llm/configuration.rb
+++ b/lib/ruby_llm/configuration.rb
@@ -211,8 +211,9 @@ module RubyLLM
     # :attr_accessor: log_file
     #
     # Destination for the built-in logger, a path or an IO.
-    # Default: <tt>$stdout</tt>.
-    option :log_file, -> { $stdout }
+    # Defaults to the +RUBYLLM_LOG_FILE+ environment variable when set,
+    # <tt>$stdout</tt> otherwise.
+    option :log_file, -> { ENV.fetch('RUBYLLM_LOG_FILE', nil) || $stdout }
 
     ##
     # :attr_accessor: log_level

--- a/spec/ruby_llm/configuration_spec.rb
+++ b/spec/ruby_llm/configuration_spec.rb
@@ -65,6 +65,19 @@ RSpec.describe RubyLLM::Configuration do
     end
   end
 
+  describe 'log_file' do
+    it 'defaults to $stdout' do
+      expect(described_class.new.log_file).to eq($stdout)
+    end
+
+    it 'uses the RUBYLLM_LOG_FILE environment variable when set' do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('RUBYLLM_LOG_FILE', nil).and_return('/tmp/ruby_llm.log')
+
+      expect(described_class.new.log_file).to eq('/tmp/ruby_llm.log')
+    end
+  end
+
   describe 'method redefinition warnings' do
     it 'does not emit method redefined warning for log_regexp_timeout=' do
       warnings = `#{RbConfig.ruby} -W -e 'require "ruby_llm"' 2>&1`


### PR DESCRIPTION
Allows setting the log destination from the environment, complementing `RUBYLLM_DEBUG` and `RUBYLLM_STREAM_DEBUG`. `config.log_file` now defaults to `RUBYLLM_LOG_FILE` when set, falling back to `$stdout`.

Includes specs and documentation updates.

Fixes #658