### PR TITLE
Fix long-context tier pricing for cost_for (#854)

### DIFF
--- a/docs/_core_features/cost-and-usage-tracking.md
+++ b/docs/_core_features/cost-and-usage-tracking.md
@@ -123,6 +123,8 @@ puts cost.thinking
 puts cost.total
 ```
 
+When a model publishes a long-context tier, `cost_for` uses those rates once the prompt exceeds the registry threshold. Prompt size is `input + cache_read + cache_write`. Below that threshold—or when the model has no long-context tier—standard rates apply. Batch rates remain unused by `cost_for`; see [Batches]({% link _advanced/batches.md %}).
+
 Most applications use the shorter helpers on messages, chats, and agents: `response.cost.total`, `chat.cost.total`, `agent.cost.total`.
 
 To combine several cost objects yourself, use `RubyLLM::Cost.aggregate`:

--- a/lib/ruby_llm/cost.rb
+++ b/lib/ruby_llm/cost.rb
@@ -214,17 +214,37 @@ module RubyLLM
 
     def price_for(component)
       case component
-      when :input
-        image_cost? ? text_pricing.input : category_pricing.input
-      when :output
-        image_cost? ? (image_pricing.output || text_pricing.output) : category_pricing.output
-      when :cache_read
-        text_pricing.cache_read_input
-      when :cache_write
-        text_pricing.cache_write_input
-      when :thinking
-        text_pricing.reasoning_output
+      when :input then input_price
+      when :output then output_price
+      when :cache_read then text_price(:cache_read_input_per_million, text_pricing.cache_read_input)
+      when :cache_write then text_price(:cache_write_input_per_million, text_pricing.cache_write_input)
+      when :thinking then text_price(:reasoning_output_per_million, text_pricing.reasoning_output)
       end
+    end
+
+    def input_price
+      return text_price(:input_per_million, text_pricing.input) if @category == :text_tokens || image_cost?
+
+      category_pricing.input
+    end
+
+    def output_price
+      return image_pricing.output || text_price(:output_per_million, text_pricing.output) if image_cost?
+      return text_price(:output_per_million, text_pricing.output) if @category == :text_tokens
+
+      category_pricing.output
+    end
+
+    def text_price(attribute, standard_price)
+      applicable_text_tier&.public_send(attribute) || standard_price
+    end
+
+    def applicable_text_tier
+      text_pricing.tier_for(prompt_tokens)
+    end
+
+    def prompt_tokens
+      tokens_for(:input).to_i + tokens_for(:cache_read).to_i + tokens_for(:cache_write).to_i
     end
 
     def text_pricing
@@ -270,9 +290,10 @@ module RubyLLM
     end
 
     def image_input_parts
+      text_input_price = applicable_text_tier&.input_per_million || text_pricing.input
       [
-        [:text, input_detail('text_tokens'), text_pricing.input],
-        [:image, input_detail('image_tokens'), image_pricing.input || text_pricing.input]
+        [:text, input_detail('text_tokens'), text_input_price],
+        [:image, input_detail('image_tokens'), image_pricing.input || text_input_price]
       ]
     end
 
@@ -281,10 +302,11 @@ module RubyLLM
     end
 
     def thinking_priced_separately?
-      reasoning_price = text_pricing.reasoning_output
+      tier = applicable_text_tier
+      reasoning_price = tier&.reasoning_output_per_million || text_pricing.reasoning_output
       return false unless reasoning_price
 
-      output_price = text_pricing.output
+      output_price = tier&.output_per_million || text_pricing.output
       output_price.nil? || reasoning_price != output_price
     end
 

--- a/lib/ruby_llm/model.rb
+++ b/lib/ruby_llm/model.rb
@@ -79,8 +79,8 @@ module RubyLLM
       @knowledge_cutoff = Utils.to_date(data[:knowledge_cutoff])
       @modalities = Modalities.new(data[:modalities] || {})
       @capabilities = data[:capabilities] || []
-      @pricing = Pricing.new(data[:pricing] || {})
       @metadata = data[:metadata]&.dup || {}
+      @pricing = Pricing.new(pricing_data_with_long_context(data[:pricing] || {}))
       @reasoning_options = normalize_reasoning_options(reasoning_options_from(data))
       store_reasoning_options_metadata
     end
@@ -183,6 +183,19 @@ module RubyLLM
     end
 
     private
+
+    def pricing_data_with_long_context(pricing)
+      pricing = RubyLLM::Utils.deep_symbolize_keys(RubyLLM::Utils.deep_dup(pricing))
+      text = pricing[:text_tokens] || {}
+      return pricing if text[:long_context]
+
+      rates, threshold = PricingCategory.long_context_from_cost(metadata[:cost] || metadata['cost'])
+      return pricing unless rates
+
+      pricing[:text_tokens] = text.merge(long_context: rates)
+      pricing[:text_tokens][:long_context_threshold] = threshold if threshold
+      pricing
+    end
 
     def reasoning_options_from(data)
       data[:reasoning_options] || metadata[:reasoning_options] || metadata['reasoning_options']

--- a/lib/ruby_llm/model/pricing_category.rb
+++ b/lib/ruby_llm/model/pricing_category.rb
@@ -2,10 +2,10 @@
 
 module RubyLLM
   class Model
-    # A PricingCategory holds the standard and batch pricing tiers for one
-    # kind of model usage, such as text tokens or images. Model#pricing
-    # returns a Pricing collection whose categories are PricingCategory
-    # instances. Prices are in USD per million tokens.
+    # A PricingCategory holds the standard, batch, and long-context pricing
+    # tiers for one kind of model usage, such as text tokens or images.
+    # Model#pricing returns a Pricing collection whose categories are
+    # PricingCategory instances. Prices are in USD per million tokens.
     #
     #   model    = RubyLLM.models.find "claude-sonnet-4-6"
     #   category = model.pricing.text_tokens
@@ -14,7 +14,7 @@ module RubyLLM
     #
     class PricingCategory
       # The billing tiers a category may define.
-      TIERS = %i[standard batch].freeze
+      TIERS = %i[standard batch long_context].freeze
 
       # The standard-tier PricingTier, or +nil+ when the model has no
       # standard pricing for this category.
@@ -24,9 +24,21 @@ module RubyLLM
       # pricing for this category.
       attr_reader :batch
 
+      # The long-context PricingTier, or +nil+ when the model has no
+      # separate rates for prompts above #long_context_threshold.
+      attr_reader :long_context
+
+      # Prompt-size threshold (in tokens) above which long-context rates
+      # apply, or +nil+ when the model has no long-context tier.
+      attr_reader :long_context_threshold
+
       def initialize(data = {}) # :nodoc:
-        @standard = PricingTier.new(data[:standard] || {}) unless empty_tier?(data[:standard])
-        @batch = PricingTier.new(data[:batch] || {}) unless empty_tier?(data[:batch])
+        data = data.transform_keys(&:to_sym) if data.respond_to?(:transform_keys)
+
+        @standard = tier_from(data[:standard])
+        @batch = tier_from(data[:batch])
+        @long_context = tier_from(data[:long_context])
+        @long_context_threshold = Integer(data[:long_context_threshold], exception: false)
       end
 
       # Returns the standard-tier input price in USD per million tokens,
@@ -59,16 +71,70 @@ module RubyLLM
         standard&.reasoning_output_per_million
       end
 
-      # Returns a Hash with +:standard+ and +:batch+ tier hashes, omitting
-      # absent tiers.
+      # Returns the PricingTier that applies for a prompt of the given size.
+      # Uses #long_context when that tier exists and +prompt_tokens+ is
+      # greater than #long_context_threshold; otherwise returns #standard.
+      def tier_for(prompt_tokens)
+        if long_context && long_context_threshold &&
+           prompt_tokens.to_i > long_context_threshold
+          long_context
+        else
+          standard
+        end
+      end
+
+      # Returns a Hash with present tier hashes and optional
+      # +:long_context_threshold+, omitting absent entries.
       def to_h
         result = {}
         result[:standard] = standard.to_h if standard
         result[:batch] = batch.to_h if batch
+        result[:long_context] = long_context.to_h if long_context
+        result[:long_context_threshold] = long_context_threshold if long_context_threshold
         result
       end
 
+      # Builds long-context rates and threshold from a models.dev-style cost
+      # Hash (as stored on Model#metadata under +:cost+). Returns
+      # <tt>[rates_hash, threshold]</tt>, or <tt>[nil, nil]</tt> when the
+      # cost has no context tier.
+      def self.long_context_from_cost(cost) # :nodoc:
+        cost = RubyLLM::Utils.deep_symbolize_keys(cost || {})
+        return [nil, nil] if cost.empty?
+
+        entry, threshold = context_cost(cost)
+        return [nil, nil] unless entry
+
+        rates = {
+          input_per_million: entry[:input],
+          output_per_million: entry[:output],
+          cache_read_input_per_million: entry[:cache_read],
+          cache_write_input_per_million: entry[:cache_write],
+          reasoning_output_per_million: entry[:reasoning]
+        }.compact
+        rates.empty? ? [nil, nil] : [rates, threshold]
+      end
+
+      def self.context_cost(cost) # :nodoc:
+        context_tier = Array(cost[:tiers]).find do |entry|
+          entry.is_a?(Hash) && entry.dig(:tier, :type).to_s == 'context'
+        end
+        if context_tier
+          [context_tier, Integer(context_tier.dig(:tier, :size), exception: false)]
+        elsif cost[:context_over_200k].is_a?(Hash)
+          [cost[:context_over_200k], 200_000]
+        end
+      end
+
+      private_class_method :context_cost
+
       private
+
+      def tier_from(tier_data)
+        return nil if empty_tier?(tier_data)
+
+        PricingTier.new(tier_data || {})
+      end
 
       def empty_tier?(tier_data)
         return true unless tier_data

--- a/lib/ruby_llm/model/pricing_tier.rb
+++ b/lib/ruby_llm/model/pricing_tier.rb
@@ -3,11 +3,11 @@
 module RubyLLM
   class Model
     # A PricingTier holds the prices a model charges within one billing tier,
-    # standard or batch. Each price is in USD per one million tokens. Prices
-    # missing from the registry read as +nil+. A zero price means the usage
-    # is free.
+    # such as standard, batch, or long_context. Each price is in USD per one
+    # million tokens. Prices missing from the registry read as +nil+. A zero
+    # price means the usage is free.
     #
-    # Instances come from PricingCategory#standard and PricingCategory#batch:
+    # Instances come from PricingCategory#standard, #batch, and #long_context:
     #
     #   model = RubyLLM.models.find "claude-sonnet-4-6"
     #   tier  = model.pricing.text_tokens.standard

--- a/lib/ruby_llm/model_schema.rb
+++ b/lib/ruby_llm/model_schema.rb
@@ -71,6 +71,10 @@ module RubyLLM
               end
             end
           end
+          integer :long_context_threshold,
+                  minimum: 0,
+                  required: false,
+                  description: 'Prompt size above which long_context rates apply'
         end
       end
     end

--- a/lib/ruby_llm/models.rb
+++ b/lib/ruby_llm/models.rb
@@ -405,9 +405,24 @@ module RubyLLM
         }.compact
 
         pricing = {}
-        pricing[:text_tokens] = { standard: text_standard } if text_standard.any?
+        text_tokens = models_dev_text_tokens_pricing(text_standard, cost)
+        pricing[:text_tokens] = text_tokens if text_tokens
         pricing[:audio_tokens] = { standard: audio_standard } if audio_standard.any?
         pricing
+      end
+
+      def models_dev_text_tokens_pricing(text_standard, cost) # :nodoc:
+        long_context, threshold = Model::PricingCategory.long_context_from_cost(cost)
+
+        return nil if text_standard.empty? && long_context.nil?
+
+        text_tokens = {}
+        text_tokens[:standard] = text_standard if text_standard.any?
+        if long_context
+          text_tokens[:long_context] = long_context
+          text_tokens[:long_context_threshold] = threshold if threshold
+        end
+        text_tokens
       end
 
       def models_dev_metadata(model_data, provider_key) # :nodoc:

--- a/spec/ruby_llm/cost_spec.rb
+++ b/spec/ruby_llm/cost_spec.rb
@@ -132,6 +132,72 @@ RSpec.describe RubyLLM::Cost do
       expect(cost.total).to eq(0.012)
     end
 
+    it 'uses long-context rates when the prompt exceeds the model threshold' do
+      long_context_model = RubyLLM::Model.new(
+        id: 'gpt-5.6-sol',
+        name: 'GPT-5.6 Sol',
+        provider: 'openai',
+        pricing: {
+          text_tokens: {
+            standard: {
+              input_per_million: 5.0,
+              output_per_million: 30.0,
+              cache_read_input_per_million: 0.5
+            },
+            long_context: {
+              input_per_million: 10.0,
+              output_per_million: 45.0,
+              cache_read_input_per_million: 1.0
+            },
+            long_context_threshold: 272_000
+          }
+        }
+      )
+
+      short = described_class.new(
+        tokens: RubyLLM::Tokens.new(input: 100_000, output: 10_000),
+        model: long_context_model
+      )
+      long = described_class.new(
+        tokens: RubyLLM::Tokens.new(input: 500_000, output: 10_000),
+        model: long_context_model
+      )
+
+      expect(short.total).to be_within(0.0000000001).of(0.8)
+      expect(long.total).to be_within(0.0000000001).of(5.45)
+    end
+
+    it 'counts cache tokens toward the long-context prompt threshold' do
+      long_context_model = RubyLLM::Model.new(
+        id: 'gpt-5.6-sol',
+        name: 'GPT-5.6 Sol',
+        provider: 'openai',
+        pricing: {
+          text_tokens: {
+            standard: {
+              input_per_million: 5.0,
+              output_per_million: 30.0,
+              cache_read_input_per_million: 0.5
+            },
+            long_context: {
+              input_per_million: 10.0,
+              output_per_million: 45.0,
+              cache_read_input_per_million: 1.0
+            },
+            long_context_threshold: 272_000
+          }
+        }
+      )
+      cost = described_class.new(
+        tokens: RubyLLM::Tokens.new(input: 100_000, output: 1_000, cache_read: 200_000),
+        model: long_context_model
+      )
+
+      expect(cost.input).to be_within(0.0000000001).of(1.0)
+      expect(cost.cache_read).to be_within(0.0000000001).of(0.2)
+      expect(cost.output).to be_within(0.0000000001).of(0.045)
+    end
+
     it 'returns nil when pricing is missing for tokens that were used' do
       incomplete_model = RubyLLM::Model.new(
         id: 'incomplete-model',

--- a/spec/ruby_llm/model_spec.rb
+++ b/spec/ruby_llm/model_spec.rb
@@ -268,6 +268,44 @@ RSpec.describe RubyLLM::Model do
 
       expect(model.cost_for(tokens).total).to eq(0.0225)
     end
+
+    it 'hydrates long_context pricing from metadata.cost when pricing lacks it' do
+      model = described_class.new(
+        data.merge(
+          pricing: {
+            text_tokens: {
+              standard: {
+                input_per_million: 5.0,
+                output_per_million: 30.0
+              }
+            }
+          },
+          metadata: {
+            cost: {
+              input: 5.0,
+              output: 30.0,
+              tiers: [
+                {
+                  input: 10.0,
+                  output: 45.0,
+                  tier: { type: 'context', size: 272_000 }
+                }
+              ]
+            }
+          }
+        )
+      )
+
+      expect(model.pricing.to_h[:text_tokens]).to include(
+        long_context: {
+          input_per_million: 10.0,
+          output_per_million: 45.0
+        },
+        long_context_threshold: 272_000
+      )
+      expect(model.cost_for(RubyLLM::Tokens.new(input: 500_000, output: 10_000)).total)
+        .to be_within(0.0000000001).of(5.45)
+    end
   end
 
   describe '#to_h' do

--- a/spec/ruby_llm/models_spec.rb
+++ b/spec/ruby_llm/models_spec.rb
@@ -250,6 +250,72 @@ RSpec.describe RubyLLM::Models do
       )
     end
 
+    it 'maps models.dev context tiers into text_tokens.long_context' do
+      model_data_with_tiers = model_data.merge(
+        cost: {
+          input: 5.0,
+          output: 30.0,
+          cache_read: 0.5,
+          cache_write: 6.25,
+          tiers: [
+            {
+              input: 10.0,
+              output: 45.0,
+              cache_read: 1.0,
+              cache_write: 12.5,
+              tier: { type: 'context', size: 272_000 }
+            }
+          ]
+        }
+      )
+
+      data = described_class.models_dev_model_attributes(model_data_with_tiers, 'openai', 'openai')
+
+      expect(data[:pricing]).to eq(
+        text_tokens: {
+          standard: {
+            input_per_million: 5.0,
+            output_per_million: 30.0,
+            cache_read_input_per_million: 0.5,
+            cache_write_input_per_million: 6.25
+          },
+          long_context: {
+            input_per_million: 10.0,
+            output_per_million: 45.0,
+            cache_read_input_per_million: 1.0,
+            cache_write_input_per_million: 12.5
+          },
+          long_context_threshold: 272_000
+        }
+      )
+    end
+
+    it 'falls back to context_over_200k when models.dev omits structured tiers' do
+      model_data_with_over = model_data.merge(
+        cost: {
+          input: 1.25,
+          output: 10.0,
+          cache_read: 0.125,
+          context_over_200k: {
+            input: 2.5,
+            output: 15.0,
+            cache_read: 0.25
+          }
+        }
+      )
+
+      data = described_class.models_dev_model_attributes(model_data_with_over, 'google', 'google')
+
+      expect(data[:pricing][:text_tokens]).to include(
+        long_context: {
+          input_per_million: 2.5,
+          output_per_million: 15.0,
+          cache_read_input_per_million: 0.25
+        },
+        long_context_threshold: 200_000
+      )
+    end
+
     it 'keeps models.dev authoritative for overlapping capabilities when merging provider metadata' do
       models_dev_model = RubyLLM::Model.new(
         id: 'test-model',


### PR DESCRIPTION
## What this does

Fixes #854. Models with long-context / over-threshold rates (OpenAI gpt-5.6-sol and gpt-5.x peers, Gemini Pro over 200k, etc.) keep those tiers in `metadata.cost`, but `pricing` and `cost_for` ignored them and always billed at the short-context (standard) rate.

`models_dev_pricing` only copied top-level `cost.input` / `output` / cache fields into `pricing.text_tokens.standard`, and `PricingCategory` / `Cost` only knew `standard` and `batch`. So after refresh you could inspect the long-context tiers in metadata, while `pricing.to_h` and `cost_for(500k in, 10k out)` still used the short rates.

This PR:

- Maps models.dev context tiers (`tiers` with `type: "context"`, falling back to `context_over_200k`) into `pricing.text_tokens.long_context`, including `long_context_threshold` (e.g. 272000 for OpenAI, 200000 for Gemini).
- Extends `PricingCategory` with a `long_context` tier and `tier_for(prompt_tokens)`.
- Makes `Cost` / `cost_for` use long-context rates when prompt size (`input + cache_read + cache_write`) exceeds the threshold; below that, standard rates still apply.
- Hydrates `long_context` from `metadata.cost` when loading a Model whose `pricing` lacks it, so bundled registry entries work without waiting for `models:update`.
- Leaves `batch` unused by `cost_for` (unchanged; still documented separately).

Example (gpt-5.5 / gpt-5.6-sol rates): `cost_for(500_000 in, 10_000 out)` → `5.45` (long); `100_000 in` → `0.8` (short).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

N/A — bug fix.

- [ ] I opened an issue **before** writing code and received maintainer approval
- [x] Linked issue: #854

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

---

**Notes**

- Additive only: `pricing.text_tokens` may now include `long_context` / `long_context_threshold`. Existing `#input` / `#output` helpers still return standard rates.
- No `models.json` edit in this PR; hydration covers current bundled entries. A later registry refresh will persist long-context into `pricing` on write.
- VCR N/A — registry/pricing only, no live provider HTTP.
