### PR TITLE
Use model association for chat model display

### DIFF
--- a/lib/generators/ruby_llm/chat_ui/templates/tailwind/views/chats/_chat.html.erb.tt
+++ b/lib/generators/ruby_llm/chat_ui/templates/tailwind/views/chats/_chat.html.erb.tt
@@ -1,7 +1,7 @@
 <div id="<%%= dom_id <%= chat_model_name.demodulize.underscore %> %>" class="w-full sm:w-auto my-5 space-y-3">
   <div>
     <strong class="block font-medium mb-1">Model:</strong>
-    <%%= <%= chat_model_name.demodulize.underscore %>.<%= model_table_name.singularize %>&.label || default_model_display_name %>
+    <%%= <%= chat_model_name.demodulize.underscore %>.model&.label || default_model_display_name %>
   </div>
 
   <div>

--- a/lib/generators/ruby_llm/chat_ui/templates/tailwind/views/chats/show.html.erb.tt
+++ b/lib/generators/ruby_llm/chat_ui/templates/tailwind/views/chats/show.html.erb.tt
@@ -12,7 +12,7 @@
 
   <div class="my-5">
     <strong class="block font-medium mb-1">Model:</strong>
-    <%%= @<%= chat_variable_name %>.<%= model_table_name.singularize %>&.label || default_model_display_name %>
+    <%%= @<%= chat_variable_name %>.model&.label || default_model_display_name %>
   </div>
 
   <div id="<%= message_table_name %>" class="min-w-full divide-y divide-gray-200 space-y-5 my-5">

--- a/lib/generators/ruby_llm/chat_ui/templates/views/chats/_chat.html.erb.tt
+++ b/lib/generators/ruby_llm/chat_ui/templates/views/chats/_chat.html.erb.tt
@@ -1,7 +1,7 @@
 <div id="<%%= dom_id <%= chat_model_name.demodulize.underscore %> %>">
   <div>
     <strong>Model:</strong>
-    <%%= <%= chat_model_name.demodulize.underscore %>.<%= model_table_name.singularize %>&.label || default_model_display_name %>
+    <%%= <%= chat_model_name.demodulize.underscore %>.model&.label || default_model_display_name %>
   </div>
 
   <div>

--- a/lib/generators/ruby_llm/chat_ui/templates/views/chats/show.html.erb.tt
+++ b/lib/generators/ruby_llm/chat_ui/templates/views/chats/show.html.erb.tt
@@ -8,7 +8,7 @@
 
 <h1><%= chat_model_name %> <%%= @<%= chat_variable_name %>.id %></h1>
 
-<p>Using <strong><%%= @<%= chat_variable_name %>.<%= model_table_name.singularize %>&.label || default_model_display_name %></strong></p>
+<p>Using <strong><%%= @<%= chat_variable_name %>.model&.label || default_model_display_name %></strong></p>
 
 <div id="<%= message_table_name %>">
   <%% @<%= chat_variable_name %>.<%= message_table_name %>.each do |<%= message_variable_name %>| %>


### PR DESCRIPTION
## What this does

When install UI with namespace

```
bin/rails g ruby_llm:chat_ui chat:AIChat message:AIMessage
```

`model_table_name` will output `ai_models`, 

```
<%= @ai_chat.ai_model&.label || default_model_display_name %>
```

it will cause an exception `undefined method 'ai_model' for an instance of AI::Chat`.

`.model` is is a fixed method name.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

<!-- Skip this section for bug fixes and documentation -->

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: #___

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [ ] All tests pass: `bundle exec rspec`
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes
