### PR TITLE
Fix instruction declarations not inheriting to Agent subclasses

### DIFF
--- a/docs/_advanced/agents.md
+++ b/docs/_advanced/agents.md
@@ -254,7 +254,7 @@ RubyLLM looks for:
 
 * `app/prompts/work_assistant/instructions.txt.erb`
 
-If the file exists, it is rendered and used as instructions automatically. If it does not exist and you did not set `instructions`, the agent starts without system instructions. To require a prompt and fail loudly when it is missing, reference it explicitly:
+If the file exists, it is rendered and used as instructions automatically. If it does not exist and you did not set `instructions` on the class or an ancestor, the agent starts without system instructions. Subclasses inherit instruction declarations, and inherited declarations suppress the conventional prompt the same way the class's own declarations do; declare `instructions(append: true) { prompt("instructions") }` to use both.
 
 ```ruby
 class WorkAssistant < RubyLLM::Agent

--- a/lib/ruby_llm/agent.rb
+++ b/lib/ruby_llm/agent.rb
@@ -54,7 +54,7 @@ module RubyLLM
       :@fallbacks => [],
       :@fallback_options => {},
       :@rescue_handlers => [],
-      :@instructions => []
+      :@instruction_declarations => []
     }.freeze
     # Simple value options: a class-level getter/setter macro whose value the
     # agent forwards to the matching Chat#with_* when it builds its chat.

--- a/spec/ruby_llm/agent_dsl_spec.rb
+++ b/spec/ruby_llm/agent_dsl_spec.rb
@@ -280,6 +280,29 @@ RSpec.describe RubyLLM::Agent do
       expect(child.model).to eq(model: model_for(:openai, :temperature), provider: :openai)
       expect(child.model).not_to equal(parent.model)
     end
+
+    it 'copies instruction declarations with their options' do
+      parent = Class.new(described_class) do
+        instructions 'Be terse.', cache_until_here: true
+      end
+
+      child = Class.new(parent)
+
+      expect(child.instructions).to eq(parent.instructions)
+      expect(child.instructions.first[:cache_until_here]).to be(true)
+    end
+
+    it 'keeps a subclass declaration out of the parent' do
+      parent = Class.new(described_class) do
+        instructions 'Be terse.'
+      end
+
+      child = Class.new(parent)
+      child.instructions 'Answer in French.', append: true
+
+      expect(parent.instructions.length).to eq(1)
+      expect(child.instructions.length).to eq(2)
+    end
   end
 
   describe 'prompt paths' do


### PR DESCRIPTION
## Problem

Every other piece of Agent class configuration — tools, server tools, tool options, provider options, headers, inputs, fallbacks, rescue handlers, thinking, temperature — is copied to subclasses on `inherited`. Instruction declarations are not:

```ruby
class BaseAgent < RubyLLM::Agent
  instructions "Be terse.", cache_until_here: true
end

class ChildAgent < BaseAgent; end

BaseAgent.instructions
# => [{value: "Be terse.", append: false, persist: true, cache_until_here: true}]
ChildAgent.instructions
# => []
```

Verified on 2.0.0.rc1, 2.0.0.rc2, and current main; also verified ivar-by-ivar that every other `DUPED_INHERITED_CONFIG` and `COPIED_INHERITED_CONFIG` entry does inherit correctly — instructions is the only one that doesn't.

The failure is silent in the common Rails setup: when the subclass has a conventional prompt template, `instructions_config` falls back to the template default, which hardcodes `append: false, persist: true, cache_until_here: false`. Instructions still appear, so nothing looks broken, while every option on the base class's declaration quietly vanishes — in our app, an Anthropic cache boundary declared on an `ApplicationAgent` base class evaporated in every concrete agent, a cost regression with no error.

## Root cause

`DUPED_INHERITED_CONFIG` lists `:@instructions`, an ivar nothing writes — the `instructions` macro stores declarations in `@instruction_declarations` (agent.rb:186–195, reader at :781–783). `copy_inherited_config_to` therefore dups an always-empty ivar and never copies the real declarations.

## Fix

Rename the table entry to `:@instruction_declarations`. The existing `.dup` semantics keep subclass declarations independent of the parent (a subclass appending doesn't mutate the base class), matching how `tools` accumulates.

Two specs added under the existing `describe 'inheritance'` block: declarations (with their options) reach the subclass, and a subclass declaration stays out of the parent.

Ruby 4.0.6 / Rails 8.1.3; found upgrading a Rails app from 1.16.0. Full non-live suite passes locally (3,135 examples, 0 failures).