### PR TITLE
Add RubyLLM::Team for multi-agent collaboration

### DIFF
--- a/Archspec.rb
+++ b/Archspec.rb
@@ -25,6 +25,7 @@ component :domain, in: %w[
   lib/ruby_llm/search_results.rb
   lib/ruby_llm/stream_accumulator.rb
   lib/ruby_llm/streaming.rb
+  lib/ruby_llm/team.rb
   lib/ruby_llm/thinking.rb
   lib/ruby_llm/tokens.rb
   lib/ruby_llm/tool.rb

--- a/docs/_advanced/agents.md
+++ b/docs/_advanced/agents.md
@@ -434,7 +434,7 @@ WorkAssistant.new.ask("Help me find docs about callbacks.")
 
 * Compose agents with [Agentic Workflows]({% link _advanced/agentic-workflows.md %})
 * Run them as jobs that survive anything with [Durable Agents]({% link _advanced/durable-agents.md %})
-* Coordinate several as one [Team]({% link _core_features/teams.md %}) the model can delegate to
+* Coordinate several as one [Team]({% link _advanced/teams.md %}) the model can delegate to
 * Give them [Memory]({% link _advanced/memory.md %}) across conversations
 * Ground them in your documents with [RAG]({% link _advanced/rag.md %})
 * Learn about [Chat Basics]({% link _core_features/chat.md %})

--- a/docs/_advanced/agents.md
+++ b/docs/_advanced/agents.md
@@ -434,6 +434,7 @@ WorkAssistant.new.ask("Help me find docs about callbacks.")
 
 * Compose agents with [Agentic Workflows]({% link _advanced/agentic-workflows.md %})
 * Run them as jobs that survive anything with [Durable Agents]({% link _advanced/durable-agents.md %})
+* Coordinate several as one [Team]({% link _core_features/teams.md %}) the model can delegate to
 * Give them [Memory]({% link _advanced/memory.md %}) across conversations
 * Ground them in your documents with [RAG]({% link _advanced/rag.md %})
 * Learn about [Chat Basics]({% link _core_features/chat.md %})

--- a/docs/_advanced/teams.md
+++ b/docs/_advanced/teams.md
@@ -73,6 +73,8 @@ When a coworker replies with attachments, the tool returns `[content, *attachmen
 
 When the model names an unknown coworker, the tool returns an error such as `{ error: "Unknown coworker 'Editor'. Available: Researcher, Writer" }`. The model can then correct the call and continue.
 
+When a coworker raises while answering, the tool turns the failure into an error such as `{ error: "Coworker 'Editor' failed: <message>" }` instead, so the orchestrator can retry or move on.
+
 ## Concurrency
 
 Register every coworker before calling `collaboration_tools`. The returned tools capture a stable snapshot of the registry, so concurrent calls only read Team state and need no locks.

--- a/docs/_advanced/teams.md
+++ b/docs/_advanced/teams.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Teams
-nav_order: 12
+parent: "Agents"
+nav_order: 5
 description: Coordinate specialized agents as one team the model can delegate work to
 ---
 

--- a/docs/_core_features/teams.md
+++ b/docs/_core_features/teams.md
@@ -1,0 +1,85 @@
+---
+layout: default
+title: Teams
+nav_order: 12
+description: Coordinate specialized agents as one team the model can delegate work to
+---
+
+# {{ page.title }}
+
+{{ page.description }}
+{: .fs-6 .fw-300 }
+
+After reading this guide, you will know:
+
+* How to register coworkers on a `RubyLLM::Team`.
+* How to hand a chat the team's collaboration tools.
+* How the model delegates tasks and asks questions.
+* How coworker instances, attachments, and concurrency behave.
+
+## What Is a Team?
+
+A `RubyLLM::Team` groups named coworkers and creates tools that let a model delegate work to them. A Team does not define a task graph or run a process. Use ordinary Ruby or an [Agentic Workflow]({% link _advanced/agentic-workflows.md %}) to coordinate the work around it.
+
+```ruby
+team = RubyLLM::Team.new
+team.add("Researcher", ResearcherAgent)
+team.add("Writer", WriterAgent)
+
+chat.with_tools(*team.collaboration_tools)
+chat.ask "Write an article about the benefits of tea"
+```
+
+## Registering Coworkers
+
+`add` takes a role and an agent. The agent can be a `RubyLLM::Agent` subclass, an instance, or any object that responds to `#ask`. Use descriptive roles so the model knows which coworker to choose.
+
+```ruby
+team.add("Researcher", ResearcherAgent)
+```
+
+Each call to a registered class creates a fresh coworker. Register an instance to preserve its conversation:
+
+```ruby
+team.add("Support specialist", SupportAgent.new)
+```
+
+## Collaboration Tools
+
+`collaboration_tools` returns `delegate_work` and `ask_question`. Pass them to `Chat#with_tools`, or declare them on an agent class:
+
+```ruby
+team = RubyLLM::Team.new
+team.add("Researcher", ResearcherAgent)
+
+Orchestrator = Class.new(RubyLLM::Agent) do
+  tools(*team.collaboration_tools)
+end
+```
+
+Both tools list the available coworker roles in their descriptions:
+
+| Tool | Arguments | Use it to |
+|---|---|---|
+| `delegate_work` | `task`, `coworker`, optional `context` | Hand a task to a coworker and get its result |
+| `ask_question` | `question`, `coworker`, optional `context` | Consult a coworker about its expertise |
+
+The optional `context:` argument adds labeled shared context after the request.
+
+When a coworker replies with attachments, the tool returns `[content, *attachments]`, so coworkers can hand files or images back to the orchestrator.
+
+## Unknown Coworkers
+
+When the model names an unknown coworker, the tool returns an error such as `{ error: "Unknown coworker 'Editor'. Available: Researcher, Writer" }`. The model can then correct the call and continue.
+
+## Concurrency
+
+Register every coworker before calling `collaboration_tools`. The returned tools capture a stable snapshot of the registry, so concurrent calls only read Team state and need no locks.
+
+Classes create a fresh coworker for every call. Registered instances are reused, including their conversation state. Register a class whenever you enable concurrent tool execution.
+
+## Next Steps
+
+* [Agents]({% link _advanced/agents.md %}) - Define reusable coworker classes.
+* [Tools]({% link _core_features/tools.md %}) - Understand the tools a team exposes.
+* [Agentic Workflows]({% link _advanced/agentic-workflows.md %}) - Add task order and dependencies around a team. This guide appears under Agents in the navigation.

--- a/lib/ruby_llm/team.rb
+++ b/lib/ruby_llm/team.rb
@@ -53,8 +53,13 @@ module RubyLLM
         agent = @agents[coworker.to_s]
         return unknown_coworker(coworker) unless agent
 
-        agent = agent.new if agent.is_a?(Class)
-        content, attachments = extract_result(agent.ask(prompt))
+        begin
+          agent = agent.new if agent.is_a?(Class)
+          content, attachments = extract_result(agent.ask(prompt))
+        rescue StandardError => e
+          return { error: "Coworker '#{coworker}' failed: #{e.message}" }
+        end
+
         attachments.empty? ? content : [content, *attachments]
       end
 

--- a/lib/ruby_llm/team.rb
+++ b/lib/ruby_llm/team.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  # Groups named coworkers and creates tools for delegating work.
+  #
+  #   team = RubyLLM::Team.new
+  #   team.add(:researcher, ResearcherAgent)
+  #   chat.with_tools(*team.collaboration_tools)
+  #
+  # Registered classes are instantiated per call; registered instances are reused.
+  class Team
+    def initialize
+      @agents = {}
+    end
+
+    # Registers +agent+ under +role+ and returns +self+.
+    def add(role, agent)
+      role = role.to_s
+      raise ArgumentError, 'provide a role' if role.empty?
+      raise ArgumentError, 'provide an agent' unless agent
+
+      @agents[role] = agent
+      self
+    end
+
+    # Returns collaboration tools for the current registry snapshot.
+    def collaboration_tools
+      agents = @agents.dup.freeze
+      [DelegateWork.new(agents), AskQuestion.new(agents)]
+    end
+
+    class CoworkerTool < Tool # :nodoc:
+      parameter :coworker, type: 'string', description: 'Name of the teammate to consult'
+      parameter :context, type: 'string', description: 'Shared context for the teammate',
+                          required: false
+
+      def initialize(agents)
+        super()
+        @agents = agents
+      end
+
+      def description
+        "#{self.class.description}\n\nCoworkers: #{coworkers}"
+      end
+
+      private
+
+      def with_context(main, context)
+        context ? "#{main}\n\nContext: #{context}" : main
+      end
+
+      def consult(prompt:, coworker:)
+        agent = @agents[coworker.to_s]
+        return unknown_coworker(coworker) unless agent
+
+        agent = agent.new if agent.is_a?(Class)
+        content, attachments = extract_result(agent.ask(prompt))
+        attachments.empty? ? content : [content, *attachments]
+      end
+
+      def unknown_coworker(coworker)
+        { error: "Unknown coworker '#{coworker}'. Available: #{coworkers}" }
+      end
+
+      def coworkers
+        @agents.keys.join(', ')
+      end
+
+      def extract_result(result)
+        return [result, []] unless result.respond_to?(:content)
+
+        attachments = result.respond_to?(:attachments) ? Array(result.attachments) : []
+        [result.content, attachments]
+      end
+    end
+
+    class DelegateWork < CoworkerTool # :nodoc:
+      description 'Delegate a task to a teammate and get their result'
+      parameter :task, type: 'string', description: 'The task to delegate'
+
+      def self.tool_name = 'delegate_work'
+
+      def execute(task:, coworker:, context: nil)
+        consult(prompt: with_context(task, context), coworker: coworker)
+      end
+    end
+
+    class AskQuestion < CoworkerTool # :nodoc:
+      description 'Ask a teammate a question about their expertise'
+      parameter :question, type: 'string', description: 'The question to ask'
+
+      def self.tool_name = 'ask_question'
+
+      def execute(question:, coworker:, context: nil)
+        consult(prompt: with_context(question, context), coworker: coworker)
+      end
+    end
+
+    private_constant :CoworkerTool, :DelegateWork, :AskQuestion
+  end
+end

--- a/spec/fixtures/vcr_cassettes/team_live_delegation_openrouter_nvidia_nemotron-3-super-120b-a12b_free_delegates_through_collaboration_tools.yml
+++ b/spec/fixtures/vcr_cassettes/team_live_delegation_openrouter_nvidia_nemotron-3-super-120b-a12b_free_delegates_through_collaboration_tools.yml
@@ -1,0 +1,212 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://openrouter.ai/api/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"nvidia/nemotron-3-super-120b-a12b:free","messages":[{"role":"developer","content":"You
+        must call the delegate_work tool with coworker \"researcher\" and task \"What
+        is 2 + 2?\" before answering. Then report what it says."},{"role":"user","content":"What
+        is 2 plus 2? Ask your researcher teammate first."}],"stream":false,"tools":[{"type":"function","function":{"name":"delegate_work","description":"Delegate
+        a task to a teammate and get their result\n\nCoworkers: researcher","parameters":{"type":"object","properties":{"coworker":{"type":"string","description":"Name
+        of the teammate to consult"},"context":{"type":"string","description":"Shared
+        context for the teammate"},"task":{"type":"string","description":"The task
+        to delegate"}},"required":["coworker","task"],"additionalProperties":false,"strict":true}}},{"type":"function","function":{"name":"ask_question","description":"Ask
+        a teammate a question about their expertise\n\nCoworkers: researcher","parameters":{"type":"object","properties":{"coworker":{"type":"string","description":"Name
+        of the teammate to consult"},"context":{"type":"string","description":"Shared
+        context for the teammate"},"question":{"type":"string","description":"The
+        question to ask"}},"required":["coworker","question"],"additionalProperties":false,"strict":true}}}]}'
+    headers:
+      User-Agent:
+      - Faraday v2.14.3
+      Authorization:
+      - Bearer <AUTH_TOKEN>
+      Http-Referer:
+      - https://rubyllm.com
+      X-Openrouter-Title:
+      - RubyLLM
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 26 Aug 2026 18:10:19 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Generation-Id:
+      - gen-1787767819-kb2OPcxhk1aTQYtIbSeC
+      Access-Control-Expose-Headers:
+      - X-Generation-Id,X-Provider-Name,request-id,cf-ray
+      Set-Cookie:
+      - "<COOKIE>"
+      Permissions-Policy:
+      - payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com"
+        "https://js.stripe.com" "https://*.js.stripe.com" "https://hooks.stripe.com")
+      Referrer-Policy:
+      - no-referrer, strict-origin-when-cross-origin
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+    body:
+      encoding: ASCII-8BIT
+      string: "\n         \n\n         \n{\"id\":\"gen-1787767819-kb2OPcxhk1aTQYtIbSeC\",\"object\":\"chat.completion\",\"created\":1787767819,\"model\":\"nvidia/nemotron-3-super-120b-a12b:free\",\"provider\":\"Nvidia\",\"system_fingerprint\":null,\"service_tier\":null,\"choices\":[{\"index\":0,\"logprobs\":null,\"finish_reason\":\"tool_calls\",\"native_finish_reason\":\"tool_calls\",\"message\":{\"role\":\"assistant\",\"content\":null,\"refusal\":null,\"reasoning\":\"We
+        need to follow instruction: call delegate_work with coworker \\\"researcher\\\"
+        and task \\\"What is 2 + 2?\\\" Then report what it says.\\n\\nWe'll call
+        delegate_work with those parameters. Let's do that.\\n\\n\",\"tool_calls\":[{\"type\":\"function\",\"index\":0,\"id\":\"call-f02816c5-c725-4d2d-8169-a0a72cea64e4\",\"function\":{\"name\":\"delegate_work\",\"arguments\":\"{\\\"coworker\\\":\\\"researcher\\\",\\\"task\\\":\\\"What
+        is 2 + 2?\\\"}\"}}],\"reasoning_details\":[{\"type\":\"reasoning.text\",\"text\":\"We
+        need to follow instruction: call delegate_work with coworker \\\"researcher\\\"
+        and task \\\"What is 2 + 2?\\\" Then report what it says.\\n\\nWe'll call
+        delegate_work with those parameters. Let's do that.\\n\\n\",\"format\":\"unknown\",\"index\":0}]}}],\"usage\":{\"prompt_tokens\":585,\"completion_tokens\":94,\"total_tokens\":679,\"cost\":0,\"is_byok\":false,\"prompt_tokens_details\":{\"cached_tokens\":0,\"cache_write_tokens\":0,\"audio_tokens\":0,\"video_tokens\":0},\"cost_details\":{\"upstream_inference_cost\":0,\"upstream_inference_prompt_cost\":0,\"upstream_inference_completions_cost\":0},\"completion_tokens_details\":{\"reasoning_tokens\":50,\"image_tokens\":0,\"audio_tokens\":0}}}"
+  recorded_at: Wed, 26 Aug 2026 18:10:20 GMT
+- request:
+    method: post
+    uri: https://openrouter.ai/api/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"nvidia/nemotron-3-super-120b-a12b:free","messages":[{"role":"developer","content":"You
+        are a terse assistant. Answer in one short sentence."},{"role":"user","content":"What
+        is 2 + 2?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.14.3
+      Authorization:
+      - Bearer <AUTH_TOKEN>
+      Http-Referer:
+      - https://rubyllm.com
+      X-Openrouter-Title:
+      - RubyLLM
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 26 Aug 2026 18:10:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Generation-Id:
+      - gen-1787767820-6wczIaldO7xlTcwSvige
+      Access-Control-Expose-Headers:
+      - X-Generation-Id,X-Provider-Name,request-id,cf-ray
+      Set-Cookie:
+      - "<COOKIE>"
+      Permissions-Policy:
+      - payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com"
+        "https://js.stripe.com" "https://*.js.stripe.com" "https://hooks.stripe.com")
+      Referrer-Policy:
+      - no-referrer, strict-origin-when-cross-origin
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        CiAgICAgICAgIAoKICAgICAgICAgCgogICAgICAgICAKeyJpZCI6Imdlbi0xNzg3NzY3ODIwLTZ3Y3pJYWxkTzd4bFRjd1N2aWdlIiwib2JqZWN0IjoiY2hhdC5jb21wbGV0aW9uIiwiY3JlYXRlZCI6MTc4Nzc2NzgyMCwibW9kZWwiOiJudmlkaWEvbmVtb3Ryb24tMy1zdXBlci0xMjBiLWExMmI6ZnJlZSIsInByb3ZpZGVyIjoiTnZpZGlhIiwic3lzdGVtX2ZpbmdlcnByaW50IjpudWxsLCJzZXJ2aWNlX3RpZXIiOm51bGwsImNob2ljZXMiOlt7ImluZGV4IjowLCJsb2dwcm9icyI6bnVsbCwiZmluaXNoX3JlYXNvbiI6InN0b3AiLCJuYXRpdmVfZmluaXNoX3JlYXNvbiI6InN0b3AiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjoiMuKAryvigK8yIGVxdWFscyA0LiIsInJlZnVzYWwiOm51bGwsInJlYXNvbmluZyI6IlRoZSB1c2VyIGFza3M6IFwiV2hhdCBpcyAyICsgMj9cIiBUaGUgYW5zd2VyIGlzIDQuIFByb3ZpZGUgc2hvcnQgc2VudGVuY2U6IFwiMiArIDIgZXF1YWxzIDQuXCJcblxuIiwicmVhc29uaW5nX2RldGFpbHMiOlt7InR5cGUiOiJyZWFzb25pbmcudGV4dCIsInRleHQiOiJUaGUgdXNlciBhc2tzOiBcIldoYXQgaXMgMiArIDI/XCIgVGhlIGFuc3dlciBpcyA0LiBQcm92aWRlIHNob3J0IHNlbnRlbmNlOiBcIjIgKyAyIGVxdWFscyA0LlwiXG5cbiIsImZvcm1hdCI6InVua25vd24iLCJpbmRleCI6MH1dfX1dLCJ1c2FnZSI6eyJwcm9tcHRfdG9rZW5zIjozNiwiY29tcGxldGlvbl90b2tlbnMiOjQ0LCJ0b3RhbF90b2tlbnMiOjgwLCJjb3N0IjowLCJpc19ieW9rIjpmYWxzZSwicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjp7ImNhY2hlZF90b2tlbnMiOjAsImNhY2hlX3dyaXRlX3Rva2VucyI6MCwiYXVkaW9fdG9rZW5zIjowLCJ2aWRlb190b2tlbnMiOjB9LCJjb3N0X2RldGFpbHMiOnsidXBzdHJlYW1faW5mZXJlbmNlX2Nvc3QiOjAsInVwc3RyZWFtX2luZmVyZW5jZV9wcm9tcHRfY29zdCI6MCwidXBzdHJlYW1faW5mZXJlbmNlX2NvbXBsZXRpb25zX2Nvc3QiOjB9LCJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjp7InJlYXNvbmluZ190b2tlbnMiOjI0LCJpbWFnZV90b2tlbnMiOjAsImF1ZGlvX3Rva2VucyI6MH19fQ==
+  recorded_at: Wed, 26 Aug 2026 18:10:22 GMT
+- request:
+    method: post
+    uri: https://openrouter.ai/api/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"nvidia/nemotron-3-super-120b-a12b:free","messages":[{"role":"developer","content":"You
+        must call the delegate_work tool with coworker \"researcher\" and task \"What
+        is 2 + 2?\" before answering. Then report what it says."},{"role":"user","content":"What
+        is 2 plus 2? Ask your researcher teammate first."},{"role":"assistant","content":"","tool_calls":[{"id":"call-f02816c5-c725-4d2d-8169-a0a72cea64e4","type":"function","function":{"name":"delegate_work","arguments":"{\"coworker\":\"researcher\",\"task\":\"What
+        is 2 + 2?\"}"}}],"reasoning_details":[{"type":"reasoning.text","text":"We
+        need to follow instruction: call delegate_work with coworker \"researcher\"
+        and task \"What is 2 + 2?\" Then report what it says.\n\nWe''ll call delegate_work
+        with those parameters. Let''s do that.\n\n","format":"unknown","index":0}]},{"role":"tool","content":"2 + 2
+        equals 4.","tool_call_id":"call-f02816c5-c725-4d2d-8169-a0a72cea64e4"}],"stream":false,"tools":[{"type":"function","function":{"name":"delegate_work","description":"Delegate
+        a task to a teammate and get their result\n\nCoworkers: researcher","parameters":{"type":"object","properties":{"coworker":{"type":"string","description":"Name
+        of the teammate to consult"},"context":{"type":"string","description":"Shared
+        context for the teammate"},"task":{"type":"string","description":"The task
+        to delegate"}},"required":["coworker","task"],"additionalProperties":false,"strict":true}}},{"type":"function","function":{"name":"ask_question","description":"Ask
+        a teammate a question about their expertise\n\nCoworkers: researcher","parameters":{"type":"object","properties":{"coworker":{"type":"string","description":"Name
+        of the teammate to consult"},"context":{"type":"string","description":"Shared
+        context for the teammate"},"question":{"type":"string","description":"The
+        question to ask"}},"required":["coworker","question"],"additionalProperties":false,"strict":true}}}]}'
+    headers:
+      User-Agent:
+      - Faraday v2.14.3
+      Authorization:
+      - Bearer <AUTH_TOKEN>
+      Http-Referer:
+      - https://rubyllm.com
+      X-Openrouter-Title:
+      - RubyLLM
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 26 Aug 2026 18:10:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Generation-Id:
+      - gen-1787767822-e6AZ5vHUjqcmToRYI89x
+      Access-Control-Expose-Headers:
+      - X-Generation-Id,X-Provider-Name,request-id,cf-ray
+      Set-Cookie:
+      - "<COOKIE>"
+      Permissions-Policy:
+      - payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com"
+        "https://js.stripe.com" "https://*.js.stripe.com" "https://hooks.stripe.com")
+      Referrer-Policy:
+      - no-referrer, strict-origin-when-cross-origin
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        CiAgICAgICAgIAoKICAgICAgICAgCnsiaWQiOiJnZW4tMTc4Nzc2NzgyMi1lNkFaNXZIVWpxY21Ub1JZSTg5eCIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbiIsImNyZWF0ZWQiOjE3ODc3Njc4MjIsIm1vZGVsIjoibnZpZGlhL25lbW90cm9uLTMtc3VwZXItMTIwYi1hMTJiOmZyZWUiLCJwcm92aWRlciI6Ik52aWRpYSIsInN5c3RlbV9maW5nZXJwcmludCI6bnVsbCwic2VydmljZV90aWVyIjpudWxsLCJjaG9pY2VzIjpbeyJpbmRleCI6MCwibG9ncHJvYnMiOm51bGwsImZpbmlzaF9yZWFzb24iOiJzdG9wIiwibmF0aXZlX2ZpbmlzaF9yZWFzb24iOiJzdG9wIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6IlRoZSByZXNlYXJjaGVyIHRlYW1tYXRlIHNheXMgdGhhdCAy4oCvK+KArzIgZXF1YWxzIDQuIiwicmVmdXNhbCI6bnVsbCwicmVhc29uaW5nIjoiTm93IHdlIGhhdmUgcmVzdWx0OiBcIjLigK8r4oCvMiBlcXVhbHMgNC5cIiBXZSBzaG91bGQgcmVwb3J0IHdoYXQgaXQgc2F5cy4gUHJvYmFibHkgYW5zd2VyOiBUaGUgcmVzZWFyY2hlciBzYXlzIDIrMiBlcXVhbHMgNC5cbiIsInJlYXNvbmluZ19kZXRhaWxzIjpbeyJ0eXBlIjoicmVhc29uaW5nLnRleHQiLCJ0ZXh0IjoiTm93IHdlIGhhdmUgcmVzdWx0OiBcIjLigK8r4oCvMiBlcXVhbHMgNC5cIiBXZSBzaG91bGQgcmVwb3J0IHdoYXQgaXQgc2F5cy4gUHJvYmFibHkgYW5zd2VyOiBUaGUgcmVzZWFyY2hlciBzYXlzIDIrMiBlcXVhbHMgNC5cbiIsImZvcm1hdCI6InVua25vd24iLCJpbmRleCI6MH1dfX1dLCJ1c2FnZSI6eyJwcm9tcHRfdG9rZW5zIjo3MDQsImNvbXBsZXRpb25fdG9rZW5zIjo1NCwidG90YWxfdG9rZW5zIjo3NTgsImNvc3QiOjAsImlzX2J5b2siOmZhbHNlLCJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOnsiY2FjaGVkX3Rva2VucyI6MCwiY2FjaGVfd3JpdGVfdG9rZW5zIjowLCJhdWRpb190b2tlbnMiOjAsInZpZGVvX3Rva2VucyI6MH0sImNvc3RfZGV0YWlscyI6eyJ1cHN0cmVhbV9pbmZlcmVuY2VfY29zdCI6MCwidXBzdHJlYW1faW5mZXJlbmNlX3Byb21wdF9jb3N0IjowLCJ1cHN0cmVhbV9pbmZlcmVuY2VfY29tcGxldGlvbnNfY29zdCI6MH0sImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOnsicmVhc29uaW5nX3Rva2VucyI6MzMsImltYWdlX3Rva2VucyI6MCwiYXVkaW9fdG9rZW5zIjowfX19
+  recorded_at: Wed, 26 Aug 2026 18:10:23 GMT
+recorded_with: VCR 6.4.0

--- a/spec/ruby_llm/generators/upgrade_migration_adapters_spec.rb
+++ b/spec/ruby_llm/generators/upgrade_migration_adapters_spec.rb
@@ -77,6 +77,14 @@ RSpec.describe 'RubyLLM upgrade migration adapters', :generator do # rubocop:dis
 
       after do
         drop_test_tables
+        restore_test_connection
+      end
+
+      def restore_test_connection
+        return unless defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+
+        dummy_config = Rails.application.config.database_configuration['test']
+        ActiveRecord::Base.establish_connection(dummy_config)
       end
 
       it 'rejects an incompatible application schema before changing it' do

--- a/spec/ruby_llm/team_spec.rb
+++ b/spec/ruby_llm/team_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Team do
+  def coworker_class(response: 'done')
+    Class.new do
+      define_method :ask do |prompt|
+        RubyLLM::Message.new(role: :assistant, content: "#{response}: #{prompt}")
+      end
+    end
+  end
+
+  describe '#add' do
+    it 'returns itself for chaining' do
+      team = described_class.new
+
+      expect(team.add(:researcher, coworker_class)).to equal(team)
+    end
+
+    it 'requires a role and an agent' do
+      team = described_class.new
+
+      expect { team.add('', coworker_class) }.to raise_error(ArgumentError, 'provide a role')
+      expect { team.add(:researcher, nil) }.to raise_error(ArgumentError, 'provide an agent')
+    end
+
+    it 'replaces a coworker registered under the same role' do
+      team = described_class.new
+      team.add(:researcher, coworker_class(response: 'first'))
+      team.add(:researcher, coworker_class(response: 'second'))
+
+      result = team.collaboration_tools.first.call({ 'task' => 'check', 'coworker' => 'researcher' })
+
+      expect(result).to eq('second: check')
+    end
+
+    it 'detaches a string role from its caller' do
+      role = +'researcher'
+      team = described_class.new.add(role, coworker_class)
+      role.replace('writer')
+
+      result = team.collaboration_tools.first.call({ 'task' => 'check', 'coworker' => 'researcher' })
+
+      expect(result).to eq('done: check')
+    end
+  end
+
+  describe '#collaboration_tools' do
+    def stateful_coworker
+      Class.new do
+        def initialize
+          @log = []
+        end
+
+        def ask(prompt)
+          @log << prompt
+          RubyLLM::Message.new(role: :assistant, content: "#{@log.size}:#{prompt}")
+        end
+      end
+    end
+
+    def team_with(coworker)
+      described_class.new.add(:researcher, coworker)
+    end
+
+    let(:team) { team_with(stateful_coworker) }
+    let(:tools) { team.collaboration_tools }
+    let(:delegate_tool) { tools.first }
+    let(:ask_tool) { tools.last }
+
+    it 'returns delegation and question tools' do
+      expect(team.collaboration_tools.map(&:name)).to eq(%w[delegate_work ask_question])
+    end
+
+    it 'lists the available coworker roles in each tool description' do
+      team.add(:writer, coworker_class)
+      delegate, ask = team.collaboration_tools
+
+      expect(delegate.description).to end_with('Coworkers: researcher, writer')
+      expect(ask.description).to end_with('Coworkers: researcher, writer')
+    end
+
+    it 'keeps context optional in the argument schemas' do
+      expect(delegate_tool.parameters_schema['required']).to eq(%w[coworker task])
+      expect(ask_tool.parameters_schema['required']).to eq(%w[coworker question])
+      expect(delegate_tool.parameters_schema['properties']).to have_key('context')
+    end
+
+    it 'delegates work and asks questions' do
+      delegated = delegate_tool.call({ 'task' => 'Summarize X', 'coworker' => 'researcher' })
+      answered = ask_tool.call({ 'question' => 'How big is X?', 'coworker' => 'researcher' })
+
+      expect(delegated).to eq('1:Summarize X')
+      expect(answered).to eq('1:How big is X?')
+    end
+
+    it 'returns plain coworker replies as-is' do
+      coworker = Class.new do
+        def ask(_prompt) = 'plain reply'
+      end
+
+      result = team_with(coworker).collaboration_tools.first.call(
+        { 'task' => 'check', 'coworker' => 'researcher' }
+      )
+
+      expect(result).to eq('plain reply')
+    end
+
+    it 'reads content from replies without attachments' do
+      reply = Struct.new(:content).new('content only')
+      coworker = Class.new do
+        define_method(:ask) { |_prompt| reply }
+      end
+
+      result = team_with(coworker).collaboration_tools.first.call(
+        { 'task' => 'check', 'coworker' => 'researcher' }
+      )
+
+      expect(result).to eq('content only')
+    end
+
+    it 'appends shared context to the coworker prompt' do
+      prompts = []
+      coworker = Class.new do
+        define_method(:ask) do |prompt|
+          prompts << prompt
+          RubyLLM::Message.new(role: :assistant, content: 'ok')
+        end
+      end
+
+      team_with(coworker).collaboration_tools.first.call(
+        { 'task' => 'Summarize X', 'coworker' => 'researcher', 'context' => 'for an intro' }
+      )
+
+      expect(prompts).to eq(["Summarize X\n\nContext: for an intro"])
+    end
+
+    it 'instantiates registered classes fresh for every delegation' do
+      delegate = team_with(stateful_coworker).collaboration_tools.first
+
+      delegate.call({ 'task' => 'first', 'coworker' => 'researcher' })
+
+      expect(delegate.call({ 'task' => 'second', 'coworker' => 'researcher' })).to eq('1:second')
+    end
+
+    it 'reuses a registered instance between delegations' do
+      team = described_class.new.add(:writer, stateful_coworker.new)
+      delegate = team.collaboration_tools.first
+
+      expect(delegate.call({ 'task' => 'first', 'coworker' => 'writer' })).to eq('1:first')
+      expect(delegate.call({ 'task' => 'second', 'coworker' => 'writer' })).to eq('2:second')
+    end
+
+    it 'returns an error that names available coworkers for an unknown role' do
+      result = delegate_tool.call({ 'task' => 'Summarize X', 'coworker' => 'nobody' })
+
+      expect(result[:error]).to eq("Unknown coworker 'nobody'. Available: researcher")
+    end
+
+    it 'returns message attachments with the reply content' do
+      attachment = RubyLLM::Attachment.new(StringIO.new('image bytes'), filename: 'diagram.png')
+      coworker = Class.new do
+        define_method(:ask) do |_prompt|
+          RubyLLM::Message.new(role: :assistant, content: 'See the diagram', attachments: [attachment])
+        end
+      end
+
+      result = team_with(coworker).collaboration_tools.first.call(
+        { 'task' => 'draw', 'coworker' => 'researcher' }
+      )
+
+      expect(result).to eq(['See the diagram', attachment])
+    end
+
+    it 'uses a stable snapshot of the registered coworkers' do
+      tools = team.collaboration_tools
+      team.add(:writer, coworker_class)
+
+      result = tools.first.call({ 'task' => 'Draft', 'coworker' => 'writer' })
+
+      expect(tools.first.description).to end_with('Coworkers: researcher')
+      expect(result[:error]).to eq("Unknown coworker 'writer'. Available: researcher")
+    end
+  end
+
+  describe 'live delegation', :live do
+    it 'openrouter/nvidia/nemotron-3-super-120b-a12b:free delegates through collaboration tools' do
+      skip_without_cassette_or_key('OPENROUTER_API_KEY')
+
+      model_id = 'nvidia/nemotron-3-super-120b-a12b:free'
+      provider = :openrouter
+      coworker = Class.new(RubyLLM::Agent) do
+        model model_id, provider: provider
+        instructions 'You are a terse assistant. Answer in one short sentence.'
+      end
+
+      team = described_class.new.add(:researcher, coworker)
+      chat = RubyLLM.chat(model: model_id, provider: provider)
+                    .with_tools(*team.collaboration_tools)
+                    .with_instructions(
+                      'You must call the delegate_work tool with coworker "researcher" and ' \
+                      'task "What is 2 + 2?" before answering. Then report what it says.'
+                    )
+
+      response = chat.ask('What is 2 plus 2? Ask your researcher teammate first.')
+
+      delegation = chat.messages.flat_map { |message| message.tool_calls&.values || [] }.find do |tool_call|
+        tool_call.name == 'delegate_work' && tool_call.arguments.values.any? { |value| value.to_s.include?('2 + 2') }
+      end
+      expect(delegation).not_to be_nil
+
+      tool_result = chat.messages.find { |message| message.tool_call_id == delegation.id }
+      expect(tool_result).not_to be_nil
+      expect(tool_result.content).to include('4')
+      expect(response.content).to include('4')
+    end
+  end
+end

--- a/spec/ruby_llm/team_spec.rb
+++ b/spec/ruby_llm/team_spec.rb
@@ -158,6 +158,38 @@ RSpec.describe RubyLLM::Team do
       expect(result[:error]).to eq("Unknown coworker 'nobody'. Available: researcher")
     end
 
+    it 'returns a recoverable error when a coworker raises while answering' do
+      coworker = Class.new do
+        def ask(_prompt)
+          raise 'boom'
+        end
+      end
+
+      result = team_with(coworker).collaboration_tools.first.call(
+        { 'task' => 'check', 'coworker' => 'researcher' }
+      )
+
+      expect(result).to eq(error: "Coworker 'researcher' failed: boom")
+    end
+
+    it 'returns a recoverable error when a registered class cannot be instantiated' do
+      coworker = Class.new do
+        def initialize(name)
+          @name = name
+        end
+
+        def ask(_prompt)
+          'ok'
+        end
+      end
+
+      result = team_with(coworker).collaboration_tools.first.call(
+        { 'task' => 'check', 'coworker' => 'researcher' }
+      )
+
+      expect(result[:error]).to include("Coworker 'researcher' failed:")
+    end
+
     it 'returns message attachments with the reply content' do
       attachment = RubyLLM::Attachment.new(StringIO.new('image bytes'), filename: 'diagram.png')
       coworker = Class.new do


### PR DESCRIPTION
## What this does

Adds `RubyLLM::Team`, a small registry that exposes two ordinary `RubyLLM::Tool` objects: `delegate_work` and `ask_question`. A model can route a task or question to a named coworker without adding a workflow engine, scheduler, protocol, or new execution path.

```ruby
team = RubyLLM::Team.new
team.add(:researcher, ResearcherAgent)
team.add(:writer, WriterAgent)

chat.with_tools(*team.collaboration_tools)
chat.ask "Research and draft an article about Ruby"
```

Applications can already wrap one agent in one tool. `Team` standardizes the reusable boundary around that pattern: coworker roles, collaboration schemas, class-versus-instance lifecycle, recoverable lookup errors, shared context, attachment results, and a stable registry snapshot for concurrent tool execution. Applications still own task order, dependencies, persistence, and orchestration.

This remains a draft pending an approved issue or maintainer confirmation that this helper belongs in core. Unlike the A2A proposal declined in [#670](https://github.com/crmne/ruby_llm/issues/670), this PR adds no transport or external integration; the scope question is only whether local agent-to-tool composition merits a shared core API.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits users composing multiple agents, not one application-specific workflow

## Required for new features

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: none yet

This remains a draft until the scope is approved.

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: not applicable
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

`overcommit --install` succeeded. `overcommit --run` was attempted, but its wrapper is blocked in this environment by baseline SVG whitespace, unavailable Rubygems network access, an unwritable RuboCop cache, and denied `sysctl` worker detection. The PR-relevant gates below were run directly.

Validation run on the final diff:

- GitHub Actions: all 23 checks pass across lint, Gitleaks, Codecov, Ruby 3.1-4.0, JRuby, and Rails 7.1-8.1
- Team specs: 17 examples, 0 failures
- Full suite: 3,835 examples, 0 failures, 94 expected pending
- Overall coverage: 97.74% lines and 89.56% branches
- PR production coverage: 51/51 lines and 16/16 branches
- RuboCop: 520 files, no offenses
- Archspec: passed
- Flay: mass 58, below the project threshold of 70
- RDoc: passed; only `RubyLLM::Team` is public
- Docs front matter and all four Jekyll link targets: valid
- Gitleaks staged scan: no leaks
- Generated registries and `.gitignore`: unchanged

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I reviewed and understand the generated code

## API changes

- [ ] Breaking change
- [x] New public methods/classes
- [ ] Changed method signatures
- [ ] No API changes
