### PR TITLE
Fix streaming error parsing crashing on non-Hash JSON error bodies

### DIFF
--- a/lib/ruby_llm/protocols/chat_completions/streaming.rb
+++ b/lib/ruby_llm/protocols/chat_completions/streaming.rb
@@ -47,15 +47,18 @@ module RubyLLM
 
         def parse_streaming_error(data)
           error_data = JSON.parse(data)
-          return unless error_data['error']
+          return unless error_data.is_a?(Hash) && error_data['error']
 
-          case error_data.dig('error', 'type')
+          error = error_data['error']
+          return [500, error] unless error.is_a?(Hash)
+
+          case error['type']
           when 'server_error'
-            [500, error_data['error']['message']]
+            [500, error['message']]
           when 'rate_limit_exceeded', 'insufficient_quota'
-            [429, error_data['error']['message']]
+            [429, error['message']]
           else
-            [400, error_data['error']['message']]
+            [400, error['message']]
           end
         end
       end

--- a/spec/ruby_llm/chat_streaming_spec.rb
+++ b/spec/ruby_llm/chat_streaming_spec.rb
@@ -106,5 +106,50 @@ RSpec.describe RubyLLM::Chat do
         end
       end
     end
+
+    context 'with non-Hash error bodies (deepseek/deepseek-chat)' do
+      let(:chat) { RubyLLM.chat(model: 'deepseek-chat', provider: :deepseek) }
+      let(:url) { 'https://api.deepseek.com/chat/completions' }
+
+      { '1' => '1.10.0', '2' => '2.0.0' }.each do |major, faraday_version|
+        describe "Faraday version #{major}" do # rubocop:disable RSpec/NestedGroups
+          before do
+            stub_const('Faraday::VERSION', faraday_version)
+          end
+
+          it 'surfaces the message when the error value is a string' do
+            stub_request(:post, url).to_return(
+              status: 500,
+              body: { error: 'The model is not available in your region.' }.to_json,
+              headers: { 'Content-Type' => 'application/json' }
+            )
+
+            expect do
+              chat.ask('Count from 1 to 3') { |chunk| chunk }
+            end.to raise_error(RubyLLM::ServerError, /not available in your region/)
+          end
+
+          it 'raises a server error when the body is a bare JSON string' do
+            stub_request(:post, url).to_return(
+              status: 500,
+              body: 'The upstream provider returned an error.'.to_json,
+              headers: { 'Content-Type' => 'application/json' }
+            )
+
+            # Faraday 1 streams the error body away before on_complete, so only
+            # the HTTP status is available to build the error message.
+            expected = if major == '1'
+                         [RubyLLM::ServerError]
+                       else
+                         [RubyLLM::ServerError, /upstream provider returned an error/]
+                       end
+
+            expect do
+              chat.ask('Count from 1 to 3') { |chunk| chunk }
+            end.to raise_error(*expected)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/ruby_llm/protocols/chat_completions/streaming_spec.rb
+++ b/spec/ruby_llm/protocols/chat_completions/streaming_spec.rb
@@ -21,4 +21,43 @@ RSpec.describe RubyLLM::Protocols::ChatCompletions::Streaming do
 
     expect(chunk.finish_reason).to eq('tool_calls')
   end
+
+  describe '#parse_streaming_error' do
+    it 'classifies server errors as 500' do
+      data = { 'error' => { 'type' => 'server_error', 'message' => 'The server had an error' } }.to_json
+
+      expect(protocol.send(:parse_streaming_error, data)).to eq([500, 'The server had an error'])
+    end
+
+    it 'classifies rate limit errors as 429' do
+      data = { 'error' => { 'type' => 'rate_limit_exceeded', 'message' => 'Rate limit reached' } }.to_json
+
+      expect(protocol.send(:parse_streaming_error, data)).to eq([429, 'Rate limit reached'])
+    end
+
+    it 'classifies other typed errors as 400' do
+      data = { 'error' => { 'type' => 'invalid_request_error', 'message' => 'Bad request' } }.to_json
+
+      expect(protocol.send(:parse_streaming_error, data)).to eq([400, 'Bad request'])
+    end
+
+    it 'returns nil when the body has no error key' do
+      data = { 'choices' => [] }.to_json
+
+      expect(protocol.send(:parse_streaming_error, data)).to be_nil
+    end
+
+    it 'handles a string-valued error without raising' do
+      data = { 'error' => 'The model foo is not available in your region.' }.to_json
+
+      expect(protocol.send(:parse_streaming_error, data))
+        .to eq([500, 'The model foo is not available in your region.'])
+    end
+
+    it 'returns nil when the body parses to a JSON string mentioning an error' do
+      data = 'The upstream provider returned an error.'.to_json
+
+      expect(protocol.send(:parse_streaming_error, data)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## What this does

Fixes #837.

When a **streaming** request fails with a body that parses to something other than the expected `{"error": {...}}` shape, `ChatCompletions::Streaming#parse_streaming_error` crashed instead of surfacing the provider's error message:

- `{"error": "The model is not available in your region."}` (string-valued `error`) → `TypeError: String does not have #dig method`
- a bare JSON string body containing the substring `error` → slips past the `error_data['error']` guard via `String#[]` substring matching → `NoMethodError: undefined method 'dig' for an instance of String`

The identical bodies are handled fine on the non-streaming path by `Provider#parse_error`, which already guards Hash/Array/String shapes — so the real error message was lost only when streaming.

The fix guards the parsed body shape before digging into it:
- non-Hash bodies return no status hint (the failed HTTP status wins in `build_stream_error_response` anyway, and `Provider#parse_error` still extracts the message downstream)
- string-valued `error` keys are surfaced as the error message directly

No change to the happy path or to correctly-shaped error objects.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## Tests

- Unit specs for `parse_streaming_error` covering all classification branches (server_error → 500, rate limit → 429, other → 400, no error key → nil) plus the two crashing shapes from the issue.
- End-to-end streaming specs (webmock-stubbed, no cassettes needed) on a ChatCompletions provider for both body shapes, on both Faraday 1 and 2, asserting the proper `RubyLLM::ServerError` with the provider's message. One caveat encoded in the spec: Faraday 1 streams the error body away before `on_complete`, so for bare-string bodies only the status (and thus error class) is available there — the message assertion applies to Faraday 2.

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
