### PR TITLE
feat(speech): add direct MiniMax generation

### DIFF
--- a/lib/ruby_llm.rb
+++ b/lib/ruby_llm.rb
@@ -23,6 +23,7 @@ loader.inflector.inflect(
   'deepseek' => 'DeepSeek',
   'gpustack' => 'GPUStack',
   'llm' => 'LLM',
+  'minimax' => 'MiniMax',
   'mistral' => 'Mistral',
   'ocr' => 'OCR',
   'openai' => 'OpenAI',
@@ -375,6 +376,7 @@ RubyLLM::Provider.register :bedrock, RubyLLM::Providers::Bedrock
 RubyLLM::Provider.register :deepseek, RubyLLM::Providers::DeepSeek
 RubyLLM::Provider.register :gemini, RubyLLM::Providers::Gemini
 RubyLLM::Provider.register :gpustack, RubyLLM::Providers::GPUStack
+RubyLLM::Provider.register :minimax, RubyLLM::Providers::MiniMax
 RubyLLM::Provider.register :mistral, RubyLLM::Providers::Mistral
 RubyLLM::Provider.register :ollama, RubyLLM::Providers::Ollama
 RubyLLM::Provider.register :openai, RubyLLM::Providers::OpenAI

--- a/lib/ruby_llm/providers/minimax.rb
+++ b/lib/ruby_llm/providers/minimax.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    # Direct MiniMax speech API integration.
+    class MiniMax < Provider
+      MODELS = %w[
+        speech-2.8-hd speech-2.8-turbo speech-2.6-hd speech-2.6-turbo
+        speech-02-hd speech-02-turbo speech-01-hd speech-01-turbo
+      ].freeze
+
+      class SpeechProtocol < Protocol
+        include MiniMax::Speech
+      end
+
+      protocol :speech, SpeechProtocol
+
+      def api_base
+        @config.minimax_api_base || 'https://api.minimax.io/v1'
+      end
+
+      def headers
+        { 'Authorization' => "Bearer #{@config.minimax_api_key}" }
+      end
+
+      def synthesize_async(input, model: MODELS.first, voice: nil, provider_options: {})
+        default_protocol.new(self, model).send(:synthesize_async, input, model:, voice:, provider_options:)
+      end
+
+      def speech_task(task_id)
+        default_protocol.new(self).send(:speech_task, task_id)
+      end
+
+      def speech_websocket_url
+        api_base.sub(/\Ahttp/, 'ws').sub(%r{/v1/?\z}, '/ws/v1/t2a_v2')
+      end
+
+      class << self
+        def assume_models_exist?
+          true
+        end
+
+        def configuration_options
+          %i[minimax_api_key minimax_api_base]
+        end
+
+        def configuration_requirements
+          %i[minimax_api_key]
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/providers/minimax/speech.rb
+++ b/lib/ruby_llm/providers/minimax/speech.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Providers
+    class MiniMax
+      # MiniMax synchronous and asynchronous text-to-audio operations.
+      module Speech
+        module_function
+
+        def speech_url(model:) # rubocop:disable Lint/UnusedMethodArgument
+          't2a_v2'
+        end
+
+        def render_speech_payload(input, model:, voice:, format:, provider_options: {})
+          payload = {
+            model: model,
+            text: input,
+            stream: false,
+            output_format: 'hex',
+            voice_setting: voice && { voice_id: voice },
+            audio_setting: format && { format: format.to_s }
+          }.compact
+          Utils.deep_merge(payload, provider_options)
+        end
+
+        def parse_speech_response(response, model:, voice:, format:)
+          body = response.body
+          validate_response!(body)
+          audio = value(value(body, :data), :audio)
+          raise Error, 'MiniMax did not return speech audio' unless audio
+
+          RubyLLM::Speech.new(
+            data: [audio].pack('H*'),
+            model: model,
+            voice: voice,
+            format: (format || 'mp3').to_s
+          )
+        end
+
+        def synthesize_async(input, model:, voice: nil, provider_options: {})
+          payload = render_speech_payload(input, model:, voice:, format: nil, provider_options:)
+          payload.delete(:stream)
+          payload.delete(:output_format)
+          validate_response!(@connection.post('t2a_async_v2', payload).body)
+        end
+
+        def speech_task(task_id)
+          validate_response!(@connection.post('query/t2a_async_query_v2', task_id: task_id).body)
+        end
+
+        def validate_response!(body)
+          status = value(value(body, :base_resp), :status_code)
+          raise Error, "MiniMax speech request failed with status #{status}" if status && !status.zero?
+
+          body
+        end
+
+        def value(hash, key)
+          hash&.[](key) || hash&.[](key.to_s)
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_llm/provider_spec.rb
+++ b/spec/ruby_llm/provider_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe RubyLLM::Provider do
         key: :gpustack_api_base,
         custom: 'https://gpustack.example.com/v1'
       },
