### PR TITLE
Canonicalize the scaffold spec sandbox

### DIFF
--- a/spec/ruby_llm/provider_generator_cli_spec.rb
+++ b/spec/ruby_llm/provider_generator_cli_spec.rb
@@ -7,7 +7,7 @@ require 'stringio'
 require 'tmpdir'
 
 RSpec.describe RubyLLM::ProviderGeneratorCLI do
-  let(:dir) { Dir.mktmpdir('ruby_llm_provider_cli') }
+  let(:dir) { File.realpath(Dir.mktmpdir('ruby_llm_provider_cli')) }
 
   after do
     FileUtils.rm_rf(dir)

--- a/spec/ruby_llm/provider_scaffold_spec.rb
+++ b/spec/ruby_llm/provider_scaffold_spec.rb
@@ -6,7 +6,7 @@ require 'rbconfig'
 require 'tmpdir'
 
 RSpec.describe RubyLLM::ProviderScaffold do
-  let(:dir) { Dir.mktmpdir('ruby_llm_provider_scaffold') }
+  let(:dir) { File.realpath(Dir.mktmpdir('ruby_llm_provider_scaffold')) }
 
   after do
     FileUtils.rm_rf(dir)


### PR DESCRIPTION
## What this does

Fixes #901.

Three examples fail on every macOS checkout of `main`:

```
rspec ./spec/ruby_llm/provider_generator_cli_spec.rb:95 # generates from outside the RubyLLM checkout
rspec ./spec/ruby_llm/provider_scaffold_spec.rb:16      # generates a standalone provider gem that boots
rspec ./spec/ruby_llm/provider_scaffold_spec.rb:267     # creates provider gems in a named directory by default
```

`Dir.mktmpdir` returns a path under `/var`, which macOS symlinks to `/private/var`. The scaffold and the CLI report canonical paths, so each assertion compared an unresolved expectation against a resolved actual:

```
expected: "/var/folders/.../ruby_llm-providers-acme-cloud"
     got: "/private/var/folders/.../ruby_llm-providers-acme-cloud"
```

Resolving the sandbox once where it is created fixes all three, and is a no-op on Linux, where `/tmp` is not a symlink and CI is already green.

The library itself is unaffected — this is the specs assuming `mktmpdir` returns a canonical path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [x] All tests pass: `bundle exec rspec --tag ~live` (2510 examples, 0 failures, down from 3) and `bundle exec archspec check`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

Verified on macOS 15.7.7, Ruby 3.2.2 (arm64-darwin24). No provider behavior changed, so no cassettes were re-recorded.

## AI-generated code

- [x] I used AI tools to help write this code
- [ ] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
