### PR TITLE
Document using the Ollama provider with llmman

### DIFF
--- a/docs/_getting_started/configuration-providers.md
+++ b/docs/_getting_started/configuration-providers.md
@@ -145,6 +145,20 @@ RubyLLM.models.by_provider(:ollama_cloud).map(&:id)
 
 Ollama Cloud does not support [structured output]({% link _core_features/structured-output.md %}); use local Ollama or another provider when you need a schema.
 
+## llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API, alongside OpenAI- and Anthropic-compatible ones, on port 17434. It pulls models as OCI artifacts or straight from Hugging Face and runs them with `llama.cpp`, `vllm`, or `mlx-lm`. Because the wire format is the same, point the `:ollama` provider at it and everything else stays as it is:
+
+```ruby
+RubyLLM.configure do |config|
+  config.ollama_api_base = 'http://localhost:17434/v1'
+end
+
+RubyLLM.chat(model: 'gemma4', provider: :ollama).ask('Hello from llmman')
+```
+
+Chat, tools, structured output, embeddings, and `RubyLLM.models.refresh` all go through the same endpoints RubyLLM already uses for Ollama. If you move the server with `LLMMAN_HOST`, update `ollama_api_base` to match.
+
 ## Bedrock Credential Providers
 
 For IAM roles, assume-role flows, and rotating credentials, configure an AWS SDK credential provider instead of static keys:


### PR DESCRIPTION
## What this does

Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434, to the provider setup guide.

- Docs only, no new provider: the `:ollama` provider already speaks llmman's wire format, so `config.ollama_api_base = 'http://localhost:17434/v1'` is the whole integration.
- Adds a short `## llmman` section in `docs/_getting_started/configuration-providers.md`, right after `## Ollama Cloud`.
- No README/provider list or logo changes, since no provider is added.

**Testing:** `ruby -c` on the snippet; confirmed with `lib/` loaded that the `:ollama` provider resolves to `http://localhost:17434/v1/...` and `/api/show` with the documented `ollama_api_base`.

## Type of change

- [x] Documentation

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

Skipped: documentation only.

## Quality check

- [x] I tested my changes thoroughly
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [x] No API changes

> AI-assisted, reviewed before submitting.
