### PR TITLE
Group parallel Anthropic tool results in one user message

### DIFF
--- a/lib/ruby_llm/protocols/anthropic/chat.rb
+++ b/lib/ruby_llm/protocols/anthropic/chat.rb
@@ -57,9 +57,7 @@ module RubyLLM
         def build_base_payload(chat_messages, model, stream, thinking, citations: false, caching: nil)
           payload = {
             model: model.id,
-            messages: chat_messages.map do |msg|
-              format_message(msg, thinking: thinking, citations: citations, caching:)
-            end,
+            messages: format_messages(chat_messages, thinking:, citations:, caching:),
             stream: stream,
             max_tokens: model.max_output_tokens || 4096
           }
@@ -67,6 +65,28 @@ module RubyLLM
           add_thinking_fields(payload, thinking, model)
 
           payload
+        end
+
+        def format_messages(messages, thinking: nil, citations: false, caching: nil)
+          rendered = []
+          tool_result_blocks = []
+
+          messages.each do |msg|
+            if msg.tool_result?
+              tool_result_blocks << Tools.format_tool_result_block(msg)
+              next
+            end
+
+            unless tool_result_blocks.empty?
+              rendered << { role: 'user', content: tool_result_blocks }
+              tool_result_blocks = []
+            end
+
+            rendered << format_message(msg, thinking:, citations:, caching:)
+          end
+
+          rendered << { role: 'user', content: tool_result_blocks } unless tool_result_blocks.empty?
+          rendered
         end
 
         def add_optional_fields(payload, system_content:, tools:, tool_prefs:, temperature:, schema: nil)

--- a/spec/ruby_llm/protocols/anthropic/chat_spec.rb
+++ b/spec/ruby_llm/protocols/anthropic/chat_spec.rb
@@ -133,6 +133,45 @@ RSpec.describe RubyLLM::Protocols::Anthropic::Chat do
   describe '.render_payload' do
     let(:model) { instance_double(RubyLLM::Model, id: 'claude-sonnet-4-5', max_output_tokens: nil) }
 
+    it 'groups consecutive tool results into a single user message' do
+      tool_calls = {
+        'tool_1' => RubyLLM::ToolCall.new(id: 'tool_1', name: 'inspect', arguments: {}),
+        'tool_2' => RubyLLM::ToolCall.new(id: 'tool_2', name: 'date_calculator', arguments: {})
+      }
+      messages = [
+        RubyLLM::Message.new(role: :user, content: 'Check the date'),
+        RubyLLM::Message.new(role: :assistant, content: '', tool_calls: tool_calls),
+        RubyLLM::Message.new(role: :tool, content: 'Context inspected', tool_call_id: 'tool_1'),
+        RubyLLM::Message.new(role: :tool, content: '2026-07-21', tool_call_id: 'tool_2')
+      ]
+
+      payload = described_class.render_payload(
+        messages,
+        tools: {},
+        temperature: nil,
+        model: model,
+        stream: false,
+        schema: nil
+      )
+
+      expect(payload[:messages].length).to eq(3)
+      expect(payload[:messages].last).to eq(
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool_1',
+            content: [{ type: 'text', text: 'Context inspected' }]
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool_2',
+            content: [{ type: 'text', text: '2026-07-21' }]
+          }
+        ]
+      )
+    end
+
     it 'adds top-level automatic cache_control when caching is enabled without explicit boundaries' do
       payload = described_class.render_payload(
         [RubyLLM::Message.new(role: :user, content: 'Hello there')],


### PR DESCRIPTION
## What this does

Fixes Anthropic parallel tool-call transcripts by grouping consecutive `tool_result` blocks into the single next `user` message required by the Messages API.

RubyLLM stores each tool result as a separate `:tool` message. The Anthropic renderer previously mapped those messages one-for-one, producing multiple consecutive `user` messages after an assistant response with several `tool_use` blocks. Strict Anthropic-compatible endpoints reject that history because every result for the assistant turn must be returned together.

This change:
- accumulates consecutive tool results while rendering Anthropic messages
- emits them in order as multiple `tool_result` blocks within one `user` message
- preserves existing single-tool behavior and result content formatting
- adds a regression spec for a two-tool response

Validation:
- `bundle exec rspec`: 1894 examples, 0 failures, 89 pending
- Anthropic protocol specs: 41 examples, 0 failures
- All Overcommit hooks pass

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

<!-- Skip this section for bug fixes and documentation -->

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: #___

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
    - Not re-recorded: this is a request serialization fix covered by a protocol regression spec; provider response fixtures are unchanged.
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
  - No documentation changes were required because this does not change the public API.
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes