### PR TITLE
Return {} for empty-string tool-call arguments in the interactions protocol

### DIFF
--- a/lib/ruby_llm/protocols/interactions/tools.rb
+++ b/lib/ruby_llm/protocols/interactions/tools.rb
@@ -31,7 +31,9 @@ module RubyLLM
         end
 
         def parse_interaction_arguments(arguments)
-          arguments.is_a?(String) ? JSON.parse(arguments) : arguments || {}
+          return {} if arguments.nil? || (arguments.is_a?(String) && arguments.empty?)
+
+          arguments.is_a?(String) ? JSON.parse(arguments) : arguments
         rescue JSON::ParserError => e
           raise ToolCallParseError.new(finish_reason: :tool_calls), cause: e
         end

--- a/spec/ruby_llm/protocols/interactions/tools_spec.rb
+++ b/spec/ruby_llm/protocols/interactions/tools_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyLLM::Protocols::Interactions::Tools do
+  describe '.parse_interaction_calls' do
+    def call(arguments)
+      step = { 'type' => 'function_call', 'id' => 'c1', 'name' => 'now' }
+      step['arguments'] = arguments unless arguments == :absent
+      described_class.parse_interaction_calls([step]).fetch('c1')
+    end
+
+    it 'parses a JSON object string' do
+      expect(call('{"tz":"UTC"}').arguments).to eq({ 'tz' => 'UTC' })
+    end
+
+    it 'returns {} for empty-string arguments' do
+      expect(call('').arguments).to eq({})
+    end
+
+    it 'returns {} for a missing arguments key' do
+      expect(call(:absent).arguments).to eq({})
+    end
+
+    it 'passes a Hash through unchanged' do
+      expect(call({ 'tz' => 'UTC' }).arguments).to eq({ 'tz' => 'UTC' })
+    end
+
+    it 'wraps malformed JSON in a RubyLLM error' do
+      expect { call('{"tz":') }.to raise_error(RubyLLM::ToolCallParseError) do |error|
+        expect(error).to be_a(RubyLLM::Error)
+        expect(error.cause).to be_a(JSON::ParserError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Problem

`Protocols::Interactions::Tools.parse_interaction_arguments` runs `JSON.parse` on any `String`:

```ruby
def parse_interaction_arguments(arguments)
  arguments.is_a?(String) ? JSON.parse(arguments) : arguments || {}
rescue JSON::ParserError => e
  raise ToolCallParseError.new(finish_reason: :tool_calls), cause: e
end
```

A `function_call` step whose `arguments` is an empty string (`""`) makes `JSON.parse("")` raise, so the whole run fails with `ToolCallParseError` for what is a valid zero-argument tool call.

The sibling parser already handles this — `Protocols::ChatCompletions::Tools.parse_tool_call_arguments`:

```ruby
if arguments.nil? || arguments.empty?
  {}
else
  JSON.parse(arguments)
end
```

So the two tool-call parsers disagree on the same input.

### Fix

Guard empty (and nil) arguments in `parse_interaction_arguments` the same way, before `JSON.parse`.

```ruby
return {} if arguments.nil? || (arguments.is_a?(String) && arguments.empty?)
```

### Tests

New `spec/ruby_llm/protocols/interactions/tools_spec.rb`: empty string → `{}`, missing key → `{}`, Hash passthrough, valid JSON object, malformed JSON → `ToolCallParseError`. The empty-string case raises on `main`.

`bundle exec rspec spec/ruby_llm/protocols/interactions{_spec.rb,/tools_spec.rb} spec/ruby_llm/protocols/chat_completions/tools_spec.rb` — green; `rubocop` clean on both files.