### PR TITLE
Fix Bedrock thinking effort mapping for Claude models (#851)

### DIFF
--- a/docs/_core_features/thinking.md
+++ b/docs/_core_features/thinking.md
@@ -119,7 +119,7 @@ end
 
 - Claude uses budget-based or adaptive thinking depending on the model, and can return both text and signature.
 - Anthropic requires a thinking budget for older Claude models and effort-based adaptive thinking for newer models.
-- Bedrock thinking params are model-dependent; models may accept budget, effort, or provider-specific fields.
+- Bedrock thinking params are model-dependent. Claude models on Bedrock only take a token budget, so RubyLLM converts `effort` into the budget level the model advertises. Pass `budget` to set the exact number of tokens.
 - Gemini 2.5 uses a token budget; Gemini 3 uses effort levels.
 - OpenAI reasoning models accept `effort` but may not return thinking text or signatures.
 - Perplexity sonar reasoning models stream `<think>` blocks inside content; RubyLLM extracts them after the response completes.

--- a/lib/ruby_llm/protocols/converse.rb
+++ b/lib/ruby_llm/protocols/converse.rb
@@ -8,11 +8,43 @@ module RubyLLM
       include Converse::Media
       include Converse::Streaming
 
-      def self.reasoning_embedded?(model)
-        metadata = RubyLLM::Utils.deep_symbolize_keys(model.metadata || {})
-        converse = metadata[:converse] || {}
-        reasoning_supported = converse[:reasoningSupported] || {}
-        reasoning_supported[:embedded] || false
+      # The budgetTokens entry of the model's additionalRequestFieldsSchema, which Bedrock
+      # publishes as a JSON string. Models that expose one only accept a token budget for
+      # reasoning, never an effort level.
+      def self.reasoning_budget_schema(model)
+        budget_tokens_schema(model) || budget_tokens_schema(region_sibling(model))
+      end
+
+      def self.budget_tokens_schema(model)
+        metadata = RubyLLM::Utils.deep_symbolize_keys(model&.metadata || {})
+        raw_schema = metadata.dig(:converse, :additionalRequestFieldsSchema)
+        return nil unless raw_schema.is_a?(String)
+
+        schema = begin
+          JSON.parse(raw_schema, symbolize_names: true)
+        rescue JSON::ParserError
+          nil
+        end
+
+        budget = schema.is_a?(Hash) ? schema.dig(:reasoningConfig, :budgetTokens) : nil
+        budget.is_a?(Hash) ? budget : nil
+      end
+
+      # Bedrock only publishes converse metadata for some regional entries of a foundation
+      # model, so fall back to a sibling entry that carries it.
+      def self.region_sibling(model)
+        return nil unless model
+
+        foundation_id = foundation_model_id(model.id)
+        RubyLLM.models.all.find do |candidate|
+          candidate.provider == 'bedrock' && candidate.id != model.id &&
+            foundation_model_id(candidate.id) == foundation_id && budget_tokens_schema(candidate)
+        end
+      end
+
+      def self.foundation_model_id(model_id)
+        prefixes = Providers::Bedrock::Models::REGION_PREFIXES.join('|')
+        model_id.to_s.sub(/\A(?:#{prefixes})\./, '')
       end
 
       private

--- a/lib/ruby_llm/protocols/converse.rb
+++ b/lib/ruby_llm/protocols/converse.rb
@@ -8,45 +8,6 @@ module RubyLLM
       include Converse::Media
       include Converse::Streaming
 
-      # The budgetTokens entry of the model's additionalRequestFieldsSchema, which Bedrock
-      # publishes as a JSON string. Models that expose one only accept a token budget for
-      # reasoning, never an effort level.
-      def self.reasoning_budget_schema(model)
-        budget_tokens_schema(model) || budget_tokens_schema(region_sibling(model))
-      end
-
-      def self.budget_tokens_schema(model)
-        metadata = RubyLLM::Utils.deep_symbolize_keys(model&.metadata || {})
-        raw_schema = metadata.dig(:converse, :additionalRequestFieldsSchema)
-        return nil unless raw_schema.is_a?(String)
-
-        schema = begin
-          JSON.parse(raw_schema, symbolize_names: true)
-        rescue JSON::ParserError
-          nil
-        end
-
-        budget = schema.is_a?(Hash) ? schema.dig(:reasoningConfig, :budgetTokens) : nil
-        budget.is_a?(Hash) ? budget : nil
-      end
-
-      # Bedrock only publishes converse metadata for some regional entries of a foundation
-      # model, so fall back to a sibling entry that carries it.
-      def self.region_sibling(model)
-        return nil unless model
-
-        foundation_id = foundation_model_id(model.id)
-        RubyLLM.models.all.find do |candidate|
-          candidate.provider == 'bedrock' && candidate.id != model.id &&
-            foundation_model_id(candidate.id) == foundation_id && budget_tokens_schema(candidate)
-        end
-      end
-
-      def self.foundation_model_id(model_id)
-        prefixes = Providers::Bedrock::Models::REGION_PREFIXES.join('|')
-        model_id.to_s.sub(/\A(?:#{prefixes})\./, '')
-      end
-
       private
 
       def sync_response(payload, additional_headers = {})

--- a/lib/ruby_llm/protocols/converse/chat.rb
+++ b/lib/ruby_llm/protocols/converse/chat.rb
@@ -324,13 +324,12 @@ module RubyLLM
           return nil unless thinking&.enabled?
 
           effort = thinking.effort.to_s
-          return nil if effort == 'none'
+          return nil if effort.empty? || effort == 'none'
 
           budget = reasoning_budget(thinking, effort, model, max_output_tokens)
           return { reasoning_config: { type: 'enabled', budget_tokens: budget } } if budget
-          return { reasoning_effort: effort } unless effort.empty?
 
-          nil
+          { reasoning_effort: effort }
         end
 
         def reasoning_budget(thinking, effort, model, max_output_tokens)

--- a/lib/ruby_llm/protocols/converse/chat.rb
+++ b/lib/ruby_llm/protocols/converse/chat.rb
@@ -324,17 +324,16 @@ module RubyLLM
           return nil unless thinking&.enabled?
 
           effort = thinking.effort.to_s
-          return nil if effort.empty? || effort == 'none'
-
           budget = reasoning_budget(thinking, effort, model, max_output_tokens)
           return { reasoning_config: { type: 'enabled', budget_tokens: budget } } if budget
+          return nil if effort.empty? || effort == 'none'
 
           { reasoning_effort: effort }
         end
 
         def reasoning_budget(thinking, effort, model, max_output_tokens)
           return thinking.budget if thinking.budget.is_a?(Integer)
-          return nil if effort.empty?
+          return nil if effort.empty? || effort == 'none'
 
           schema = Converse.reasoning_budget_schema(model)
           schema && effort_budget_tokens(effort, schema, max_output_tokens)

--- a/lib/ruby_llm/protocols/converse/chat.rb
+++ b/lib/ruby_llm/protocols/converse/chat.rb
@@ -335,8 +335,43 @@ module RubyLLM
           return thinking.budget if thinking.budget.is_a?(Integer)
           return nil if effort.empty? || effort == 'none'
 
-          schema = Converse.reasoning_budget_schema(model)
+          schema = reasoning_budget_schema(model)
           schema && effort_budget_tokens(effort, schema, max_output_tokens)
+        end
+
+        # Bedrock only publishes Converse metadata for some regional entries, so use the
+        # schema from another entry for the same foundation model when needed.
+        def reasoning_budget_schema(model)
+          schema = budget_tokens_schema(model)
+          return schema if schema
+          return unless model
+
+          foundation_id = foundation_model_id(model.id)
+          RubyLLM.models.all.each do |candidate|
+            next unless candidate.provider == 'bedrock' && candidate.id != model.id
+            next unless foundation_model_id(candidate.id) == foundation_id
+
+            return schema if (schema = budget_tokens_schema(candidate))
+          end
+
+          nil
+        end
+
+        def budget_tokens_schema(model)
+          metadata = RubyLLM::Utils.deep_symbolize_keys(model&.metadata || {})
+          raw_schema = metadata.dig(:converse, :additionalRequestFieldsSchema)
+          return unless raw_schema.is_a?(String)
+
+          schema = JSON.parse(raw_schema, symbolize_names: true)
+          budget = schema.is_a?(Hash) ? schema.dig(:reasoningConfig, :budgetTokens) : nil
+          budget if budget.is_a?(Hash)
+        rescue JSON::ParserError
+          nil
+        end
+
+        def foundation_model_id(model_id)
+          prefixes = Providers::Bedrock::Models::REGION_PREFIXES.join('|')
+          model_id.to_s.sub(/\A(?:#{prefixes})\./, '')
         end
 
         # Models that take a budget reject reasoning_effort, so effort has to become a budget.

--- a/lib/ruby_llm/protocols/converse/chat.rb
+++ b/lib/ruby_llm/protocols/converse/chat.rb
@@ -43,7 +43,7 @@ module RubyLLM
           tool_config = format_tool_config(tools, tool_prefs)
           payload[:toolConfig] = tool_config if tool_config
 
-          additional_fields = format_additional_model_request_fields(thinking)
+          additional_fields = format_additional_model_request_fields(thinking, model, max_output_tokens)
           payload[:additionalModelRequestFields] = additional_fields if additional_fields
 
           output_config = build_output_config(schema)
@@ -291,10 +291,10 @@ module RubyLLM
           RubyLLM::Utils.deep_merge(tool_spec, tool.provider_options)
         end
 
-        def format_additional_model_request_fields(thinking)
+        def format_additional_model_request_fields(thinking, model, max_output_tokens = nil)
           fields = {}
 
-          reasoning_fields = format_reasoning_fields(thinking)
+          reasoning_fields = format_reasoning_fields(thinking, model, max_output_tokens)
           fields = RubyLLM::Utils.deep_merge(fields, reasoning_fields) if reasoning_fields
 
           fields.empty? ? nil : fields
@@ -320,31 +320,56 @@ module RubyLLM
           }
         end
 
-        def format_reasoning_fields(thinking)
+        def format_reasoning_fields(thinking, model, max_output_tokens = nil)
           return nil unless thinking&.enabled?
 
-          effort_config = effort_reasoning_config(thinking)
-          return effort_config if effort_config
-
-          budget_reasoning_config(thinking)
-        end
-
-        def effort_reasoning_config(thinking)
           effort = thinking.effort.to_s
-          return nil if effort.empty? || effort == 'none'
+          return nil if effort == 'none'
 
-          if Converse.reasoning_embedded?(@model)
-            { reasoning_config: { type: 'enabled', reasoning_effort: effort } }
-          else
-            { reasoning_effort: effort }
-          end
+          budget = reasoning_budget(thinking, effort, model, max_output_tokens)
+          return { reasoning_config: { type: 'enabled', budget_tokens: budget } } if budget
+          return { reasoning_effort: effort } unless effort.empty?
+
+          nil
         end
 
-        def budget_reasoning_config(thinking)
-          budget = thinking.budget
-          return nil unless budget.is_a?(Integer)
+        def reasoning_budget(thinking, effort, model, max_output_tokens)
+          return thinking.budget if thinking.budget.is_a?(Integer)
+          return nil if effort.empty?
 
-          { reasoning_config: { type: 'enabled', budget_tokens: budget } }
+          schema = Converse.reasoning_budget_schema(model)
+          schema && effort_budget_tokens(effort, schema, max_output_tokens)
+        end
+
+        # Models that take a budget reject reasoning_effort, so effort has to become a budget.
+        # Bedrock names the levels of an enumerated budget after the efforts they stand for;
+        # otherwise the effort spans the range the schema allows.
+        def effort_budget_tokens(effort, schema, max_output_tokens)
+          minimum = schema[:minimum]
+          budget = enumerated_budget(effort, schema) || ranged_budget(effort, schema)
+          return nil unless budget
+
+          # Bedrock rejects a budget that leaves no room for the answer.
+          budget = max_output_tokens - 1 if max_output_tokens && budget >= max_output_tokens
+          minimum.is_a?(Integer) ? [budget, minimum].max : budget
+        end
+
+        def enumerated_budget(effort, schema)
+          levels = schema[:enum]
+          level = levels.is_a?(Hash) ? levels[effort.to_sym] : nil
+          level if level.is_a?(Integer)
+        end
+
+        def ranged_budget(effort, schema)
+          minimum = schema[:minimum]
+          maximum = schema[:maximum]
+          return nil unless minimum.is_a?(Integer) && maximum.is_a?(Integer)
+
+          case effort
+          when 'low' then minimum
+          when 'medium' then minimum + ((maximum - minimum) / 2)
+          else maximum
+          end
         end
 
         def format_thinking_block(thinking)

--- a/spec/ruby_llm/protocols/converse/chat_spec.rb
+++ b/spec/ruby_llm/protocols/converse/chat_spec.rb
@@ -454,7 +454,7 @@ RSpec.describe RubyLLM::Protocols::Converse::Chat do
       target = Object.new
       target.extend(protocol)
       target.instance_variable_set(:@model, model)
-      target.send(:format_reasoning_fields, thinking)
+      target.send(:format_reasoning_fields, thinking, model)
     end
 
     it 'is nil when thinking is off' do
@@ -466,16 +466,18 @@ RSpec.describe RubyLLM::Protocols::Converse::Chat do
       expect(reasoning_fields(RubyLLM::Thinking::Config.new(effort: :none))).to be_nil
     end
 
-    it 'nests the effort for models with embedded reasoning' do
-      allow(RubyLLM::Protocols::Converse).to receive(:reasoning_embedded?).and_return(true)
+    it 'maps effort to an advertised token budget' do
+      allow(RubyLLM::Protocols::Converse).to receive(:reasoning_budget_schema).and_return(
+        enum: { low: 1024, high: 8192 }, minimum: 1024, maximum: 8192
+      )
 
       expect(reasoning_fields(RubyLLM::Thinking::Config.new(effort: :high))).to eq(
-        reasoning_config: { type: 'enabled', reasoning_effort: 'high' }
+        reasoning_config: { type: 'enabled', budget_tokens: 8192 }
       )
     end
 
     it 'sends a flat effort otherwise' do
-      allow(RubyLLM::Protocols::Converse).to receive(:reasoning_embedded?).and_return(false)
+      allow(RubyLLM::Protocols::Converse).to receive(:reasoning_budget_schema).and_return(nil)
 
       expect(reasoning_fields(RubyLLM::Thinking::Config.new(effort: :low))).to eq(reasoning_effort: 'low')
     end

--- a/spec/ruby_llm/protocols/converse/chat_spec.rb
+++ b/spec/ruby_llm/protocols/converse/chat_spec.rb
@@ -347,6 +347,14 @@ RSpec.describe RubyLLM::Protocols::Converse::Chat do
         )
       end
 
+      it 'sends an explicit budget without requiring an effort' do
+        payload = render_payload(model: enumerated_budget_model, thinking: thinking(budget: 5000))
+
+        expect(payload[:additionalModelRequestFields]).to eq(
+          reasoning_config: { type: 'enabled', budget_tokens: 5000 }
+        )
+      end
+
       it 'maps effort for regional entries that carry no converse metadata of their own' do
         model = instance_double(RubyLLM::Model,
                                 id: 'eu.anthropic.claude-sonnet-5',

--- a/spec/ruby_llm/protocols/converse/chat_spec.rb
+++ b/spec/ruby_llm/protocols/converse/chat_spec.rb
@@ -282,6 +282,98 @@ RSpec.describe RubyLLM::Protocols::Converse::Chat do
       end
     end
 
+    context 'when thinking is configured' do
+      def bedrock_model(id, budget_schema)
+        schema = budget_schema ? { reasoningConfig: { budgetTokens: budget_schema } } : {}
+        instance_double(RubyLLM::Model,
+                        id: id,
+                        max_output_tokens: nil,
+                        metadata: { converse: { additionalRequestFieldsSchema: JSON.generate(schema) } })
+      end
+
+      let(:enumerated_budget_model) do
+        bedrock_model('us.anthropic.claude-sonnet-5',
+                      { type: 'enum', enum: { low: 1024, medium: 40_000, high: 63_999 },
+                        minimum: 1024, maximum: 63_999 })
+      end
+
+      let(:ranged_budget_model) do
+        bedrock_model('us.anthropic.claude-haiku-4-5-20251001-v1:0',
+                      { type: 'integer', default: 2048, minimum: 1024, maximum: 63_999 })
+      end
+
+      def thinking(effort: nil, budget: nil)
+        RubyLLM::Thinking::Config.new(effort: effort, budget: budget)
+      end
+
+      it 'maps effort onto the budget level the model names for it' do
+        payload = render_payload(model: enumerated_budget_model, thinking: thinking(effort: :medium))
+
+        expect(payload[:additionalModelRequestFields]).to eq(
+          reasoning_config: { type: 'enabled', budget_tokens: 40_000 }
+        )
+      end
+
+      it 'maps efforts the model does not enumerate onto its largest budget' do
+        payload = render_payload(model: enumerated_budget_model, thinking: thinking(effort: :xhigh))
+
+        expect(payload[:additionalModelRequestFields]).to eq(
+          reasoning_config: { type: 'enabled', budget_tokens: 63_999 }
+        )
+      end
+
+      it 'spreads effort across the range when the model does not enumerate budgets' do
+        payload = render_payload(model: ranged_budget_model, thinking: thinking(effort: :low))
+
+        expect(payload[:additionalModelRequestFields]).to eq(
+          reasoning_config: { type: 'enabled', budget_tokens: 1024 }
+        )
+      end
+
+      it 'keeps a derived budget under an explicit max_output_tokens' do
+        payload = render_payload(model: enumerated_budget_model, thinking: thinking(effort: :high),
+                                 max_output_tokens: 8000)
+
+        expect(payload[:additionalModelRequestFields]).to eq(
+          reasoning_config: { type: 'enabled', budget_tokens: 7999 }
+        )
+      end
+
+      it 'prefers an explicit budget over effort' do
+        payload = render_payload(model: enumerated_budget_model, thinking: thinking(effort: :high, budget: 5000))
+
+        expect(payload[:additionalModelRequestFields]).to eq(
+          reasoning_config: { type: 'enabled', budget_tokens: 5000 }
+        )
+      end
+
+      it 'maps effort for regional entries that carry no converse metadata of their own' do
+        model = instance_double(RubyLLM::Model,
+                                id: 'eu.anthropic.claude-sonnet-5',
+                                max_output_tokens: nil,
+                                metadata: {})
+
+        payload = render_payload(model: model, thinking: thinking(effort: :low))
+
+        expect(payload[:additionalModelRequestFields]).to eq(
+          reasoning_config: { type: 'enabled', budget_tokens: 1024 }
+        )
+      end
+
+      it 'sends reasoning_effort for models that do not advertise a budget' do
+        payload = render_payload(model: bedrock_model('openai.gpt-oss-120b-1:0', nil),
+                                 thinking: thinking(effort: :high))
+
+        expect(payload[:additionalModelRequestFields]).to eq(reasoning_effort: 'high')
+      end
+
+      it 'omits reasoning fields when effort is none' do
+        payload = render_payload(model: enumerated_budget_model, thinking: thinking(effort: :none))
+
+        expect(payload).not_to have_key(:additionalModelRequestFields)
+      end
+    end
+
     it 'does not send finish_reason back to the provider' do
       message = RubyLLM::Message.new(role: :assistant, content: 'Done', finish_reason: 'MAX_TOKENS')
 

--- a/spec/ruby_llm/protocols/converse/chat_spec.rb
+++ b/spec/ruby_llm/protocols/converse/chat_spec.rb
@@ -444,12 +444,12 @@ RSpec.describe RubyLLM::Protocols::Converse::Chat do
   end
 
   describe '.format_reasoning_fields' do
-    let(:embedded_model) do
+    let(:model_without_budget) do
       instance_double(RubyLLM::Model, id: 'anthropic.claude-haiku-4-5', metadata: {},
                                       capabilities: ['reasoning'])
     end
 
-    def reasoning_fields(thinking, model: embedded_model)
+    def reasoning_fields(thinking, model: model_without_budget)
       protocol = described_class
       target = Object.new
       target.extend(protocol)
@@ -467,18 +467,24 @@ RSpec.describe RubyLLM::Protocols::Converse::Chat do
     end
 
     it 'maps effort to an advertised token budget' do
-      allow(RubyLLM::Protocols::Converse).to receive(:reasoning_budget_schema).and_return(
-        enum: { low: 1024, high: 8192 }, minimum: 1024, maximum: 8192
+      model = instance_double(
+        RubyLLM::Model,
+        id: 'anthropic.claude-test',
+        metadata: {
+          converse: {
+            additionalRequestFieldsSchema: JSON.generate(
+              reasoningConfig: { budgetTokens: { enum: { low: 1024, high: 8192 }, minimum: 1024, maximum: 8192 } }
+            )
+          }
+        }
       )
 
-      expect(reasoning_fields(RubyLLM::Thinking::Config.new(effort: :high))).to eq(
+      expect(reasoning_fields(RubyLLM::Thinking::Config.new(effort: :high), model: model)).to eq(
         reasoning_config: { type: 'enabled', budget_tokens: 8192 }
       )
     end
 
     it 'sends a flat effort otherwise' do
-      allow(RubyLLM::Protocols::Converse).to receive(:reasoning_budget_schema).and_return(nil)
-
       expect(reasoning_fields(RubyLLM::Thinking::Config.new(effort: :low))).to eq(reasoning_effort: 'low')
     end
 


### PR DESCRIPTION
## What this does

Fixes #851. 

Extended thinking on Bedrock Claude models (Sonnet 5, and every other Claude on Bedrock) raised `RubyLLM::BadRequestError: The model returned the following errors: reasoning_effort: Extra inputs are not permitted` whenever `with_thinking(effort:)` was used.

The Converse protocol branched on `reasoningSupported.embedded` metadata to decide how to send thinking params. That flag is unrelated to how a model accepts reasoning input, and it's `false` for every Bedrock Claude, so effort-based thinking always fell into a `{ reasoning_effort: ... }` branch. Bedrock forwards `additionalModelRequestFields` straight to Anthropic, which rejects the unknown `reasoning_effort` key.

Bedrock actually publishes each model's accepted fields in `converse.additionalRequestFieldsSchema`. Claude models expose a `reasoningConfig.budgetTokens` schema and only accept a token budget, never an effort level. This PR:

- Replaces the `reasoning_embedded?` check with `reasoning_budget_schema`, which reads that published schema.
- Maps `effort` onto a budget: enumerated schemas use the token value they name for each level (e.g. Sonnet 5 `low → 1024`, `medium → 40000`, `high → 63999`); integer-range schemas spread low/medium/high across the range; efforts a schema doesn't enumerate clamp to its maximum.
- Keeps sending `reasoning_effort` for models whose schema advertises no budget (e.g. `openai.gpt-oss-120b`).
- Prefers an explicit `budget:` over `effort:`, and clamps a derived budget below `max_output_tokens` when one is set so it can't consume the whole output allowance.
- Falls back to a sibling regional registry entry for the same foundation model, since Bedrock only stores the Converse schema on some regional entries — without this, `eu.`/`global.`/bare `anthropic.` ids still failed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

N/A — bug fix.

- [ ] I opened an issue **before** writing code and received maintainer approval
- [x] Linked issue: #851

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

---

**Notes for the maintainer:**

- **VCR cassettes not re-recorded.** No Bedrock credentials were available to record a live effort-based thinking cassette. The change is covered by unit specs in `spec/ruby_llm/protocols/converse/chat_spec.rb` asserting the emitted payload, plus a WebMock-stubbed end-to-end reproduction. The derived payload shape matches what the existing budget-based Bedrock cassettes already send, but you may want to add `{ provider: :bedrock, model: 'claude-sonnet-5' }` to the thinking models and record one.
