### PR TITLE
Classify Anthropic's "input length and max_tokens exceed context limit" as ContextLengthExceededError

### DIFF
--- a/lib/ruby_llm/error_middleware.rb
+++ b/lib/ruby_llm/error_middleware.rb
@@ -60,7 +60,8 @@ module RubyLLM
         /input[_\s-]?token/i,
         /input or output tokens? must be reduced/i,
         /reduce the length of messages/i,
-        /prompt is too long/i
+        /prompt is too long/i,
+        /context limit/i
       ].freeze
 
       RATE_LIMIT_PATTERNS = [

--- a/spec/ruby_llm/error_middleware_spec.rb
+++ b/spec/ruby_llm/error_middleware_spec.rb
@@ -178,6 +178,16 @@ RSpec.describe RubyLLM::ErrorMiddleware do
       end.to raise_error(RubyLLM::ContextLengthExceededError)
     end
 
+    it "maps Anthropic's 'input length and max_tokens exceed context limit' 400 error to ContextLengthExceededError" do
+      msg = 'input length and max_tokens exceed context limit: 900000 + 128000 > 1000000'
+      response = Struct.new(:status, :body).new(400, %({"error":{"message":"#{msg}"}}))
+      provider = instance_double(RubyLLM::Provider, parse_error: msg)
+
+      expect do
+        described_class.parse_error(provider: provider, response: response)
+      end.to raise_error(RubyLLM::ContextLengthExceededError)
+    end
+
     it 'keeps regular 400 errors as BadRequestError' do
       response = Struct.new(:status, :body).new(400, '{"error":{"message":"Invalid model specified"}}')
       provider = instance_double(RubyLLM::Provider, parse_error: 'Invalid model specified')


### PR DESCRIPTION
## What this does

Adds `/context limit/i` to `ErrorMiddleware::CONTEXT_LENGTH_PATTERNS` so Anthropic's second context-window error raises `RubyLLM::ContextLengthExceededError` instead of `BadRequestError`:

```json
{"type":"error","error":{"type":"invalid_request_error","message":"input length and max_tokens exceed context limit: 900000 + 128000 > 1000000"}}
```

Closes #906.

## Why

Anthropic checks `input + max_tokens <= context_window` before it checks the prompt alone, and the chat payload always sends `max_tokens` (`model.max_tokens || 4096`, 128k for `claude-opus-4-8`). So on a long-context model this is the *first* error a growing conversation hits, at roughly `context_window - max_output_tokens` input tokens. The `"prompt is too long"` pattern from #755 only fires later, once the prompt alone no longer fits. Applications rescuing `ContextLengthExceededError` for Anthropic therefore missed the case that actually occurs.

## Type of change

- [x] Bug fix

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Quality check

- [x] I ran `bundle exec rspec spec/ruby_llm/error_middleware_spec.rb spec/ruby_llm/error_spec.rb` (48 examples, 0 failures) and `bundle exec rubocop` on the touched files
- [x] I added a spec for the new phrasing next to the existing `"prompt is too long"` one
- [ ] `overcommit --run` — not run locally (mysql2 does not build on this machine); RuboCop and the affected specs were run by hand

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures

## Related issues

#906 (this), #755 (the earlier `"prompt is too long"` half). The streaming-status half of #906, where 1.16.0's Anthropic adapter labels every failure a 500, is already fixed on `main` by `failed_http_status`; this PR only adds the missing pattern.
