### PR TITLE
Preserve omitted Bedrock thinking blocks

### DIFF
--- a/lib/ruby_llm/protocols/converse/chat.rb
+++ b/lib/ruby_llm/protocols/converse/chat.rb
@@ -458,16 +458,19 @@ module RubyLLM
         end
 
         def parse_thinking(content_blocks)
-          text = +''
+          text = nil
           signature = nil
 
           content_blocks.each do |block|
             chunk_text, chunk_signature = parse_reasoning_content_block(block)
-            text << chunk_text if chunk_text
+            if chunk_text
+              text ||= +''
+              text << chunk_text
+            end
             signature ||= chunk_signature
           end
 
-          [text.empty? ? nil : text, signature]
+          [text, signature]
         end
 
         def parse_reasoning_content_block(block)

--- a/lib/ruby_llm/protocols/converse/streaming.rb
+++ b/lib/ruby_llm/protocols/converse/streaming.rb
@@ -221,7 +221,18 @@ module RubyLLM
           reasoning_content = normalized_delta(event)['reasoningContent'] || {}
 
           reasoning_text = reasoning_content['reasoningText'] || {}
-          reasoning_text['text'] || reasoning_content['text']
+          return reasoning_text['text'] if reasoning_text.key?('text')
+          return reasoning_content['text'] if reasoning_content.key?('text')
+          return '' if [reasoning_text, reasoning_content].any? { |block| block.key?('signature') }
+
+          extract_thinking_from_start(event)
+        end
+
+        def extract_thinking_from_start(event)
+          start = event.dig('contentBlockStart', 'start', 'reasoningContent') || {}
+          return unless start.key?('reasoningText')
+
+          start.dig('reasoningText', 'text').to_s
         end
 
         def extract_thinking_signature(event)
@@ -237,7 +248,7 @@ module RubyLLM
         def extract_signature_from_delta(event)
           reasoning_content = normalized_delta(event)['reasoningContent'] || {}
           reasoning_text = reasoning_content['reasoningText'] || {}
-          reasoning_text['signature'] || reasoning_content['signature']
+          reasoning_text['signature'] || reasoning_content['signature'] || reasoning_content['redactedContent']
         end
 
         def extract_signature_from_start(event)

--- a/lib/ruby_llm/stream_accumulator.rb
+++ b/lib/ruby_llm/stream_accumulator.rb
@@ -10,7 +10,7 @@ module RubyLLM
     def initialize
       @content = +''
       @citations = []
-      @thinking_text = +''
+      @thinking_text = nil
       @thinking_signature = nil
       @tool_calls = {}
       @input_tokens = nil
