### PR TITLE
Allow Marcel 2 for Rails compatibility

### DIFF
--- a/ruby_llm.gemspec
+++ b/ruby_llm.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-multipart', '>= 1'
   spec.add_dependency 'faraday-net_http', '>= 1'
   spec.add_dependency 'faraday-retry', '>= 1'
-  spec.add_dependency 'marcel', '~> 1'
+  spec.add_dependency 'marcel', '>= 1.0', '< 3'
   spec.add_dependency 'schematist', '~> 1.1'
   spec.add_dependency 'zeitwerk', '~> 2'
 end

--- a/spec/ruby_llm_gemspec_spec.rb
+++ b/spec/ruby_llm_gemspec_spec.rb
@@ -17,4 +17,8 @@ RSpec.describe 'ruby_llm.gemspec' do
   it 'keeps faraday-retry compatible with Faraday v1 and v2' do
     expect(runtime_dependency('faraday-retry').requirement.to_s).to eq('>= 1')
   end
+
+  it 'supports Marcel v1 and v2' do
+    expect(runtime_dependency('marcel').requirement.to_s).to eq('>= 1.0, < 3')
+  end
 end


### PR DESCRIPTION
## What this does

Widens the Marcel runtime dependency from `~> 1` to `>= 1.0, < 3` so RubyLLM can be installed when an application resolves Marcel 2.

Rails [#58549](https://github.com/rails/rails/pull/58549) upgrades Active Storage to Marcel 2 and widens its own requirement to the same major-version range. The current RubyLLM constraint prevents Bundler from selecting Marcel 2 even though RubyLLM delegates MIME detection through the unchanged `Marcel::MimeType.for` API.

Keeping Marcel 1 in the supported range preserves RubyLLM compatibility with Ruby 3.1 and 3.2, while Bundler can select Marcel 2 on Ruby 3.3 and newer. The `< 3` upper bound avoids opting into an untested future major release.

A gemspec regression example records the intended range.

Alternatively, the minimum Ruby version could be bumped and the dependency on Marcel be updated to simply ~> 2.0, but that would be beyond the scope of this compatibility fix.

## Type of change

- [x] Bug fix

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM focus on **LLM communication**
- [x] This is not application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

Not applicable. This is a dependency compatibility fix.

## Quality check

- [x] I ran `overcommit --install` and all hooks pass
- [x] I tested my changes thoroughly
  - [x] For provider changes: Not applicable — this PR does not change a provider
  - [x] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I did not modify auto-generated files manually (`models.json`, `aliases.json`)

Validation completed:

- Full suite: 3,648 examples, 0 failures, 91 pending
- All pre-commit hooks pass against `upstream/main`, including RSpec, RuboCop, Gitleaks, ArchSpec, trailing whitespace, and appraisal checks
- `spec/ruby_llm_gemspec_spec.rb`: 3 examples, 0 failures
- `spec/ruby_llm/attachment_spec.rb` with Marcel 2.1.0: 25 examples, 0 failures
- Rails #58549 head with Rails 8.2.0.alpha, Active Storage, RubyLLM, and Marcel 2.1.0: bundle resolution and load smoke test passed

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [x] No API changes