+      minimax: {
+        provider: RubyLLM::Providers::MiniMax,
+        key: :minimax_api_base,
+        custom: 'https://api.minimaxi.com/v1',
+        default: 'https://api.minimax.io/v1'
+      },
       mistral: {
         provider: RubyLLM::Providers::Mistral,
         key: :mistral_api_base,
@@ -102,6 +108,8 @@ RSpec.describe RubyLLM::Provider do
       when :gpustack
         config.gpustack_api_base = 'https://gpustack.example.com/v1'
         config.gpustack_api_key = 'gpustack-key'
+      when :minimax
+        config.minimax_api_key = 'minimax-key'
       when :mistral
         config.mistral_api_key = 'mistral-key'
       when :ollama

--- a/spec/ruby_llm/providers/minimax/speech_spec.rb
+++ b/spec/ruby_llm/providers/minimax/speech_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::MiniMax::Speech do # rubocop:disable RSpec/SpecFilePathFormat
+  describe '.render_speech_payload' do
+    it 'maps the complete synchronous request vocabulary' do
+      payload = described_class.render_speech_payload(
+        'Hello', model: 'speech-2.8-hd', voice: 'English_Graceful_Lady', format: 'wav',
+                 provider_options: { language_boost: 'English', subtitle_enable: true,
+                                     pronunciation_dict: { tone: ['Ruby/(ru1)(bi3)'] },
+                                     voice_modify: { pitch: 1 } }
+      )
+
+      expect(payload).to include(model: 'speech-2.8-hd', text: 'Hello', stream: false, output_format: 'hex',
+                                 voice_setting: { voice_id: 'English_Graceful_Lady' },
+                                 audio_setting: { format: 'wav' }, language_boost: 'English',
+                                 subtitle_enable: true, pronunciation_dict: { tone: ['Ruby/(ru1)(bi3)'] },
+                                 voice_modify: { pitch: 1 })
+    end
+  end
+
+  describe '.parse_speech_response' do
+    it 'decodes hexadecimal audio and validates the API status' do
+      response = instance_double(Faraday::Response,
+                                 body: { 'data' => { 'audio' => '617564696f', 'status' => 2 },
+                                         'base_resp' => { 'status_code' => 0 } })
+
+      speech = described_class.parse_speech_response(response, model: 'speech-2.8-hd', voice: 'voice', format: 'mp3')
+
+      expect(speech.data).to eq('audio')
+      expect(speech.model).to eq('speech-2.8-hd')
+    end
+
+    it 'raises on a provider error status' do
+      response = instance_double(Faraday::Response, body: { base_resp: { status_code: 1002 } })
+
+      expect do
+        described_class.parse_speech_response(response, model: 'speech-2.8-hd', voice: nil, format: nil)
+      end.to raise_error(RubyLLM::Error, /1002/)
+    end
+  end
+end

--- a/spec/ruby_llm/providers/minimax_spec.rb
+++ b/spec/ruby_llm/providers/minimax_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Providers::MiniMax do # rubocop:disable RSpec/SpecFilePathFormat
+  before { RubyLLM.config.minimax_api_key = 'test' }
+
+  it 'registers the complete speech model catalog' do
+    expect(described_class::MODELS).to eq(
+      %w[
+        speech-2.8-hd speech-2.8-turbo speech-2.6-hd speech-2.6-turbo
+        speech-02-hd speech-02-turbo speech-01-hd speech-01-turbo
+      ]
+    )
+  end
+
+  it 'supports the global and China endpoints' do
+    expect(described_class.new(RubyLLM.config).api_base).to eq('https://api.minimax.io/v1')
+
+    RubyLLM.config.minimax_api_base = 'https://api.minimaxi.com/v1'
+    provider = described_class.new(RubyLLM.config)
+    expect(provider.api_base).to eq('https://api.minimaxi.com/v1')
+    expect(provider.speech_websocket_url).to eq('wss://api.minimaxi.com/ws/v1/t2a_v2')
+  end
+
+  it 'registers as a speech-only provider with bearer authentication' do
+    provider = described_class.new(RubyLLM.config)
+
+    expect(RubyLLM::Provider.providers[:minimax]).to eq(described_class)
+    expect(provider.headers).to eq('Authorization' => 'Bearer test')
+    expect(described_class.configuration_options).to eq(%i[minimax_api_key minimax_api_base])
+  end
+end


### PR DESCRIPTION
Reason: Add direct speech generation for both configured regional endpoints.

- Add a speech-only provider with the complete supported model catalog and bearer-authenticated regional configuration.
- Map synchronous requests, decode hexadecimal audio responses, and expose asynchronous create/query and WebSocket endpoints.
- Add focused coverage for model registration, regional routing, request mapping, and response validation.

Checks:
- `bundle exec rspec spec/ruby_llm/providers/minimax_spec.rb spec/ruby_llm/providers/minimax/speech_spec.rb`
- `bundle exec rubocop lib/ruby_llm.rb lib/ruby_llm/providers/minimax.rb lib/ruby_llm/providers/minimax/speech.rb spec/ruby_llm/providers/minimax_spec.rb spec/ruby_llm/providers/minimax/speech_spec.rb`
- `git diff --check`
