### PR TITLE
Add RubyLLM::Skills to the ecosystem catalog

### DIFF
--- a/docs/_reference/ecosystem.md
+++ b/docs/_reference/ecosystem.md
@@ -39,6 +39,12 @@ See [Structured Output]({% link _core_features/structured-output.md %}) and [Too
 
 For provider-executed MCP tools, also see the built-in [Server Tools]({% link _core_features/server-tools.md %}#mcp-servers).
 
+## RubyLLM::Skills
+
+[RubyLLM::Skills](https://github.com/kieranklaassen/ruby_llm-skills) adds Agent Skills to chats and agents, so the model can discover and load instructions from `SKILL.md` directories, slash-command markdown files, and database records.
+
+Stay on `ruby_llm-skills ~> 0.3.0` with RubyLLM 1.x. For RubyLLM 2.0, use the published prerelease `0.4.0.pre1`.
+
 ## RubyLLM::Instrumentation
 
 [RubyLLM::Instrumentation](https://github.com/sinaptia/ruby_llm-instrumentation) adds ActiveSupport notifications to RubyLLM 1.x.


### PR DESCRIPTION
## What this does

Lists [RubyLLM::Skills](https://github.com/kieranklaassen/ruby_llm-skills) on the ecosystem catalog so visitors can find the gem, reach its repo, and pick the right version for RubyLLM 1.x vs 2.0.

RubyLLM 1.x stays on `ruby_llm-skills ~> 0.3.0`. RubyLLM 2.0 uses the published prerelease `0.4.0.pre1` (a bare `0.4+` would not select that prerelease).

Placed after MCP because both extend what a chat or agent can invoke. Compact catalog shape matches the other third-party entries on `main`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Performance improvement

## Scope check

- [x] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [x] This aligns with RubyLLM's focus on **LLM communication**
- [x] This isn't application-specific logic that belongs in user code
- [x] This benefits most users, not just my specific use case

## Required for new features

<!-- Skip this section for bug fixes and documentation -->

- [ ] I opened an issue **before** writing code and received maintainer approval
- [ ] Linked issue: #___

**PRs for new features or enhancements without a prior approved issue will be closed.**

## Quality check

- [ ] I ran `overcommit --install` and all hooks pass
- [ ] I tested my changes thoroughly
  - [ ] For provider changes: Re-recorded VCR cassettes with `bundle exec rake vcr:record[provider_name]`
  - [ ] All tests pass: `bundle exec rspec`
- [x] I updated documentation if needed
- [x] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## AI-generated code

- [x] I used AI tools to help write this code
- [x] I have reviewed and understand all generated code (required if above is checked)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [x] No API changes
