### PR TITLE
Pin simplecov below 1.0 to unblock CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :development do # rubocop:disable Metrics/BlockLength
   gem 'rubocop-performance'
   gem 'rubocop-rake', '>= 0.6'
   gem 'rubocop-rspec'
-  gem 'simplecov', '>= 0.21'
+  gem 'simplecov', '>= 0.21', '< 1.0'
   gem 'simplecov-cobertura'
   gem 'test-queue'
 

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -26,7 +26,7 @@ group :development do
   gem "rubocop-performance"
   gem "rubocop-rake", ">= 0.6"
   gem "rubocop-rspec"
-  gem "simplecov", ">= 0.21"
+  gem "simplecov", ">= 0.21", "< 1.0"
   gem "simplecov-cobertura"
   gem "test-queue"
   gem "activerecord-jdbcsqlite3-adapter", platform: "jruby"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -26,7 +26,7 @@ group :development do
   gem "rubocop-performance"
   gem "rubocop-rake", ">= 0.6"
   gem "rubocop-rspec"
-  gem "simplecov", ">= 0.21"
+  gem "simplecov", ">= 0.21", "< 1.0"
   gem "simplecov-cobertura"
   gem "test-queue"
   gem "activerecord-jdbcsqlite3-adapter", platform: "jruby"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -26,7 +26,7 @@ group :development do
   gem "rubocop-performance"
   gem "rubocop-rake", ">= 0.6"
   gem "rubocop-rspec"
-  gem "simplecov", ">= 0.21"
+  gem "simplecov", ">= 0.21", "< 1.0"
   gem "simplecov-cobertura"
   gem "test-queue"
   gem "activerecord-jdbcsqlite3-adapter", platform: "jruby"

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -26,7 +26,7 @@ group :development do
   gem "rubocop-performance"
   gem "rubocop-rake", ">= 0.6"
   gem "rubocop-rspec"
-  gem "simplecov", ">= 0.21"
+  gem "simplecov", ">= 0.21", "< 1.0"
   gem "simplecov-cobertura"
   gem "test-queue"
   gem "activerecord-jdbcsqlite3-adapter", platform: "jruby"


### PR DESCRIPTION
## Summary
- `simplecov` 1.0.0 (released 2026-07-12) dropped the `SimpleCov.running` accessor that `bin/rspec-queue` depends on for per-worker coverage collation (`after_fork`, `cleanup_worker`, and the final `format!` guard), breaking every CI run since.
- The `Gemfile` constraint `gem 'simplecov', '>= 0.21'` now resolves to 1.0.0 because `gemfiles/*.gemfile.lock` are gitignored, so CI resolves gems fresh on every run.
- Pins `simplecov` to `< 1.0` in the `Gemfile` and all four Appraisal-generated `gemfiles/*.gemfile` files, restoring the `0.22.0` resolution CI ran green with through July 11. `simplecov-cobertura` resolves back to `3.2.0` accordingly (it requires `simplecov ~> 0.19`, vs. `4.0.0` which requires `~> 1.0`), so no direct pin is needed there.

This is the short-term fix suggested in #842; a longer-term migration to simplecov 1.0's `ParallelAdapters` interface is out of scope here.

## Test plan
- [x] `bundle install` resolves `simplecov 0.22.0` / `simplecov-cobertura 3.2.0`
- [x] `SKIP_LOCAL_PROVIDER_TESTS=1 bundle exec bin/rspec-queue` — full suite green (1,801 examples, 0 failures across 8 workers), coverage report generated successfully (the exact step that was crashing)
- [x] `bundle exec archspec check` — passes
- [x] `bundle exec rubocop Gemfile` — no offenses

Fixes #842