### PR TITLE
Delegate before_request, count_tokens and render to the chat

### DIFF
--- a/lib/ruby_llm/active_record/chat_methods.rb
+++ b/lib/ruby_llm/active_record/chat_methods.rb
@@ -221,7 +221,7 @@ module RubyLLM
         with_max_output_tokens with_thinking with_citations with_caching
         with_end_user with_compaction
         with_provider_options with_headers with_schema
-        before_message after_message before_tool_call after_tool_result
+        before_request before_message after_message before_tool_call after_tool_result
         before_fallback after_fallback
       ].freeze
 
@@ -310,6 +310,27 @@ module RubyLLM
       def cost
         records = ruby_llm_usages.to_a
         RubyLLM::Cost.aggregate(records.map(&:cost), complete: records.all?(&:usage_available?))
+      end
+
+      # Returns the number of input tokens the next request would carry,
+      # counted by the provider over the persisted conversation. Pass a
+      # message to count it alongside that history without persisting it.
+      # See RubyLLM::Chat#count_tokens.
+      #
+      #   chat.count_tokens "Summarize this contract."
+      #
+      def count_tokens(...)
+        to_llm.count_tokens(...)
+      end
+
+      # Returns the request payload this chat would send to the provider for
+      # its next completion, with #before_request hooks applied. See
+      # RubyLLM::Chat#render.
+      #
+      #   chat.render[:messages]
+      #
+      def render(...)
+        to_llm.render(...)
       end
 
       # Persists +message+ as a user message, then runs the completion loop

--- a/lib/ruby_llm/agent.rb
+++ b/lib/ruby_llm/agent.rb
@@ -768,7 +768,7 @@ module RubyLLM
                    :with_headers, :with_schema, :with_fallbacks, :before_request, :before_message, :after_message,
                    :before_tool_call, :after_tool_result, :before_fallback, :after_fallback, :each, :complete?,
                    :cancel!, :cancelled?, :approve!, :deny!, :awaiting_approval?, :pending_approvals,
-                   :add_message, :add_completion, :tokens, :cost
+                   :add_message, :add_completion, :tokens, :cost, :count_tokens, :render
 
     ##
     # :method: ask

--- a/spec/ruby_llm/active_record/chat_methods_spec.rb
+++ b/spec/ruby_llm/active_record/chat_methods_spec.rb
@@ -306,6 +306,23 @@ RSpec.describe RubyLLM::ActiveRecord::ChatMethods do
       expect(chat.run_tools).to eq(chat)
       expect(chat).to be_complete
     end
+
+    it 'forwards count_tokens and returns the count' do
+      chat = Chat.create!(model: model_id)
+      llm = chat.to_llm
+      allow(llm).to receive(:count_tokens).and_return(42)
+
+      expect(chat.count_tokens('Summarize this contract.')).to eq(42)
+      expect(llm).to have_received(:count_tokens).with('Summarize this contract.')
+    end
+
+    it 'renders the payload with before_request hooks applied' do
+      chat = Chat.create!(model: model_id)
+      chat.before_request { |payload| payload[:metadata] = { user_id: 'u-1' } }
+      chat.ask_later('Hello')
+
+      expect(chat.render[:metadata]).to eq({ user_id: 'u-1' })
+    end
   end
 
   describe '#complete failure handling' do

--- a/spec/ruby_llm/agent_spec.rb
+++ b/spec/ruby_llm/agent_spec.rb
@@ -414,6 +414,24 @@ RSpec.describe RubyLLM::Agent, :live do
                                    ])
   end
 
+  it 'delegates count_tokens and render to the underlying chat' do
+    fake_chat = Class.new do
+      def count_tokens(message = nil)
+        message ? 42 : 7
+      end
+
+      def render
+        { messages: [] }
+      end
+    end.new
+
+    agent = Class.new(described_class).new(chat: fake_chat)
+
+    expect(agent.count_tokens('Hello')).to eq(42)
+    expect(agent.count_tokens).to eq(7)
+    expect(agent.render).to eq({ messages: [] })
+  end
+
   it 'delegates cancellation to the underlying chat' do
     fake_chat = Class.new do
       def initialize


### PR DESCRIPTION
## What this does

Fixes #883.

`RubyLLM::Chat` exposes `before_request`, `count_tokens` and `render`, but records using `acts_as_chat` expose none of them, and `Agent` is missing `count_tokens` and `render`. Each call raises `NoMethodError`.

| method | `RubyLLM::Chat` | `Agent` | `acts_as_chat` |
|---|---|---|---|
| `before_request` | yes | yes (#872) | **no** |
| `count_tokens` | yes | **no** | **no** |
| `render` | yes | **no** | **no** |

This is the same omission as #872, fixed in 48a7e751 — but that commit only touched `agent.rb`, so the Rails integration kept the gap. The issue's table also shows `count_tokens` and `render` missing from `Agent`, so this PR closes both rows.

Three docs already describe the behavior that doesn't work:

- `docs/_advanced/rails-advanced-config.md:126` sends Rails users to the `before_request` hook for provider-specific payloads.
- `docs/_core_features/cost-and-usage-tracking.md:83-104` documents `chat.count_tokens` for enforcing a context budget.
- `docs/_advanced/agents.md:301` states agents "delegate the full `RubyLLM::Chat` instance API".

No doc changes are included because the docs already say what this makes true.

### Implementation note

`before_request` joins `CHAT_DELEGATES`. `count_tokens` and `render` cannot: that loop returns `self` so calls chain, which would swallow their return values. They delegate like the existing `generate` and `step`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [x] All tests pass: `bundle exec rspec --tag ~live` (2642 examples, 0 failures) and `bundle exec archspec check`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

Both new spec groups fail with `NoMethodError` when the library change is reverted, so they are load-bearing rather than restating the implementation. No provider behavior changed, so no cassettes were re-recorded.

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [x] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes
