### PR TITLE
Fix Anthropic multi-turn replay of structured-output content (1.x backport)

### DIFF
--- a/lib/ruby_llm/providers/anthropic/media.rb
+++ b/lib/ruby_llm/providers/anthropic/media.rb
@@ -8,7 +8,14 @@ module RubyLLM
         module_function
 
         def format_content(content) # rubocop:disable Metrics/PerceivedComplexity
-          return content.value if content.is_a?(RubyLLM::Content::Raw)
+          if content.is_a?(RubyLLM::Content::Raw)
+            value = content.value
+            # Parsed structured-output hashes (no :type key) are replayed as the
+            # JSON text the model produced; provider-typed raw blocks pass through.
+            return [format_text(value.to_json)] if value.is_a?(Hash) && !value.key?(:type) && !value.key?('type')
+
+            return value
+          end
           return [format_text(content.to_json)] if content.is_a?(Hash) || content.is_a?(Array)
           return [format_text(content)] unless content.is_a?(RubyLLM::Content)
 

--- a/spec/ruby_llm/providers/anthropic/media_spec.rb
+++ b/spec/ruby_llm/providers/anthropic/media_spec.rb
@@ -19,6 +19,28 @@ RSpec.describe RubyLLM::Providers::Anthropic::Media do
       expect(document_block[:source][:data]).to be_present
     end
 
+    it 'serializes a raw structured-output Hash into a JSON text block' do
+      content = RubyLLM::Content::Raw.new({ 'name' => 'Sophie' })
+
+      blocks = described_class.format_content(content)
+
+      expect(blocks).to eq([{ type: 'text', text: '{"name":"Sophie"}' }])
+    end
+
+    it 'passes through a raw provider-typed block Hash verbatim' do
+      raw_block = { type: 'text', text: 'hello', cache_control: { type: 'ephemeral' } }
+      content = RubyLLM::Content::Raw.new(raw_block)
+
+      expect(described_class.format_content(content)).to eq(raw_block)
+    end
+
+    it 'passes through raw block Arrays verbatim' do
+      raw_blocks = [{ type: 'text', text: 'hello' }]
+      content = RubyLLM::Content::Raw.new(raw_blocks)
+
+      expect(described_class.format_content(content)).to eq(raw_blocks)
+    end
+
     it 'raises an actionable error for unsupported Office documents' do
       content = RubyLLM::Content.new('Summarize this file')
       content.add_attachment(StringIO.new('docx bytes'), filename: 'proposal.docx')


### PR DESCRIPTION
> [!NOTE]
> **The merge conflict GitHub reports is expected and structural — this is a 1.x backport, as offered in #882.** The branch is based on the `1.16.0` tag and patches `lib/ruby_llm/providers/anthropic/media.rb`, which no longer exists on `main` after the protocols restructuring (modify/delete conflict). On `main` the bug cannot occur: structured-output content stays a JSON String and `response.parsed` parses on demand, so there is nothing to port forward. The commit applies cleanly onto the 1.x line: `git cherry-pick -x a76a1d2` on top of `1.16.0` (or a future 1.x branch — happy to retarget this PR there if you cut one).

## What this does

Fixes the Anthropic half of #882: with `with_schema` + Rails persistence (`acts_as_*`), the second turn of a conversation on an Anthropic model fails with `RubyLLM::BadRequestError`.

The parsed structured-output `Hash` stored in `content_raw` is reloaded as `Content::Raw`, and `Providers::Anthropic::Media.format_content` replayed it **verbatim** as a content block without a `type` field, which Anthropic rejects. #531 fixed exactly this for OpenAI in `providers/openai/media.rb`; the Anthropic path never got the equivalent.

This mirrors #531, adapted to Anthropic's block format: a `Content::Raw` hash **without** a `:type`/`"type"` key (i.e. a parsed schema reply, not a provider-typed raw block) is serialized back into the JSON text block the model originally produced. Provider-typed raw block hashes and raw block arrays still pass through verbatim, so existing `Content::Raw` use (e.g. manual `cache_control` blocks) is unaffected.

Repro (from #882):

```ruby
class PersonSchema < RubyLLM::Schema
  string :name
end

chat = Chat.create!(model: 'claude-sonnet-4-5')
chat.with_schema(PersonSchema)
chat.ask('Generate a person from Paris')
chat.ask('Now generate one from Rome') # => RubyLLM::BadRequestError before this patch
```

Verified against the live Anthropic API on a Rails 7.1 app: the second `ask` now returns a second structured reply.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass (`overcommit --run` under Ruby 3.4.8: TrailingWhitespace, Gitleaks, Flay, RSpec, RuboCop, AppraisalUpdate all OK)
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]` (no request-shape change on already-recorded turns; the new unit specs cover the changed formatting)
  - [x] All tests pass: `rspec --tag '~live' --tag '~generator'` — 1217 examples, 0 failures
- [ ] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes

## Related issues

Fixes #882 (Anthropic; #531 covered OpenAI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
