### PR TITLE
Add MiniMax as a first-class provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ GOOGLE_CLOUD_LOCATION=global
 GOOGLE_CLOUD_PROJECT=$(op read "op://RubyLLM/Google Cloud/project")
 GPUSTACK_API_BASE=http://localhost:11444/v1
 GPUSTACK_API_KEY=$(op read "op://RubyLLM/GPUStack/credential")
+MINIMAX_API_KEY=$(op read "op://RubyLLM/MiniMax/credential")
 MISTRAL_API_KEY=$(op read "op://RubyLLM/Mistral/credential")
 OLLAMA_API_BASE=http://localhost:11434/v1
 OPENAI_API_KEY=$(op read "op://RubyLLM/OpenAI/credential")

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ response = chat.with_schema(ProductSchema).ask "Analyze this product", with: "pr
 * **Extended thinking:** Control, view, and persist model deliberation
 * **Citations:** Normalized source citations from documents, search, and grounding
 * **Batches:** Provider-side batch processing at half price with `RubyLLM.batch`
-* **Providers:** OpenAI, xAI, Anthropic, Gemini, VertexAI, Bedrock, DeepSeek, Mistral, Ollama, OpenRouter, Perplexity, GPUStack, and any OpenAI-compatible API
+* **Providers:** OpenAI, xAI, Anthropic, Gemini, VertexAI, Bedrock, DeepSeek, MiniMax, Mistral, Ollama, OpenRouter, Perplexity, GPUStack, and any OpenAI-compatible API
 
 ## Installation
 

--- a/docs/_getting_started/configuration-providers.md
+++ b/docs/_getting_started/configuration-providers.md
@@ -62,6 +62,10 @@ RubyLLM.configure do |config|
   config.gpustack_api_base = ENV['GPUSTACK_API_BASE']
   config.gpustack_api_key = ENV['GPUSTACK_API_KEY']
 
+  # MiniMax
+  config.minimax_api_key = ENV['MINIMAX_API_KEY']
+  config.minimax_api_base = ENV['MINIMAX_API_BASE'] # Optional regional endpoint (defaults to https://api.minimax.io/v1; use https://api.minimaxi.com/v1 in Mainland China)
+
   # Mistral
   config.mistral_api_key = ENV['MISTRAL_API_KEY']
   config.mistral_api_base = ENV['MISTRAL_API_BASE'] # v1.16+ (optional custom Mistral endpoint)

--- a/docs/_getting_started/configuration-reference.md
+++ b/docs/_getting_started/configuration-reference.md
@@ -61,6 +61,10 @@ RubyLLM.configure do |config|
   config.gpustack_api_base = String
   config.gpustack_api_key = String
 
+  # MiniMax
+  config.minimax_api_key = String
+  config.minimax_api_base = String  # Optional regional endpoint
+
   # Mistral
   config.mistral_api_key = String
   config.mistral_api_base = String  # v1.16+

--- a/lib/ruby_llm.rb
+++ b/lib/ruby_llm.rb
@@ -23,6 +23,7 @@ loader.inflector.inflect(
   'deepseek' => 'DeepSeek',
   'gpustack' => 'GPUStack',
   'llm' => 'LLM',
+  'minimax' => 'MiniMax',
   'mistral' => 'Mistral',
   'openai' => 'OpenAI',
   'openrouter' => 'OpenRouter',
@@ -273,6 +274,7 @@ RubyLLM::Provider.register :bedrock, RubyLLM::Providers::Bedrock
 RubyLLM::Provider.register :deepseek, RubyLLM::Providers::DeepSeek
 RubyLLM::Provider.register :gemini, RubyLLM::Providers::Gemini
 RubyLLM::Provider.register :gpustack, RubyLLM::Providers::GPUStack
+RubyLLM::Provider.register :minimax, RubyLLM::Providers::MiniMax
 RubyLLM::Provider.register :mistral, RubyLLM::Providers::Mistral
 RubyLLM::Provider.register :ollama, RubyLLM::Providers::Ollama
 RubyLLM::Provider.register :openai, RubyLLM::Providers::OpenAI

--- a/lib/ruby_llm/models.json
+++ b/lib/ruby_llm/models.json
@@ -22644,6 +22644,76 @@
     }
   },
   {
+    "id": "MiniMax-M2.7",
+    "name": "MiniMax-M2.7",
+    "provider": "minimax",
+    "family": "minimax",
+    "created_at": null,
+    "context_window": 204800,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "tool_choice",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 1.2,
+          "cache_read_input_per_million": 0.06,
+          "cache_write_input_per_million": 0.375
+        }
+      }
+    },
+    "metadata": {}
+  },
+  {
+    "id": "MiniMax-M3",
+    "name": "MiniMax-M3",
+    "provider": "minimax",
+    "family": "minimax",
+    "created_at": null,
+    "context_window": 1000000,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "tool_choice",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.4,
+          "cache_read_input_per_million": 0.12
+        }
+      }
+    },
+    "metadata": {}
+  },
+  {
     "id": "codestral-2508",
     "name": "Codestral",
     "provider": "mistral",

--- a/lib/ruby_llm/providers/minimax.rb
+++ b/lib/ruby_llm/providers/minimax.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    # MiniMax API integration. MiniMax exposes an OpenAI-compatible Chat
+    # Completions API. Point +minimax_api_base+ at the regional endpoint you
+    # use: https://api.minimax.io/v1 (global, the default) or
+    # https://api.minimaxi.com/v1 (Mainland China).
+    class MiniMax < Provider
+      # MiniMax's dialect of the Chat Completions API.
+      class ChatCompletions < Protocols::ChatCompletions
+        include MiniMax::Chat
+        include MiniMax::Models
+      end
+
+      protocol :chat_completions, ChatCompletions
+
+      def api_base
+        @config.minimax_api_base || 'https://api.minimax.io/v1'
+      end
+
+      def headers
+        {
+          'Authorization' => "Bearer #{@config.minimax_api_key}"
+        }
+      end
+
+      class << self
+        def capabilities
+          MiniMax::Capabilities
+        end
+
+        def configuration_options
+          %i[minimax_api_key minimax_api_base]
+        end
+
+        def configuration_requirements
+          %i[minimax_api_key]
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/minimax/capabilities.rb
+++ b/lib/ruby_llm/providers/minimax/capabilities.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class MiniMax
+      # Provider-level capability checks and registry fallbacks for MiniMax models.
+      module Capabilities
+        module_function
+
+        CONTEXT_WINDOWS = {
+          'MiniMax-M3' => 1_000_000,
+          'MiniMax-M2.7' => 204_800
+        }.freeze
+
+        PRICES = {
+          'MiniMax-M3' => { input: 0.6, output: 2.4, cache_read: 0.12 },
+          'MiniMax-M2.7' => { input: 0.3, output: 1.2, cache_read: 0.06, cache_write: 0.375 }
+        }.freeze
+
+        VISION_MODELS = %w[MiniMax-M3].freeze
+
+        def context_window_for(model_id)
+          CONTEXT_WINDOWS[model_id]
+        end
+
+        def max_tokens_for(_model_id)
+          nil
+        end
+
+        def critical_capabilities_for(model_id)
+          capabilities = %w[function_calling tool_choice reasoning]
+          capabilities << 'vision' if VISION_MODELS.include?(model_id)
+          capabilities
+        end
+
+        def pricing_for(model_id)
+          prices = PRICES.fetch(model_id, {})
+          standard = {
+            input_per_million: prices[:input],
+            output_per_million: prices[:output]
+          }
+          standard[:cache_read_input_per_million] = prices[:cache_read] if prices.key?(:cache_read)
+          standard[:cache_write_input_per_million] = prices[:cache_write] if prices.key?(:cache_write)
+
+          { text_tokens: { standard: standard } }
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/minimax/chat.rb
+++ b/lib/ruby_llm/providers/minimax/chat.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class MiniMax
+      # Chat methods of the MiniMax API integration.
+      module Chat
+        module_function
+
+        def format_role(role)
+          role.to_s
+        end
+
+        def format_thinking(msg)
+          return {} unless msg.role == :assistant
+
+          thinking = msg.thinking
+          text = thinking&.text.to_s
+          payload = { reasoning_content: text }
+          payload[:reasoning] = text unless text.empty?
+          payload[:reasoning_signature] = thinking.signature if thinking&.signature
+          payload
+        end
+
+        def format_content(content, attachments = [])
+          Protocols::ChatCompletions::Media.format_content(
+            content,
+            attachments,
+            document_attachments: :none,
+            image_attachments: true,
+            audio_attachments: false
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/minimax/models.rb
+++ b/lib/ruby_llm/providers/minimax/models.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class MiniMax
+      # Models methods of the MiniMax API integration. MiniMax has no public
+      # model listing endpoint, so the supported models are curated here.
+      module Models
+        MODEL_IDS = %w[
+          MiniMax-M3
+          MiniMax-M2.7
+        ].freeze
+
+        MODALITIES = {
+          'MiniMax-M3' => { input: %w[text image video], output: %w[text] },
+          'MiniMax-M2.7' => { input: %w[text], output: %w[text] }
+        }.freeze
+
+        def list_models(**)
+          slug = 'minimax'
+          parse_list_models_response(nil, slug, MiniMax::Capabilities)
+        end
+
+        def parse_list_models_response(_response, slug, capabilities)
+          MODEL_IDS.map { |id| create_model_info(id, slug, capabilities) }
+        end
+
+        def create_model_info(id, slug, capabilities)
+          Model.new(
+            id: id,
+            name: id,
+            provider: slug,
+            family: 'minimax',
+            context_window: capabilities.context_window_for(id),
+            max_output_tokens: capabilities.max_tokens_for(id),
+            modalities: MODALITIES.fetch(id, input: %w[text], output: %w[text]),
+            capabilities: capabilities.critical_capabilities_for(id),
+            pricing: capabilities.pricing_for(id),
+            metadata: {}
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_llm/provider_spec.rb
+++ b/spec/ruby_llm/provider_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe RubyLLM::Provider do
         key: :gpustack_api_base,
         custom: 'https://gpustack.example.com/v1'
       },
+      minimax: {
+        provider: RubyLLM::Providers::MiniMax,
+        key: :minimax_api_base,
+        custom: 'https://api.minimaxi.com/v1',
+        default: 'https://api.minimax.io/v1'
+      },
       mistral: {
         provider: RubyLLM::Providers::Mistral,
         key: :mistral_api_base,
@@ -102,6 +108,8 @@ RSpec.describe RubyLLM::Provider do
       when :gpustack
         config.gpustack_api_base = 'https://gpustack.example.com/v1'
         config.gpustack_api_key = 'gpustack-key'
+      when :minimax
+        config.minimax_api_key = 'minimax-key'
       when :mistral
         config.mistral_api_key = 'mistral-key'
       when :ollama

--- a/spec/ruby_llm/providers/mini_max/capabilities_spec.rb
+++ b/spec/ruby_llm/providers/mini_max/capabilities_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::MiniMax::Capabilities do
+  describe '.context_window_for' do
+    it 'returns the documented context window per model' do
+      expect(described_class.context_window_for('MiniMax-M3')).to eq(1_000_000)
+      expect(described_class.context_window_for('MiniMax-M2.7')).to eq(204_800)
+    end
+  end
+
+  describe '.critical_capabilities_for' do
+    it 'marks MiniMax-M3 as a vision-capable reasoning model' do
+      expect(described_class.critical_capabilities_for('MiniMax-M3')).to include('vision', 'reasoning')
+    end
+
+    it 'does not mark the text-only MiniMax-M2.7 as vision-capable' do
+      expect(described_class.critical_capabilities_for('MiniMax-M2.7')).not_to include('vision')
+    end
+  end
+
+  describe '.pricing_for' do
+    it 'omits cache-write pricing when the model has none' do
+      standard = described_class.pricing_for('MiniMax-M3').dig(:text_tokens, :standard)
+
+      expect(standard).not_to have_key(:cache_write_input_per_million)
+      expect(standard[:cache_read_input_per_million]).to eq(0.12)
+    end
+
+    it 'includes cache-write pricing when the model supports it' do
+      standard = described_class.pricing_for('MiniMax-M2.7').dig(:text_tokens, :standard)
+
+      expect(standard[:cache_write_input_per_million]).to eq(0.375)
+    end
+  end
+end

--- a/spec/ruby_llm/providers/mini_max/chat_spec.rb
+++ b/spec/ruby_llm/providers/mini_max/chat_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::MiniMax::Chat do
+  let(:provider) { RubyLLM::Providers::MiniMax::ChatCompletions.allocate }
+
+  describe '#format_thinking' do
+    it 'exposes assistant reasoning as reasoning_content' do
+      thinking = RubyLLM::Thinking.new(text: 'Let me reason about this')
+      message = RubyLLM::Message.new(role: :assistant, content: 'Answer', thinking: thinking)
+
+      payload = provider.send(:format_thinking, message)
+
+      expect(payload[:reasoning_content]).to eq('Let me reason about this')
+      expect(payload[:reasoning]).to eq('Let me reason about this')
+    end
+
+    it 'returns an empty payload for non-assistant messages' do
+      message = RubyLLM::Message.new(role: :user, content: 'Hi')
+
+      expect(provider.send(:format_thinking, message)).to eq({})
+    end
+  end
+
+  describe '#format_content' do
+    it 'rejects audio attachments that MiniMax does not accept' do
+      attachment = RubyLLM::Attachment.new(StringIO.new('audio bytes'), filename: 'clip.mp3')
+
+      expect do
+        provider.send(:format_content, 'Transcribe this', [attachment])
+      end.to raise_error(RubyLLM::UnsupportedAttachmentError)
+    end
+  end
+end

--- a/spec/ruby_llm/providers/mini_max/models_spec.rb
+++ b/spec/ruby_llm/providers/mini_max/models_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::MiniMax::Models do
+  describe '#list_models' do
+    let(:provider_class) do
+      Class.new do
+        include RubyLLM::Providers::MiniMax::Models
+      end
+    end
+
+    it 'returns the curated MiniMax catalog with fallback metadata' do
+      models = provider_class.new.list_models
+
+      expect(models.map(&:id)).to eq(%w[MiniMax-M3 MiniMax-M2.7])
+      expect(models).to all(have_attributes(provider: 'minimax', family: 'minimax'))
+    end
+
+    it 'describes MiniMax-M3 with multimodal input and cache-read pricing' do
+      model = provider_class.new.list_models.find { |m| m.id == 'MiniMax-M3' }
+
+      expect(model.context_window).to eq(1_000_000)
+      expect(model.modalities.input).to eq(%w[text image video])
+      expect(model.modalities.output).to eq(%w[text])
+      expect(model.capabilities).to contain_exactly('function_calling', 'tool_choice', 'reasoning', 'vision')
+      expect(model.pricing.to_h).to eq(
+        text_tokens: {
+          standard: {
+            input_per_million: 0.6,
+            output_per_million: 2.4,
+            cache_read_input_per_million: 0.12
+          }
+        }
+      )
+    end
+
+    it 'describes MiniMax-M2.7 as a text reasoning model with cache pricing' do
+      model = provider_class.new.list_models.find { |m| m.id == 'MiniMax-M2.7' }
+
+      expect(model.context_window).to eq(204_800)
+      expect(model.modalities.input).to eq(%w[text])
+      expect(model.capabilities).to contain_exactly('function_calling', 'tool_choice', 'reasoning')
+      expect(model.capabilities).not_to include('vision')
+      expect(model.pricing.to_h).to eq(
+        text_tokens: {
+          standard: {
+            input_per_million: 0.3,
+            output_per_million: 1.2,
+            cache_read_input_per_million: 0.06,
+            cache_write_input_per_million: 0.375
+          }
+        }
+      )
+    end
+  end
+end

--- a/spec/ruby_llm/providers/mini_max_spec.rb
+++ b/spec/ruby_llm/providers/mini_max_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::MiniMax do
+  describe '#api_base' do
+    it 'defaults to the global OpenAI-compatible endpoint' do
+      RubyLLM.configure do |config|
+        config.minimax_api_key = 'test'
+        config.minimax_api_base = nil
+      end
+      provider = described_class.new(RubyLLM.config)
+
+      expect(provider.api_base).to eq('https://api.minimax.io/v1')
+    end
+
+    it 'honors a configured regional endpoint' do
+      RubyLLM.configure do |config|
+        config.minimax_api_key = 'test'
+        config.minimax_api_base = 'https://api.minimaxi.com/v1'
+      end
+      provider = described_class.new(RubyLLM.config)
+
+      expect(provider.api_base).to eq('https://api.minimaxi.com/v1')
+    end
+  end
+
+  describe '#headers' do
+    it 'sends bearer authentication' do
+      RubyLLM.configure { |config| config.minimax_api_key = 'secret-key' }
+      provider = described_class.new(RubyLLM.config)
+
+      expect(provider.headers).to eq({ 'Authorization' => 'Bearer secret-key' })
+    end
+  end
+
+  describe 'registration' do
+    it 'is registered under the :minimax slug' do
+      expect(RubyLLM::Provider.providers[:minimax]).to eq(described_class)
+      expect(described_class.slug).to eq('minimax')
+    end
+
+    it 'requires an API key' do
+      expect(described_class.configuration_requirements).to eq(%i[minimax_api_key])
+      expect(described_class.configuration_options).to eq(%i[minimax_api_key minimax_api_base])
+    end
+  end
+end

--- a/spec/support/rubyllm_configuration.rb
+++ b/spec/support/rubyllm_configuration.rb
@@ -27,6 +27,7 @@ RSpec.shared_context 'with configured RubyLLM' do
       config.gpustack_api_key = ENV.fetch('GPUSTACK_API_KEY', nil)
       # Disable retries in tests for deterministic, fast failures.
       config.max_retries = 0
+      config.minimax_api_key = ENV.fetch('MINIMAX_API_KEY', 'test')
       config.mistral_api_key = ENV.fetch('MISTRAL_API_KEY', 'test')
       config.model_registry_class = 'Model'
       config.ollama_api_base = ENV.fetch('OLLAMA_API_BASE', 'http://localhost:11434/v1')


### PR DESCRIPTION
Reason: RubyLLM has no first-class MiniMax provider, so its current models are only reachable through aggregators whose generated context and pricing metadata are stale.

## Summary

Adds MiniMax as a built-in provider. MiniMax exposes an OpenAI-compatible Chat Completions API, so the provider plugs into the shared `Protocols::ChatCompletions` protocol the same way the other dedicated OpenAI-compatible integrations do.

## Changes

- New `RubyLLM::Providers::MiniMax` (`lib/ruby_llm/providers/minimax.rb`) with `minimax_api_key` / `minimax_api_base` configuration. `api_base` defaults to the global endpoint `https://api.minimax.io/v1`; set `minimax_api_base` to `https://api.minimaxi.com/v1` to use the Mainland China endpoint.
- `minimax/chat.rb` — role formatting and reasoning (`reasoning_content`) handling; accepts image attachments and rejects audio.
- `minimax/models.rb` — curated model listing, since MiniMax has no public model-list endpoint.
- `minimax/capabilities.rb` — context windows, pricing (including cache-read/cache-write), and capability flags.
- Registered the provider and its Zeitwerk inflection in `lib/ruby_llm.rb`.
- Added the two current models to the bundled registry (`lib/ruby_llm/models.json`):
  - `MiniMax-M3` — 1,000,000-token context; text, image and video input; reasoning; input $0.6 / output $2.4 / cache-read $0.12 per million tokens.
  - `MiniMax-M2.7` — 204,800-token context; text input; reasoning; input $0.3 / output $1.2 / cache-read $0.06 / cache-write $0.375 per million tokens.
- Documented the configuration keys in the README provider list, `.env.example`, and the configuration provider/reference guides.

## Tests

- New unit specs: `spec/ruby_llm/providers/mini_max_spec.rb` and `spec/ruby_llm/providers/mini_max/{models,capabilities,chat}_spec.rb`.
- Extended `spec/ruby_llm/provider_spec.rb` fixtures so the all-provider contract tests cover MiniMax.

## Checks

- `bundle exec rubocop` on the changed files — no offenses.
- `bundle exec rspec` on the MiniMax specs plus the provider-contract and model-registry validation specs — 182 examples, 0 failures.
