### PR TITLE
Send strict: false for function tools on the Responses API to preserve Chat Completions behavior

### DIFF
--- a/docs/_core_features/tool-parameters.md
+++ b/docs/_core_features/tool-parameters.md
@@ -237,17 +237,18 @@ The Responses API defaults function tools to strict schema validation, forcing t
 To opt into [strict validation](https://platform.openai.com/docs/guides/function-calling#strict-mode) per tool:
 
 ```ruby
+class LookupParams < RubyLLM::Schema
+  string :sku, description: "Product SKU"
+
+  any_of :locale, description: "Country code" do
+    string
+    null
+  end
+end
+
 class Lookup < RubyLLM::Tool
   description "Performs catalog lookups"
-
-  parameters type: "object",
-    properties: {
-      sku: { type: "string", description: "Product SKU" },
-      locale: { type: %w[string null], description: "Country code" }
-    },
-    required: %w[sku locale],
-    additionalProperties: false
-
+  parameters LookupParams
   provider_options strict: true
 
   def execute(sku:, locale: nil)

--- a/docs/_core_features/tool-parameters.md
+++ b/docs/_core_features/tool-parameters.md
@@ -230,6 +230,34 @@ Provider metadata is passed through verbatim. Turn on `RUBYLLM_DEBUG=true` if yo
 
 Pass `nil` to `provider_options` to clear provider-specific tool options.
 
+### Strict Mode on the OpenAI Responses API
+
+The Responses API defaults function tools to strict schema validation, forcing the model to emit **every** property on each call. RubyLLM sends `strict: false` so tools keep the Chat Completions behavior: parameters not in `required` can simply be omitted.
+
+To opt into [strict validation](https://platform.openai.com/docs/guides/function-calling#strict-mode) per tool:
+
+```ruby
+class Lookup < RubyLLM::Tool
+  description "Performs catalog lookups"
+
+  parameters type: "object",
+    properties: {
+      sku: { type: "string", description: "Product SKU" },
+      locale: { type: %w[string null], description: "Country code" }
+    },
+    required: %w[sku locale],
+    additionalProperties: false
+
+  provider_options strict: true
+
+  def execute(sku:, locale: nil)
+    # ...
+  end
+end
+```
+
+Strict mode requires every property in `required`; make optional parameters nullable instead.
+
 ## Next Steps
 
 *   [Controlling Tool Execution]({% link _core_features/tool-execution.md %}) - Steer tool choice, call counts, concurrency, and callbacks.

--- a/docs/_reference/upgrading.md
+++ b/docs/_reference/upgrading.md
@@ -506,6 +506,8 @@ RubyLLM.chat(model: 'gpt-5.4', protocol: :chat_completions)
 
 If you pass Chat Completions-only options via `with_provider_options` (like `response_format`), either switch those chats to `:chat_completions` or use the Responses API equivalents (`text: { format: ... }`).
 
+Function tools keep their Chat Completions behavior on the Responses API: RubyLLM sends `strict: false` explicitly because the Responses API otherwise defaults to strict schema validation, which forces the model to fill in every parameter — including ones you declared optional. To opt a tool into strict validation, declare `provider_options strict: true` on the tool class and make sure its schema meets the [strict mode requirements](https://platform.openai.com/docs/guides/function-calling#strict-mode) (every property in `required`, optional parameters expressed as nullable types).
+
 **Wire-format internals moved to `RubyLLM::Protocols`.** `RubyLLM::Providers::OpenAI::Chat` and sibling modules are now `RubyLLM::Protocols::ChatCompletions::Chat` and friends; Anthropic, Gemini, and Bedrock Converse internals moved the same way. Provider classes no longer inherit from each other (`Mistral < OpenAI` is gone) - a provider declares its protocols instead. Providers also no longer override `#name`: the human name is `display_name` and the identifier is the registration-derived `slug`.
 
 If you maintain a provider gem, subclass a protocol for your dialect and declare it in a thin provider:

--- a/lib/ruby_llm/protocols/responses/tools.rb
+++ b/lib/ruby_llm/protocols/responses/tools.rb
@@ -13,7 +13,8 @@ module RubyLLM
             type: 'function',
             name: tool.name,
             description: tool.description,
-            parameters: ChatCompletions::Tools.parameters_schema_for(tool)
+            parameters: ChatCompletions::Tools.parameters_schema_for(tool),
+            strict: false
           }
 
           return definition if tool.provider_options.empty?

