### PR TITLE
Fix streaming error parsing crash on non-Hash JSON error bodies

### DIFF
--- a/lib/ruby_llm/protocols/anthropic/streaming.rb
+++ b/lib/ruby_llm/protocols/anthropic/streaming.rb
@@ -71,13 +71,16 @@ module RubyLLM
 
         def parse_streaming_error(data)
           error_data = JSON.parse(data)
-          return unless error_data['type'] == 'error'
+          return unless error_data.is_a?(Hash) && error_data['type'] == 'error'
 
-          case error_data.dig('error', 'type')
+          error = error_data['error']
+          return [500, error.to_s] unless error.is_a?(Hash)
+
+          case error['type']
           when 'overloaded_error'
-            [529, error_data['error']['message']]
+            [529, error['message']]
           else
-            [500, error_data['error']['message']]
+            [500, error['message']]
           end
         end
       end

--- a/lib/ruby_llm/protocols/chat_completions/streaming.rb
+++ b/lib/ruby_llm/protocols/chat_completions/streaming.rb
@@ -47,15 +47,18 @@ module RubyLLM
 
         def parse_streaming_error(data)
           error_data = JSON.parse(data)
-          return unless error_data['error']
+          return [nil, error_data.to_s] unless error_data.is_a?(Hash)
 
-          case error_data.dig('error', 'type')
+          error = error_data['error']
+          return [nil, error.to_s] unless error.is_a?(Hash)
+
+          case error['type']
           when 'server_error'
-            [500, error_data['error']['message']]
+            [500, error['message']]
           when 'rate_limit_exceeded', 'insufficient_quota'
-            [429, error_data['error']['message']]
+            [429, error['message']]
           else
-            [400, error_data['error']['message']]
+            [400, error['message']]
           end
         end
       end

--- a/lib/ruby_llm/protocols/gemini/streaming.rb
+++ b/lib/ruby_llm/protocols/gemini/streaming.rb
@@ -49,7 +49,10 @@ module RubyLLM
 
         def parse_streaming_error(data)
           error_data = JSON.parse(data)
-          [error_data['error']['code'], error_data['error']['message']]
+          error = error_data.is_a?(Hash) ? error_data['error'] || error_data : error_data
+          return [nil, error.to_s] unless error.is_a?(Hash)
+
+          [error['code'], error['message']]
         rescue JSON::ParserError => e
           RubyLLM.logger.debug { "Failed to parse streaming error: #{e.message}" }
           [500, "Failed to parse error: #{data}"]

--- a/lib/ruby_llm/providers/openrouter.rb
+++ b/lib/ruby_llm/providers/openrouter.rb
@@ -54,14 +54,34 @@ module RubyLLM
       private
 
       def parse_error_part_message(part)
-        message = part.dig('error', 'message')
-        raw = try_parse_json(part.dig('error', 'metadata', 'raw'))
+        return error_message(part) unless part.is_a?(Hash)
+
+        error = part['error']
+        message = error_message(error)
+        metadata = error['metadata'] if error.is_a?(Hash)
+        return message unless metadata.is_a?(Hash)
+
+        raw = try_parse_json(metadata['raw'])
         return message unless raw.is_a?(Hash)
 
-        raw_message = raw.dig('error', 'message')
+        raw_message = error_message(raw['error'])
         return [message, raw_message].compact.join(' - ') if raw_message
 
         message
+      end
+
+      def error_message(value)
+        case value
+        when Hash
+          value['message']
+        when Array
+          messages = value.filter_map { |part| error_message(part) }
+          messages.join('. ') unless messages.empty?
+        when nil
+          nil
+        else
+          value.to_s
+        end
       end
     end
   end

--- a/lib/ruby_llm/streaming.rb
+++ b/lib/ruby_llm/streaming.rb
@@ -115,7 +115,8 @@ module RubyLLM
 
     def parse_streaming_error(data)
       error_data = JSON.parse(data)
-      [500, error_data['message'] || 'Unknown streaming error']
+      message = error_data.is_a?(Hash) ? error_data['message'] : error_data.to_s
+      [500, message || 'Unknown streaming error']
     rescue JSON::ParserError => e
       RubyLLM.logger.debug { "Failed to parse streaming error: #{e.message}" }
       [500, "Failed to parse error: #{data}"]

--- a/spec/ruby_llm/protocols/anthropic/streaming_spec.rb
+++ b/spec/ruby_llm/protocols/anthropic/streaming_spec.rb
@@ -40,4 +40,30 @@ RSpec.describe RubyLLM::Protocols::Anthropic::Streaming do
 
     expect(captured).to eq('identity')
   end
