### PR TITLE
Make generator specs ignore user Rails config

### DIFF
--- a/spec/support/generator_test_helpers.rb
+++ b/spec/support/generator_test_helpers.rb
@@ -24,6 +24,7 @@ module GeneratorTestHelpers
 
     create_command = [
       'bundle', 'exec', 'rails', 'new', name,
+      '--no-rc',
       '--skip-bootsnap', '--skip-bundle', '--skip-kamal', '--skip-thruster',
       '--skip-asset-pipeline', '--skip-javascript', '--skip-hotwire'
     ]


### PR DESCRIPTION
## What this does

Prevents generator specs from inheriting user-level Rails configuration in `~/.railrc`. The test helper now passes Rails' `--no-rc` option when creating temporary applications.

Without this option, a developer's `~/.railsrc` could specify `--database postgresql`, causing generated test apps to require `pg`, which is not part of the test bundle, preventing the tests from passing locally.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

Not applicable.

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

Generator specs pass with `bundle exec rspec spec/ruby_llm/generators` (48 examples, 0 failures). The non-live suite passes when Rails user configuration is isolated via `HOME=/tmp`.

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes