### PR TITLE
fix: reject a duplicated embedding_index in a Gemini batch group

### DIFF
--- a/lib/ruby_llm/protocols/gemini/embedding_batches.rb
+++ b/lib/ruby_llm/protocols/gemini/embedding_batches.rb
@@ -60,6 +60,17 @@ module RubyLLM
           metadata = responses.first.fetch('metadata')
           return if responses.size < metadata.fetch('embedding_count')
 
+          # The size check above only catches a short group; a duplicated
+          # embedding_index (with the true position's response missing)
+          # still has the right count, and embedding_batch_vectors' sort_by
+          # would silently pair the wrong vector with each text instead of
+          # raising -- mirrors the equivalent check in
+          # InvokeModel::EmbeddingBatches#consistent_embedding_metadata?.
+          positions = responses.map { |inline| inline.dig('metadata', 'embedding_index') }
+          unless positions.sort == (0...responses.size).to_a
+            return [index, nil, batch_failure(key, 'Invalid or duplicate embedding record positions')]
+          end
+
           vectors = embedding_batch_vectors(responses)
           return [index, nil, batch_failure(key, 'Gemini returned no embedding')] unless vectors
 

--- a/spec/ruby_llm/protocols/gemini/embedding_batches_spec.rb
+++ b/spec/ruby_llm/protocols/gemini/embedding_batches_spec.rb
@@ -93,6 +93,19 @@ RSpec.describe RubyLLM::Protocols::Gemini::EmbeddingBatches do
     expect(protocol.send(:parse_embedding_batch_results, [success, failure])).to eq([[0, nil, :failed]])
   end
 
+  it 'rejects a duplicated embedding_index instead of silently pairing the wrong vector' do
+    inputs = protocol.send(:embedding_batch_requests, batch_request(%w[Ruby Rails]), model.id)
+    # Both responses claim position 0 (position 1's response is missing), but
+    # the group is still the expected size -- the only way this can be
+    # detected is by checking the positions themselves, not just the count.
+    duplicated = inputs.first.fetch(:metadata)
+    responses = [inline_response(inputs.first.merge(metadata: duplicated), [1.0]),
+                 inline_response(inputs.last.merge(metadata: duplicated), [2.0])]
+    allow(RubyLLM.logger).to receive(:warn)
+
+    expect(protocol.send(:parse_embedding_batch_results, responses)).to eq([[0, nil, :failed]])
+  end
+
   it 'hydrates staged embedding requests and restores a completed batch by id' do
     allow(RubyLLM::Providers::Gemini).to receive(:new).and_return(provider)
     context = RubyLLM.context { |config| config.gemini_api_key = 'test' }


### PR DESCRIPTION
### Summary

`Gemini::EmbeddingBatches#parse_embedding_batch_group` only checks that a result group has the expected *number* of responses:

```ruby
return if responses.size < metadata.fetch('embedding_count')
```

It never checks that the responses' `embedding_index` values are actually `0...embedding_count`. A group where one response's `embedding_index` is duplicated (and the true position's response is simply missing) still has the right size, so it passes this check. `embedding_batch_vectors`' `sort_by` then pairs vectors with positions using whatever order a stable sort happens to produce for the tied key — silently assigning the wrong vector to a text (or the same vector to two texts) instead of raising.

`InvokeModel::EmbeddingBatches` — the equivalent batch path for Bedrock's Titan embeddings — already guards this exact case via `consistent_embedding_metadata?`, with its own dedicated test titled *"rejects duplicate output positions."* Gemini's embedding batches never got the same check.

### Reproduction

```ruby
inputs = protocol.send(:embedding_batch_requests, batch_request(%w[Ruby Rails]), model.id)
duplicated = inputs.first.fetch(:metadata)  # embedding_index: 0
responses = [inline_response(inputs.first.merge(metadata: duplicated), [1.0]),
             inline_response(inputs.last.merge(metadata: duplicated), [2.0])]

protocol.send(:parse_embedding_batch_results, responses)
# => [[0, #<RubyLLM::Embedding count: 2, dimensions: 1>]]   # accepted silently
```

### Change

Verify the positions are exactly `0...responses.size` before extracting vectors; fail the group (`batch_failure`, matching the other error paths already in this method) instead of silently misassigning.

### Testing

```
$ bundle exec rspec spec/ruby_llm/protocols/gemini/embedding_batches_spec.rb
9 examples, 0 failures
```

The new test fails without this change:

```
$ git stash -- lib/ruby_llm/protocols/gemini/embedding_batches.rb
$ bundle exec rspec spec/ruby_llm/protocols/gemini/embedding_batches_spec.rb -e "duplicated embedding_index"
1 example, 1 failure
  expected: [[0, nil, :failed]]
       got: [[0, #<RubyLLM::Embedding model: "gemini-embedding-001", count: 2, dimensions: 1>]]
```

`bundle exec rubocop` on the touched file: no offenses.

This PR was generated with an AI assistant; I have reviewed the change and run the tests locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUQxa2vJuTi3o67JHxKG1e