+
+  describe '#parse_streaming_error' do
+    it 'parses typed error objects' do
+      status, message = protocol.send(
+        :parse_streaming_error,
+        { type: 'error', error: { type: 'overloaded_error', message: 'Overloaded' } }.to_json
+      )
+
+      expect(status).to eq(529)
+      expect(message).to eq('Overloaded')
+    end
+
+    it 'handles a string error value' do
+      status, message = protocol.send(
+        :parse_streaming_error,
+        { type: 'error', error: 'Overloaded' }.to_json
+      )
+
+      expect(status).to eq(500)
+      expect(message).to eq('Overloaded')
+    end
+
+    it 'ignores a body that parses to a bare JSON string' do
+      expect(protocol.send(:parse_streaming_error, '"model unavailable (type: error)"')).to be_nil
+    end
+  end
 end

--- a/spec/ruby_llm/protocols/anthropic/streaming_spec.rb
+++ b/spec/ruby_llm/protocols/anthropic/streaming_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe RubyLLM::Protocols::Anthropic::Streaming do
       expect(message).to eq('Overloaded')
     end
 
+    it 'falls back to a 500 for other typed error objects' do
+      status, message = protocol.send(
+        :parse_streaming_error,
+        { type: 'error', error: { type: 'invalid_request_error', message: 'Bad request' } }.to_json
+      )
+
+      expect(status).to eq(500)
+      expect(message).to eq('Bad request')
+    end
+
     it 'handles a string error value' do
       status, message = protocol.send(
         :parse_streaming_error,

--- a/spec/ruby_llm/protocols/chat_completions/streaming_spec.rb
+++ b/spec/ruby_llm/protocols/chat_completions/streaming_spec.rb
@@ -21,4 +21,52 @@ RSpec.describe RubyLLM::Protocols::ChatCompletions::Streaming do
 
     expect(chunk.finish_reason).to eq('tool_calls')
   end
+
+  describe '#parse_streaming_error' do
+    it 'parses typed error objects' do
+      status, message = protocol.send(
+        :parse_streaming_error,
+        { error: { type: 'rate_limit_exceeded', message: 'Slow down' } }.to_json
+      )
+
+      expect(status).to eq(429)
+      expect(message).to eq('Slow down')
+    end
+
+    it 'handles a body that parses to a bare JSON string' do
+      status, message = protocol.send(
+        :parse_streaming_error,
+        '"The model foo is not available in your region (error)."'
+      )
+
+      expect(status).to be_nil
+      expect(message).to eq('The model foo is not available in your region (error).')
+    end
+
+    it 'handles a string error value' do
+      status, message = protocol.send(
+        :parse_streaming_error,
+        { error: 'The model foo is not available in your region.' }.to_json
+      )
+
+      expect(status).to be_nil
+      expect(message).to eq('The model foo is not available in your region.')
+    end
+  end
+
+  it 'surfaces the provider message for a failed streaming response with a string error value' do
+    provider = instance_double(RubyLLM::Providers::OpenAI)
+    allow(provider).to receive(:parse_error) { |response| response.body['error'] }
+    protocol.instance_variable_set(:@provider, provider)
+    failed_env = Faraday::Env.from(status: 404)
+
+    expect do
+      protocol.send(
+        :handle_failed_response,
+        '{"error": "The model foo is not available in your region."}',
+        +'',
+        failed_env
+      )
+    end.to raise_error(RubyLLM::Error, /not available in your region/)
+  end
 end

--- a/spec/ruby_llm/protocols/chat_completions/streaming_spec.rb
+++ b/spec/ruby_llm/protocols/chat_completions/streaming_spec.rb
@@ -33,6 +33,26 @@ RSpec.describe RubyLLM::Protocols::ChatCompletions::Streaming do
       expect(message).to eq('Slow down')
     end
 
+    it 'reports a 500 for server errors' do
+      status, message = protocol.send(
+        :parse_streaming_error,
+        { error: { type: 'server_error', message: 'Internal error' } }.to_json
+      )
+
+      expect(status).to eq(500)
+      expect(message).to eq('Internal error')
+    end
+
+    it 'falls back to a 400 for other typed error objects' do
+      status, message = protocol.send(
+        :parse_streaming_error,
+        { error: { type: 'invalid_request_error', message: 'Bad request' } }.to_json
+      )
+
+      expect(status).to eq(400)
+      expect(message).to eq('Bad request')
+    end
+
     it 'handles a body that parses to a bare JSON string' do
       status, message = protocol.send(
         :parse_streaming_error,

--- a/spec/ruby_llm/protocols/gemini/streaming_spec.rb
+++ b/spec/ruby_llm/protocols/gemini/streaming_spec.rb
@@ -51,4 +51,30 @@ RSpec.describe RubyLLM::Protocols::Gemini::Streaming do
 
     expect(chunk.finish_reason).to eq('MAX_TOKENS')
   end
+
+  describe '#parse_streaming_error' do
+    it 'parses error objects' do
+      status, message = test_obj.send(
+        :parse_streaming_error,
+        { error: { code: 429, message: 'Quota exceeded' } }.to_json
+      )
+
+      expect(status).to eq(429)
+      expect(message).to eq('Quota exceeded')
+    end
+
+    it 'handles a body that parses to a bare JSON string' do
+      status, message = test_obj.send(:parse_streaming_error, '"model unavailable"')
+
+      expect(status).to be_nil
+      expect(message).to eq('model unavailable')
+    end
+
+    it 'handles a string error value' do
+      status, message = test_obj.send(:parse_streaming_error, { error: 'model unavailable' }.to_json)
+
+      expect(status).to be_nil
+      expect(message).to eq('model unavailable')
+    end
+  end
 end

--- a/spec/ruby_llm/providers/openrouter/parse_error_spec.rb
+++ b/spec/ruby_llm/providers/openrouter/parse_error_spec.rb
@@ -79,5 +79,43 @@ RSpec.describe RubyLLM::Providers::OpenRouter do # rubocop:disable RSpec/SpecFil
 
       expect(provider.parse_error(response)).to eq('Provider returned error')
     end
+
+    it 'handles a string error value' do
+      response = instance_double(Faraday::Response, body: { error: 'upstream 502' }.to_json)
+
+      expect(provider.parse_error(response)).to eq('upstream 502')
+    end
+
+    it 'joins messages from an array error value' do
+      response = instance_double(
+        Faraday::Response,
+        body: { error: [{ message: 'first failure' }, 'second failure'] }.to_json
+      )
+
+      expect(provider.parse_error(response)).to eq('first failure. second failure')
+    end
+
+    it 'ignores non-object metadata' do
+      response = instance_double(
+        Faraday::Response,
+        body: { error: { message: 'Provider returned error', metadata: 'raw text' } }.to_json
+      )
+
+      expect(provider.parse_error(response)).to eq('Provider returned error')
+    end
+
+    it 'handles a string error nested in metadata.raw' do
+      response = instance_double(
+        Faraday::Response,
+        body: {
+          error: {
+            message: 'Provider returned error',
+            metadata: { raw: { error: 'upstream detail' }.to_json }
+          }
+        }.to_json
+      )
+
+      expect(provider.parse_error(response)).to eq('Provider returned error - upstream detail')
+    end
   end
 end

--- a/spec/ruby_llm/streaming_spec.rb
+++ b/spec/ruby_llm/streaming_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe RubyLLM::Streaming do
     expect(response.body).to eq(parsed_error)
   end
 
+  it 'raises the provider error when a failed response body parses to a bare JSON string' do
+    failed_env = Faraday::Env.from(status: 404)
+
+    expect do
+      test_obj.send(:handle_failed_response, '"model unavailable"', +'', failed_env)
+    end.to raise_error(RubyLLM::Error)
+
+    response = failed_env[:streaming_error_response]
+    expect(response.status).to eq(404)
+    expect(response.body).to eq('model unavailable')
+  end
+
   # Faraday 2 with the net_http adapter invokes on_data with a nil env (the
   # status is not yet known mid-stream). The handler must process such chunks
   # normally rather than treating them as a failed response and discarding them.


### PR DESCRIPTION
## What this does

Fixes #837. When a streaming request fails and the error body parses to something other than the typed `{"error": {"type": …, "message": …}}` hash — a bare JSON string, or a string error value like `{"error": "msg"}` (xAI/Grok shape) — `parse_streaming_error` crashed with `TypeError: String does not have #dig method` instead of surfacing the provider's message. The same bodies were already handled fine on the non-streaming path.

The old guard `return unless error_data['error']` did substring matching on string bodies (`String#[]`), and `dig('error', 'type')` recursed into string error values — hence the crash.

This adds shape guards before the hash lookups in the `chat_completions`, `anthropic`, and `gemini` protocols plus the default fallback in `Streaming`. Untyped bodies return a `nil` status so `build_stream_error_response` falls back to the real HTTP status; the user-facing message still comes from `Provider#parse_error`, which already handles string bodies.

## Type of change

- [x] Bug fix

## How tested

Regression specs per protocol (typed object, bare string body, string error value) plus end-to-end specs through `handle_failed_response` asserting the provider's actual message surfaces in the raised error. Full suite: 1889 examples, 0 failures.