--- a/spec/ruby_llm/protocols/responses/chat_spec.rb
+++ b/spec/ruby_llm/protocols/responses/chat_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RubyLLM::Protocols::Responses::Chat do
       expect(payload[:input][1]).to eq({ role: 'assistant', content: [{ type: 'output_text', text: 'Hello!' }] })
     end
 
-    it 'uses flat function definitions' do
+    it 'uses flat non-strict function definitions' do
       tool = instance_double(RubyLLM::Tool, name: 'weather', description: 'Looks up weather',
                                             parameters_schema: { 'type' => 'object' }, provider_options: {})
 
@@ -71,8 +71,19 @@ RSpec.describe RubyLLM::Protocols::Responses::Chat do
                                       type: 'function',
                                       name: 'weather',
                                       description: 'Looks up weather',
-                                      parameters: { 'type' => 'object' }
+                                      parameters: { 'type' => 'object' },
+                                      strict: false
                                     }])
+    end
+
+    it 'lets tools opt into strict mode via provider_options' do
+      tool = instance_double(RubyLLM::Tool, name: 'weather', description: 'Looks up weather',
+                                            parameters_schema: { 'type' => 'object' },
+                                            provider_options: { strict: true })
+
+      payload = render_payload([RubyLLM::Message.new(role: :user, content: 'hi')], tools: { weather: tool })
+
+      expect(payload[:tools].first[:strict]).to be(true)
     end
 
     it 'renders structured output as a text format' do


### PR DESCRIPTION
Fixes #843

This is AI generated but I understand every line. I'm also fine with accepting the new default strict true, but then it should be mentioned in the upcoming 2.0 [upgrading guide](https://rubyllm.com/upgrading/).

## What this PR does

Explicitly sends `strict: false` in function tool definitions rendered by `Protocols::Responses::Tools.tool_for`, restoring the tool-calling behavior applications had on Chat Completions. Tools can opt into strict validation per class with `provider_options strict: true`.

## The problem

OpenAI's two APIs have opposite server-side defaults for function tool `strict`:

- Chat Completions `FunctionObject.strict`: **default `false`** ([OpenAPI spec](https://github.com/openai/openai-openapi))
- Responses `FunctionTool.strict`: **default `true`** ("Whether to enforce strict parameter validation. Default `true`.")

RubyLLM never sends the `strict` field, so when OpenAI switched to defaulting to the Responses API, every existing tool silently flipped into strict mode. Under strict mode the model's output is grammar-constrained to emit **every** property in the schema — parameters left out of `required` stop being optional (strict mode expresses optionality as nullable types + membership in `required` instead).

Concretely: a search tool with a dozen optional filters that previously received only the relevant ones now gets a value for every filter on every call, changing tool behavior without any application code change. The [upgrade guide](https://rubyllm.com/reference/upgrading/) covers the Responses API switch but doesn't mention this side effect, and there's no way to notice it except by observing degraded tool calls.

## The fix

`tool_for` now always includes `strict: false` in the flat function definition. `provider_options` is merged after, so `provider_options strict: true` on a tool class opts back in for schemas that meet the strict-mode requirements.

Docs updated:

- `docs/_reference/upgrading.md` — note under "OpenAI now defaults to the Responses API" explaining tools stay non-strict and how to opt in.
- `docs/_core_features/tool-parameters.md` — new "Strict Mode on the OpenAI Responses API" subsection with an opt-in example (nullable optional params, all properties in `required`).

## Tests

- Updated the flat-function-definition expectation in `spec/ruby_llm/protocols/responses/chat_spec.rb` and added an opt-in test for `provider_options strict: true`.
- Existing OpenAI VCR cassettes still match (default VCR matching is method + URI), verified with `CI=true bundle exec rspec spec/ruby_llm/chat_tools_spec.rb -e openai` — 18 examples, 0 failures.
