### PR TITLE
Stop guessing Bedrock structured output support by model id

### DIFF
--- a/lib/ruby_llm/providers/bedrock/models.rb
+++ b/lib/ruby_llm/providers/bedrock/models.rb
@@ -275,25 +275,8 @@ module RubyLLM
           converse = model_data['converse'] || {}
           capabilities << 'function_calling' if model_data.dig('inferenceAPIsSupported', 'converse', 'sync')
           capabilities << 'reasoning' if converse.dig('reasoningSupported', 'embedded')
-          capabilities << 'structured_output' if supports_structured_output?(model_data['modelId'])
 
           capabilities
-        end
-
-        # Structured output supported on Claude 4.5+ and assumed for future major versions.
-        # Bedrock IDs look like: us.anthropic.claude-haiku-4-5-20251001-v1:0
-        # Must handle optional region prefix (us./eu./global.) and anthropic. prefix.
-        def supports_structured_output?(model_id)
-          return false unless model_id
-
-          normalized = model_id.sub(/\A(?:#{Protocols::Converse::REGION_PREFIXES.join('|')})\./, '')
-                               .delete_prefix('anthropic.')
-          match = normalized.match(/claude-(?:opus|sonnet|haiku)-(\d+)-(\d{1,2})(?:\b|-)/)
-          return false unless match
-
-          major = match[1].to_i
-          minor = match[2].to_i
-          major > 4 || (major == 4 && minor >= 5)
         end
 
         def parse_context_window(model_data)

--- a/spec/ruby_llm/providers/bedrock/models_spec.rb
+++ b/spec/ruby_llm/providers/bedrock/models_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe RubyLLM::Providers::Bedrock::Models do
       expect(model.modalities.input).to eq(%w[text image])
       expect(model.modalities.output).to eq(['text'])
       expect(model.capabilities).to contain_exactly(
-        'streaming', 'function_calling', 'reasoning', 'structured_output'
+        'streaming', 'function_calling', 'reasoning'
       )
       expect(model.metadata).to include(provider_name: 'Anthropic', inference_types: ['ON_DEMAND'])
     end
@@ -371,25 +371,6 @@ RSpec.describe RubyLLM::Providers::Bedrock::Models do
 
     def config_for(region: 'us-east-1')
       RubyLLM::Configuration.new.tap { |c| c.bedrock_region = region }
-    end
-  end
-
-  describe '.supports_structured_output?' do
-    {
-      'anthropic.claude-haiku-4-5-20251001-v1:0' => true,
-      'anthropic.claude-sonnet-4-5-20250929-v1:0' => true,
-      'anthropic.claude-opus-4-5-20250514-v1:0' => true,
-      'us.anthropic.claude-opus-4-6-v1' => true,
-      'eu.anthropic.claude-haiku-4-5-20251001-v1:0' => true,
-      'global.anthropic.claude-haiku-4-5-20251001-v1:0' => true,
-      'anthropic.claude-opus-4-20250514-v1:0' => false,
-      'anthropic.claude-3-5-sonnet-20241022-v2:0' => false,
-      'amazon.nova-2-lite-v1:0' => false,
-      nil => false
-    }.each do |model_id, expected|
-      it "returns #{expected} for #{model_id.inspect}" do
-        expect(described_class.supports_structured_output?(model_id)).to eq(expected)
-      end
     end
   end
 end


### PR DESCRIPTION
## What this does

Deletes `Bedrock::Models.supports_structured_output?` and its one call site. The function parses a version number out of a model id and assumes `structured_output` support when it detects models with versions 4.5 or higher. 

AWS lists structured outputs as Not Supported on both `bedrock-mantle` and `bedrock-runtime` for [Claude Opus 4.7](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html), launched Apr 16, 2026, and [Claude Opus 4.8](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html), launched May 28, 2026. 

- `models.json` lists both Opus 4.7/4.8 as having `structured_output` support due to the assumptions made within `supports_structured_output?` that any Anthropic model with v 4.5 or higher supports structured outputs.
- models.dev lists structured_output suport as null for both 4.7 and 4.8

From AGENTS.md:

> Provider model parsers record facts returned by the provider. Provider `capabilities.rb` files may only augment feature capabilities that neither the provider listing nor models.dev can express. Base those additions on explicit upstream fields, exact model ids, or unambiguous operation markers, never broad family matchers that guess about current or future models.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

<!-- Skip this section for bug fixes and documentation -->

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: #___

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
