### PR TITLE
fix: validate rerank result index before indexing into documents

### DIFF
--- a/lib/ruby_llm/protocols/chat_completions/rerank.rb
+++ b/lib/ruby_llm/protocols/chat_completions/rerank.rb
@@ -38,10 +38,13 @@ module RubyLLM
         def parse_rerank_results(data, documents = [])
           Array(data['results']).map do |result|
             index = result['index']
+            unless valid_rerank_index?(index, documents)
+              raise Error, 'Rerank endpoint returned an invalid document index'
+            end
 
             RubyLLM::Rerank::Result.new(
               index: index,
-              document: rerank_document(result['document']) || (index && documents[index]),
+              document: rerank_document(result['document']) || documents[index],
               score: result['relevance_score']
             )
           end
@@ -49,6 +52,14 @@ module RubyLLM
 
         def rerank_document(document)
           document.is_a?(Hash) ? document['text'] : document
+        end
+
+        # A negative index is a valid Ruby array index (it wraps from the
+        # end) and an out-of-range positive one just returns nil, so an
+        # unchecked index would substitute the wrong document, or a missing
+        # one, without ever raising.
+        def valid_rerank_index?(index, documents)
+          index.is_a?(Integer) && index.between?(0, documents.length - 1)
         end
       end
     end

--- a/lib/ruby_llm/protocols/cohere/rerank.rb
+++ b/lib/ruby_llm/protocols/cohere/rerank.rb
@@ -38,13 +38,24 @@ module RubyLLM
         def parse_rerank_results(data, documents)
           Array(data['results']).map do |result|
             index = result['index']
+            unless valid_rerank_index?(index, documents)
+              raise Error, 'Cohere reranking returned an invalid document index'
+            end
 
             RubyLLM::Rerank::Result.new(
               index: index,
-              document: result.dig('document', 'text') || (index && documents[index]),
+              document: result.dig('document', 'text') || documents[index],
               score: result['relevance_score']
             )
           end
+        end
+
+        # A negative index is a valid Ruby array index (it wraps from the
+        # end) and an out-of-range positive one just returns nil, so an
+        # unchecked index would substitute the wrong document, or a missing
+        # one, without ever raising.
+        def valid_rerank_index?(index, documents)
+          index.is_a?(Integer) && index.between?(0, documents.length - 1)
         end
       end
     end

--- a/spec/ruby_llm/protocols/chat_completions/rerank_spec.rb
+++ b/spec/ruby_llm/protocols/chat_completions/rerank_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# The Jina-style rerank endpoint several OpenAI-compatible providers serve
+# (OpenRouter, GPUStack) with identical request and response shapes.
+RSpec.describe RubyLLM::Protocols::ChatCompletions::Rerank do
+  let(:protocol) { Object.new.extend(described_class) }
+
+  let(:documents) { %w[doc0 doc1 doc2] }
+
+  let(:body) do
+    {
+      'model' => 'voyageai/rerank-2.5-lite',
+      'results' => [
+        { 'index' => 1, 'relevance_score' => 0.91 },
+        { 'index' => 0, 'relevance_score' => 0.12 }
+      ],
+      'usage' => { 'total_tokens' => 7, 'cost' => 0.0001 }
+    }
+  end
+
+  def response
+    instance_double(Faraday::Response, body: body)
+  end
+
+  describe '#rerank_url' do
+    it 'posts to the shared rerank endpoint' do
+      expect(protocol.send(:rerank_url)).to eq('rerank')
+    end
+  end
+
+  describe '#parse_rerank_response' do
+    it 'resolves each ranked document from the documents that were sent, in relevance order' do
+      rerank = protocol.send(:parse_rerank_response, response, model: 'voyageai/rerank-2.5-lite', documents: documents)
+
+      expect(rerank.results.map(&:document)).to eq(%w[doc1 doc0])
+      expect(rerank.results.first.score).to eq(0.91)
+    end
+
+    it 'reports the exact cost when the provider returns one' do
+      rerank = protocol.send(:parse_rerank_response, response, model: 'voyageai/rerank-2.5-lite', documents: documents)
+
+      expect(rerank.tokens.reported_cost).to eq(0.0001)
+    end
+
+    # A negative index is a valid Ruby array index (documents[-1] is the
+    # last document), so an unvalidated index would silently substitute
+    # the wrong document instead of raising.
+    it 'rejects a negative document index instead of wrapping to the last document' do
+      body['results'] = [{ 'index' => -1, 'relevance_score' => 0.9 }]
+
+      expect do
+        protocol.send(:parse_rerank_response, response, model: 'voyageai/rerank-2.5-lite', documents: documents)
+      end
+        .to raise_error(RubyLLM::Error, /invalid document index/)
+    end
+
+    it 'rejects an out-of-range document index instead of returning a nil document' do
+      body['results'] = [{ 'index' => documents.length, 'relevance_score' => 0.9 }]
+
+      expect do
+        protocol.send(:parse_rerank_response, response, model: 'voyageai/rerank-2.5-lite', documents: documents)
+      end
+        .to raise_error(RubyLLM::Error, /invalid document index/)
+    end
+  end
+end

--- a/spec/ruby_llm/protocols/cohere/rerank_spec.rb
+++ b/spec/ruby_llm/protocols/cohere/rerank_spec.rb
@@ -90,6 +90,23 @@ RSpec.describe RubyLLM::Protocols::Cohere::Rerank do
 
       expect(rerank.tokens.input).to eq(42)
     end
+
+    # A negative index is a valid Ruby array index (documents[-1] is the
+    # last document), so an unvalidated index would silently substitute
+    # the wrong document instead of raising.
+    it 'rejects a negative document index instead of wrapping to the last document' do
+      body['results'] = [{ 'index' => -1, 'relevance_score' => 0.9 }]
+
+      expect { protocol.send(:parse_rerank_response, response, model: 'rerank-v4.0-pro', documents: documents) }
+        .to raise_error(RubyLLM::Error, /invalid document index/)
+    end
+
+    it 'rejects an out-of-range document index instead of returning a nil document' do
+      body['results'] = [{ 'index' => documents.length, 'relevance_score' => 0.9 }]
+
+      expect { protocol.send(:parse_rerank_response, response, model: 'rerank-v4.0-pro', documents: documents) }
+        .to raise_error(RubyLLM::Error, /invalid document index/)
+    end
   end
 
   def response


### PR DESCRIPTION
### Summary

`Cohere::Rerank` and `ChatCompletions::Rerank` (the Jina-style rerank endpoint OpenRouter and GPUStack share) both read `index` from the provider's response and use it directly as `documents[index]`, with no validation.

Ruby arrays don't raise on an out-of-range index — they return `nil` — and a negative index wraps from the end (`documents[-1]` is the last document). So a malformed rerank response silently substitutes the wrong document, or a nil one, instead of raising:

```ruby
protocol.send(:parse_rerank_response, response, model: "rerank-v3.5", documents: %w[doc0 doc1 doc2])
# body['results'] = [{ 'index' => -1, 'relevance_score' => 0.9 }]
# => Result(index: -1, document: "doc2", score: 0.9)   # wrong document, no error

# body['results'] = [{ 'index' => 3, 'relevance_score' => 0.9 }]
# => Result(index: 3, document: nil, score: 0.9)        # missing document, no error
```

`Bedrock::Rerank` already guards this exact case — its spec is literally titled *"rejects repeated page tokens and invalid provider result indices"* — with `index.is_a?(Integer) && index.between?(0, documents.length - 1)`. Cohere and ChatCompletions never got the same check.

### Change

Mirror Bedrock's guard in both, raising `RubyLLM::Error` with a clear message instead of silently indexing.

### Testing

4 new specs (negative index + out-of-range index, one pair per provider):

```
$ bundle exec rspec spec/ruby_llm/protocols/cohere/rerank_spec.rb spec/ruby_llm/protocols/chat_completions/rerank_spec.rb spec/ruby_llm/protocols/bedrock/rerank_spec.rb spec/ruby_llm/rerank_spec.rb
26 examples, 0 failures
```

All 4 new ones fail with the exact silent-substitution values shown above when the two `rerank.rb` changes are reverted:

```
$ git stash -- lib/ruby_llm/protocols/cohere/rerank.rb lib/ruby_llm/protocols/chat_completions/rerank.rb
$ bundle exec rspec spec/ruby_llm/protocols/cohere/rerank_spec.rb spec/ruby_llm/protocols/chat_completions/rerank_spec.rb
14 examples, 4 failures
```

`bundle exec rubocop` on all four touched files: no offenses.

This PR was generated with an AI assistant; I have reviewed the change and run the tests locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUQxa2vJuTi3o67JHxKG1e