### PR TITLE
Raise a clear error when a provider returns no completion message

### DIFF
--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -630,6 +630,8 @@ module RubyLLM
     end
 
     def coerce_message(message_or_attributes)
+      raise ArgumentError, 'Message cannot be nil' if message_or_attributes.nil?
+
       message = if message_or_attributes.respond_to?(:to_llm)
                   message_or_attributes.to_llm
                 else

--- a/lib/ruby_llm/protocol.rb
+++ b/lib/ruby_llm/protocol.rb
@@ -267,7 +267,10 @@ module RubyLLM
         raise Error.new('Provider returned an empty response body', response:)
       end
 
-      parse_completion_body(body, raw: response)
+      message = parse_completion_body(body, raw: response)
+      raise Error.new('Provider returned no completion message', response:) unless message
+
+      message
     end
   end
 end

--- a/lib/ruby_llm/protocols/chat_completions/chat.rb
+++ b/lib/ruby_llm/protocols/chat_completions/chat.rb
@@ -69,7 +69,7 @@ module RubyLLM
           raise Error.new(data.dig('error', 'message'), response: raw) if data.dig('error', 'message')
 
           message_data = data.dig('choices', 0, 'message')
-          return unless message_data
+          raise no_completion_message_error(data, raw) unless message_data
 
           usage = data['usage'] || {}
           thinking_tokens = thinking_tokens(usage)
@@ -94,6 +94,13 @@ module RubyLLM
             model: data['model'],
             raw: raw
           )
+        end
+
+        def no_completion_message_error(data, raw)
+          finish_reason = data.dig('choices', 0, 'finish_reason')
+          message = 'Provider returned no completion message'
+          message = "#{message} (finish_reason: #{finish_reason})" if finish_reason
+          Error.new(message, response: raw)
         end
 
         def input_tokens(usage)

--- a/spec/ruby_llm/chat_error_spec.rb
+++ b/spec/ruby_llm/chat_error_spec.rb
@@ -109,6 +109,18 @@ RSpec.describe RubyLLM::Chat do
         expect(e.response).to be_present
       end
     end
+
+    it 'surfaces the finish_reason when the provider gives one' do
+      stub_request(:post, 'https://api.deepseek.com/chat/completions').to_return(
+        status: 200,
+        body: { choices: [{ finish_reason: 'content_filter' }] }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+      expect { chat.ask('Hello') }.to raise_error(
+        RubyLLM::Error, 'Provider returned no completion message (finish_reason: content_filter)'
+      )
+    end
   end
 
   describe '#add_message with nil' do

--- a/spec/ruby_llm/chat_error_spec.rb
+++ b/spec/ruby_llm/chat_error_spec.rb
@@ -94,4 +94,28 @@ RSpec.describe RubyLLM::Chat do
       end
     end
   end
+
+  describe 'responses without a completion message' do
+    let(:chat) { RubyLLM.chat(model: 'deepseek-chat', provider: :deepseek) }
+
+    it 'raises a RubyLLM::Error instead of an obscure NoMethodError' do
+      stub_request(:post, 'https://api.deepseek.com/chat/completions').to_return(
+        status: 200,
+        body: { choices: [] }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+      expect { chat.ask('Hello') }.to raise_error(RubyLLM::Error, 'Provider returned no completion message') do |e|
+        expect(e.response).to be_present
+      end
+    end
+  end
+
+  describe '#add_message with nil' do
+    it 'raises ArgumentError instead of an obscure NoMethodError' do
+      chat = RubyLLM.chat
+
+      expect { chat.add_message(nil) }.to raise_error(ArgumentError, 'Message cannot be nil')
+    end
+  end
 end

--- a/spec/ruby_llm/protocol_spec.rb
+++ b/spec/ruby_llm/protocol_spec.rb
@@ -33,6 +33,22 @@ RSpec.describe RubyLLM::Protocol do
       expect(protocol.send(:parse_completion_response, response))
         .to eq([{ 'text' => 'hello' }, response])
     end
+
+    it 'raises RubyLLM::Error when the protocol finds no completion message in the body' do
+      messageless_protocol_class = Class.new(described_class) do
+        private
+
+        def parse_completion_body(_data, raw:) # rubocop:disable Lint/UnusedMethodArgument
+          nil
+        end
+      end
+      protocol = messageless_protocol_class.allocate
+      response = instance_double(Faraday::Response, body: { 'choices' => [] })
+
+      expect do
+        protocol.send(:parse_completion_response, response)
+      end.to raise_error(RubyLLM::Error, 'Provider returned no completion message')
+    end
   end
 
   it 'owns completion response parsing for every registered chat protocol' do


### PR DESCRIPTION
## What this does

Fixes #847.

When an OpenAI-family provider returns a response body without `choices[0].message` (e.g. an empty or content-filtered upstream response), `parse_completion_body` returns `nil` and `Chat` ended up calling `add_message(nil)`, which crashed deep inside `Message#initialize` with an unexplained `NoMethodError: undefined method 'fetch' for nil` — obscuring the real cause.

Two small guards:

- **Protocol seam** (`Protocol#parse_completion_response`): when `parse_completion_body` produces no message, raise `RubyLLM::Error.new('Provider returned no completion message', response:)` — mirroring the existing empty-body guard two lines above, and carrying the response so callers can introspect status/body as the issue requests.
- **Domain guard** (`Chat#coerce_message`): a direct `chat.add_message(nil)` (the issue's repro) now raises `ArgumentError, 'Message cannot be nil'` instead of the baffling `NoMethodError`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## Tests

- Protocol-level spec in `protocol_spec.rb` alongside the existing empty-body examples: a protocol whose `parse_completion_body` returns `nil` now raises the new error.
- End-to-end spec in `chat_error_spec.rb`: a stubbed 200 response with `{"choices": []}` raises `RubyLLM::Error` with the response attached (previously `NoMethodError`).
- Direct-repro spec: `chat.add_message(nil)` raises `ArgumentError` with a clear message.

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