@@ -48,7 +48,7 @@ module RubyLLM
         content: content.empty? ? nil : content,
         citations: resolved_citations,
         thinking: Thinking.build(
-          text: @thinking_text.empty? ? nil : @thinking_text,
+          text: @thinking_text,
           signature: @thinking_signature
         ),
         tokens: Tokens.new(
@@ -187,14 +187,20 @@ module RubyLLM
     def append_text_with_thinking(text)
       content_chunk, thinking_chunk = extract_think_tags(text)
       @content << content_chunk
-      @thinking_text << thinking_chunk if thinking_chunk
+      return unless thinking_chunk
+
+      @thinking_text ||= +''
+      @thinking_text << thinking_chunk
     end
 
     def append_thinking_from_chunk(chunk)
       thinking = chunk.thinking
       return unless thinking
 
-      @thinking_text << thinking.text.to_s if thinking.text
+      unless thinking.text.nil?
+        @thinking_text ||= +''
+        @thinking_text << thinking.text.to_s
+      end
       @thinking_signature ||= thinking.signature # rubocop:disable Naming/MemoizedInstanceVariableName
     end
 

--- a/lib/ruby_llm/thinking.rb
+++ b/lib/ruby_llm/thinking.rb
@@ -24,8 +24,8 @@ module RubyLLM
     end
 
     def self.build(text: nil, signature: nil) # :nodoc:
-      text = nil if text.is_a?(String) && text.empty?
       signature = nil if signature.is_a?(String) && signature.empty?
+      text = nil if text.is_a?(String) && text.empty? && signature.nil?
 
       return nil if text.nil? && signature.nil?
 

--- a/spec/ruby_llm/active_record/chat_methods_spec.rb
+++ b/spec/ruby_llm/active_record/chat_methods_spec.rb
@@ -428,7 +428,7 @@ RSpec.describe RubyLLM::ActiveRecord::ChatMethods do
         :persist_message_completion,
         RubyLLM::Message.new(
           role: :tool, content: 'done', tool_call_id: call.id,
-          thinking: RubyLLM::Thinking.new(text: 'why', signature: 'sig'),
+          thinking: RubyLLM::Thinking.new(text: '', signature: 'sig'),
           citations: [RubyLLM::Citation.new(url: 'https://example.test')],
           finish_reason: 'stop'
         )
@@ -436,7 +436,7 @@ RSpec.describe RubyLLM::ActiveRecord::ChatMethods do
 
       record = chat.instance_variable_get(:@message)
       expect(record.content).to eq('done')
-      expect(record.thinking_text).to eq('why')
+      expect(record.reload.to_llm.thinking.text).to eq('')
       expect(record.thinking_signature).to eq('sig')
       expect(record.finish_reason).to eq('stop')
       expect(record.citations.first.url).to eq('https://example.test')

--- a/spec/ruby_llm/protocols/converse/chat_spec.rb
+++ b/spec/ruby_llm/protocols/converse/chat_spec.rb
@@ -536,6 +536,17 @@ RSpec.describe RubyLLM::Protocols::Converse::Chat do
       expect(described_class.parse_thinking(blocks)).to eq([nil, 'sig'])
     end
 
+    it 'preserves omitted reasoning text as an empty string' do
+      blocks = [{ 'reasoningContent' => { 'reasoningText' => { 'text' => '', 'signature' => 'sig' } } }]
+
+      text, signature = described_class.parse_thinking(blocks)
+      thinking = RubyLLM::Thinking.build(text:, signature:)
+
+      expect(described_class.format_thinking_block(thinking)).to eq(
+        reasoningContent: { reasoningText: { text: '', signature: 'sig' } }
+      )
+    end
+
     it 'joins reasoning text across blocks and keeps the first signature' do
       blocks = [
         { 'reasoningContent' => { 'reasoningText' => { 'text' => 'one ' } } },

--- a/spec/ruby_llm/protocols/converse/streaming_spec.rb
+++ b/spec/ruby_llm/protocols/converse/streaming_spec.rb
@@ -41,7 +41,25 @@ RSpec.describe RubyLLM::Protocols::Converse::Streaming do
 
     chunk = streaming.send(:build_chunk, event)
 
+    expect(chunk.thinking.text).to eq('')
     expect(chunk.thinking.signature).to eq('thinking-signature')
+  end
+
+  it 'keeps redacted thinking distinct from omitted thinking' do
+    event = {
+      'contentBlockDelta' => {
+        'delta' => {
+          'reasoningContent' => {
+            'redactedContent' => 'redacted-thinking'
+          }
+        }
+      }
+    }
+
+    chunk = streaming.send(:build_chunk, event)
+
+    expect(chunk.thinking.text).to be_nil
+    expect(chunk.thinking.signature).to eq('redacted-thinking')
   end
 
   it 'preserves raw stopReason from messageStop events' do
@@ -99,6 +117,23 @@ RSpec.describe RubyLLM::Protocols::Converse::Streaming do
 
     expect(message.thinking.text).to eq('thinking text')
     expect(message.thinking.signature).to eq('thinking-signature')
+  end
+
+  it 'preserves omitted thinking through stream accumulation' do
+    accumulator = RubyLLM::StreamAccumulator.new
+    event = {
+      'contentBlockDelta' => {
+        'delta' => {
+          'reasoningContent' => {
+            'signature' => 'thinking-signature'
+          }
+        }
+      }
+    }
+
+    accumulator.add(streaming.send(:build_chunk, event))
+
+    expect(accumulator.to_message(nil).thinking.text).to eq('')
   end
 
   describe '#stream_url' do
@@ -221,7 +256,10 @@ RSpec.describe RubyLLM::Protocols::Converse::Streaming do
         }
       }
 
-      expect(streaming.send(:build_chunk, event).thinking.signature).to eq('sig')
+      thinking = streaming.send(:build_chunk, event).thinking
+
+      expect(thinking.text).to eq('')
+      expect(thinking.signature).to eq('sig')
     end
 
     it 'falls back to redacted content' do


### PR DESCRIPTION
## What this does

Sonnet 5 returns regular thinking blocks with an empty text field and an opaque signature when thinking display is omitted. RubyLLM collapsed that empty text to `nil`, then replayed the signature as `redactedContent`, which Bedrock correctly rejected as invalid redacted thinking data.

This keeps empty signed reasoning text distinct from genuinely redacted content through response parsing, streaming accumulation, and Active Record persistence.

Fixes #852

## Type of change

- [x] Bug fix

## Quality check

- [x] Full pre-commit hooks pass
- [x] Focused Converse, streaming, accumulator, and Active Record specs pass
- [x] No public API changes
- [x] AI-assisted and reviewed